### PR TITLE
Implement BY and ACROSS sort phrases and AS phrases

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,5 @@
 # ROADMAP
-- [ ] Implement a next modest and reasonable roadmap step (#24)
+- [x] Implement a next modest and reasonable roadmap step (#24) (completed at 2026-04-25 03:43:52)
 - [ ] Implement a next modest and reasonable roadmap step
 - [x] Implement a next modest and reasonable roadmap step (#22) (completed at 2026-04-25 03:26:35)
 - [x] Implement a next modest and reasonable roadmap step (#20) (completed at 2026-04-25 02:46:03)
@@ -24,8 +24,8 @@
 - [x] Define EBNF and Implement Parser for Master Files (Describing Data) (completed at 2026-04-25 02:46:02)
 - [ ] Define EBNF and Implement Parser for basic TABLE FILE requests (Creating Reports)
   - [x] Support basic verbs (PRINT, LIST, SUM, COUNT, WRITE, ADD) and wildcard (*) (completed at 2026-04-25 03:26:52)
-  - [ ] Support AS phrases for column titles
-  - [ ] Support BY and ACROSS sort phrases
+  - [x] Support AS phrases for column titles (completed at 2026-04-25 03:43:51)
+  - [x] Support BY and ACROSS sort phrases (completed at 2026-04-25 03:43:52)
   - [ ] Support HEADING, FOOTING, and other formatting commands
   - [ ] Support Prefix Operators (AVE., MIN., MAX., etc.)
 - [ ] Define EBNF and Implement Parser for Expressions and WHERE clauses

--- a/src/wf_parser.py
+++ b/src/wf_parser.py
@@ -12,6 +12,7 @@ wf_grammar = r"""
 
     ?verb_command: display_command
                  | by_command
+                 | across_command
                  | where_command
                  | heading_command
 
@@ -26,7 +27,12 @@ wf_grammar = r"""
     field: NAME (as_phrase)?
     as_phrase: AS STRING
 
-    by_command: BY NAME [NOPRINT]
+    by_command: [RANKED] BY sort_options? NAME (as_phrase)? [NOPRINT]
+    across_command: ACROSS sort_options? NAME (as_phrase)? [NOPRINT]
+
+    sort_options: (HIGHEST | LOWEST | TOP | BOTTOM) NUMBER?
+                | NUMBER
+
     where_command: WHERE NAME EQ (NAME | NUMBER | STRING)
     heading_command: HEADING CENTER? STRING
 
@@ -41,6 +47,12 @@ wf_grammar = r"""
     WRITE: /WRITE/i
     ADD: /ADD/i
     BY: /BY/i
+    ACROSS: /ACROSS/i
+    RANKED: /RANKED/i
+    HIGHEST: /HIGHEST/i
+    LOWEST: /LOWEST/i
+    TOP: /TOP/i
+    BOTTOM: /BOTTOM/i
     NOPRINT: /NOPRINT/i
     WHERE: /WHERE/i
     EQ: /EQ/i
@@ -51,7 +63,7 @@ wf_grammar = r"""
     THE: /THE/i
     END: /END/i
 
-    NAME: /(?!(TABLE|FILE|SUM|PRINT|LIST|COUNT|WRITE|ADD|BY|NOPRINT|WHERE|EQ|AS|HEADING|CENTER|AND|THE|END)\b)[a-zA-Z_][a-zA-Z0-9_.]+/i
+    NAME: /(?!(TABLE|FILE|SUM|PRINT|LIST|COUNT|WRITE|ADD|BY|ACROSS|RANKED|HIGHEST|LOWEST|TOP|BOTTOM|NOPRINT|WHERE|EQ|AS|HEADING|CENTER|AND|THE|END)\b)[a-zA-Z_][a-zA-Z0-9_.]+/i
 
     %import common.NUMBER
     %import common.WS

--- a/test/test_prototype_parser.py
+++ b/test/test_prototype_parser.py
@@ -71,6 +71,59 @@ class TestWebFocusParser(unittest.TestCase):
         fields = list(field_list.find_data('field'))
         self.assertEqual(len(fields), 2)
 
+    def test_across_command(self):
+        code = """
+        TABLE FILE EMPDATA
+        SUM SALARY
+        ACROSS DEPARTMENT
+        END
+        """
+        tree = self.parser.parse(code)
+        across_cmds = list(tree.find_data('across_command'))
+        self.assertEqual(len(across_cmds), 1)
+
+    def test_sort_options(self):
+        variations = [
+            "BY HIGHEST 5 SALARY",
+            "BY LOWEST SALARY",
+            "BY TOP 10 SALARY",
+            "BY BOTTOM SALARY",
+            "BY 12 SALARY",
+            "ACROSS HIGHEST 3 DEPT",
+            "ACROSS TOP DEPT"
+        ]
+        for var in variations:
+            code = f"TABLE FILE EMPDATA\nSUM SALARY\n{var}\nEND"
+            try:
+                self.parser.parse(code)
+            except Exception as e:
+                self.fail(f"Failed to parse sort option '{var}': {e}")
+
+    def test_ranked_by(self):
+        code = """
+        TABLE FILE EMPLOYEE
+        PRINT LAST_NAME
+        RANKED BY HIGHEST 5 CURR_SAL
+        END
+        """
+        tree = self.parser.parse(code)
+        by_cmd = next(tree.find_data('by_command'))
+        self.assertTrue(any(t.type == 'RANKED' for t in by_cmd.children if hasattr(t, 'type')))
+
+    def test_sort_as_phrase(self):
+        code = """
+        TABLE FILE EMPLOYEE
+        SUM SALARY
+        BY DEPARTMENT AS 'Dept. Title'
+        ACROSS BANK_NAME AS 'Bank Name'
+        END
+        """
+        tree = self.parser.parse(code)
+        by_cmd = next(tree.find_data('by_command'))
+        self.assertTrue(list(by_cmd.find_data('as_phrase')))
+        across_cmd = next(tree.find_data('across_command'))
+        self.assertTrue(list(across_cmd.find_data('as_phrase')))
+
     def test_samples(self):
         samples_dir = os.path.join(os.path.dirname(__file__), 'samples')
         for filename in os.listdir(samples_dir):


### PR DESCRIPTION
This PR implements the next modest roadmap steps for the WebFOCUS parser prototype. It enhances the parser to handle `AS` phrases for field and sort field aliasing, and introduces `ACROSS` sort phrases along with advanced sort options like `RANKED`, `HIGHEST/LOWEST`, and row limits. These changes bring the parser closer to supporting full `TABLE FILE` request syntax as defined in the specifications.

Fixes #24

---
*PR created automatically by Jules for task [1895438175928528085](https://jules.google.com/task/1895438175928528085) started by @chatelao*