### PR TITLE
Reorder ROADMAP.md into Chapters

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,15 +1,22 @@
 # ROADMAP
+
+## Chapter 1: Project Foundation & Meta
 - [ ] Please reorder the ROADMAP.md - Keep topics per Chapter (and subchapters if necessary) (#11)
+- [x] Add more details to the ROADMAP.md (#6) (completed at 2026-04-22 12:05:23)
+- [ ] Reverse engineer the WebFOCUS programming language syntax and functionality
+- [ ] Create a 'readthedocs' documentation of the analytics
+- [ ] Setup the empty CI/CD pipeline
+
+## Chapter 2: Specifications & Manuals
 - [ ] https://github.com/chatelao/web-focus-benf/tree/main/specifications - Move each manual into one subdirectory and split it per chapter (#10)
 - [x] Download all necessary standard, manuals, handbooks, etc. to `specifictions` and convewrt to ".md" if pdf retrieved (#8) (completed at 2026-04-23 09:07:44)
-- [ ] Create a comprehensive test suite for the parser using real-world WebFOCUS samples
-- [ ] Develop a CLI tool for automated WebFOCUS code analysis
-- [ ] Integrate parser results into the documentation generator
-- [x] Add more details to the ROADMAP.md (#6) (completed at 2026-04-22 12:05:23)
 - [x] Download all necessary standard, manuals, handbooks, etc. to `specifications` and convert to ".md" if pdf retrieved (#5) (completed at 2026-04-23 09:07:44)
+
+## Chapter 3: Core Parser & Grammar
 - [ ] Define the formal EBNF grammar for WebFOCUS (#4)
 - [ ] Implement a Lexer and Parser for WebFOCUS core syntax in Python (#3)
 
-- [ ] Setup the empty CI/CD pipeline
-- [ ] Create a 'readthedocs' documentation of the analytics
-- [ ] Reverse engineer the WebFOCUS programming language syntax and functionality
+## Chapter 4: Tooling & Integration
+- [ ] Integrate parser results into the documentation generator
+- [ ] Develop a CLI tool for automated WebFOCUS code analysis
+- [ ] Create a comprehensive test suite for the parser using real-world WebFOCUS samples


### PR DESCRIPTION
The ROADMAP.md file was restructured to group tasks by their logical domain (Chapters). This helps in tracking progress across different areas of the project like infrastructure, specifications, and core development. Existing tasks were preserved and categorized accordingly.

Fixes #11

---
*PR created automatically by Jules for task [2634143531020420378](https://jules.google.com/task/2634143531020420378) started by @chatelao*