### PR TITLE
Implement Prefix Operators, FOOTING Command, and Roadmap Breakdown

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,11 @@
 # ROADMAP
+- [ ] Integrate ANTLR4 parser into WebFocusParser dispatcher
+- [ ] Implement ANTLR4 Lexer and Parser in Python
+- [ ] Migrate Lark grammar to ANTLR4 format
+- [ ] Support ON TABLE formatting commands (PCHOLD, etc.)
+- [ ] Support SUB-TOTAL and SUMMARIZE commands
+- [ ] Support SUBHEAD and SUBFOOT commands
+- [x] Support FOOTING command (completed at 2026-04-25 04:40:54)
 - [ ] Implement a next modest and reasonable roadmap step (#31)
 - [x] Rewrite all necessary documents, specifications and plans to align with the new target descirbed in WEBFOCUS_TO_POSTGRE.md (#29) (completed at 2026-04-25 04:22:00)
 - [ ] Implement a next modest and reasonable roadmap step (#27)
@@ -27,7 +34,7 @@
   - [x] Support AS phrases for column titles (completed at 2026-04-25 03:43:51)
   - [x] Support BY and ACROSS sort phrases (completed at 2026-04-25 03:43:52)
   - [ ] Support HEADING, FOOTING, and other formatting commands
-  - [ ] Support Prefix Operators (AVE., MIN., MAX., etc.)
+  - [x] Support Prefix Operators (AVE., MIN., MAX., etc.) (completed at 2026-04-25 04:40:41)
 - [ ] Define EBNF and Implement Parser for Expressions and WHERE clauses
 
 ## Chapter 4: Middle-tier - Semantic Analysis & Optimization

--- a/src/wf_parser.py
+++ b/src/wf_parser.py
@@ -8,44 +8,53 @@ wf_grammar = r"""
 
     request: table_file verb_command* end_command
 
-    table_file: TABLE FILE NAME
+    table_file: TABLE FILE qualified_name
 
     ?verb_command: display_command
                  | by_command
                  | across_command
                  | where_command
                  | heading_command
+                 | footing_command
 
     display_command: verb (field_list | asterisk)
 
     asterisk: "*"
 
-    verb: SUM | PRINT | LIST | COUNT | WRITE | ADD
+    verb: SUM_K | PRINT_K | LIST_K | COUNT_K | WRITE_K | ADD_K
 
-    field_list: [THE] field (([AND] [THE]) field)*
+    field_list: [THE] field_or_prefixed (([AND] [THE]) field_or_prefixed)*
 
-    field: NAME (as_phrase)?
+    field_or_prefixed: (prefix_operator ".")* field
+
+    field: qualified_name (as_phrase)?
+
     as_phrase: AS STRING
 
-    by_command: [RANKED] BY sort_options? NAME (as_phrase)? [NOPRINT]
-    across_command: ACROSS sort_options? NAME (as_phrase)? [NOPRINT]
+    by_command: [RANKED] BY sort_options? field [NOPRINT]
+    across_command: ACROSS sort_options? field [NOPRINT]
 
     sort_options: (HIGHEST | LOWEST | TOP | BOTTOM) NUMBER?
                 | NUMBER
 
-    where_command: WHERE NAME EQ (NAME | NUMBER | STRING)
+    where_command: WHERE qualified_name EQ (qualified_name | NUMBER | STRING)
     heading_command: HEADING CENTER? STRING
+    footing_command: FOOTING CENTER? STRING
 
     end_command: END
 
+    qualified_name: NAME ("." NAME)*
+
+    prefix_operator: AVE | MIN | MAX | CNT | FST | LST | ASQ | MDN | MDE | PCT | RPCT | RNK | DST | TOT | SUM_K | CT
+
     TABLE: /TABLE/i
     FILE: /FILE/i
-    SUM: /SUM/i
-    PRINT: /PRINT/i
-    LIST: /LIST/i
-    COUNT: /COUNT/i
-    WRITE: /WRITE/i
-    ADD: /ADD/i
+    SUM_K: /SUM/i
+    PRINT_K: /PRINT/i
+    LIST_K: /LIST/i
+    COUNT_K: /COUNT/i
+    WRITE_K: /WRITE/i
+    ADD_K: /ADD/i
     BY: /BY/i
     ACROSS: /ACROSS/i
     RANKED: /RANKED/i
@@ -58,12 +67,29 @@ wf_grammar = r"""
     EQ: /EQ/i
     AS: /AS/i
     HEADING: /HEADING/i
+    FOOTING: /FOOTING/i
     CENTER: /CENTER/i
     AND: /AND/i
     THE: /THE/i
     END: /END/i
 
-    NAME: /(?!(TABLE|FILE|SUM|PRINT|LIST|COUNT|WRITE|ADD|BY|ACROSS|RANKED|HIGHEST|LOWEST|TOP|BOTTOM|NOPRINT|WHERE|EQ|AS|HEADING|CENTER|AND|THE|END)\b)[a-zA-Z_][a-zA-Z0-9_.]+/i
+    AVE: /AVE/i
+    MIN: /MIN/i
+    MAX: /MAX/i
+    CNT: /CNT/i
+    FST: /FST/i
+    LST: /LST/i
+    ASQ: /ASQ/i
+    MDN: /MDN/i
+    MDE: /MDE/i
+    PCT: /PCT/i
+    RPCT: /RPCT/i
+    RNK: /RNK/i
+    DST: /DST/i
+    TOT: /TOT/i
+    CT: /CT/i
+
+    NAME: /(?!(TABLE|FILE|SUM|PRINT|LIST|COUNT|WRITE|ADD|BY|ACROSS|RANKED|HIGHEST|LOWEST|TOP|BOTTOM|NOPRINT|WHERE|EQ|AS|HEADING|FOOTING|CENTER|AND|THE|END|AVE|MIN|MAX|CNT|FST|LST|ASQ|MDN|MDE|PCT|RPCT|RNK|DST|TOT|CT)\b)[a-zA-Z_][a-zA-Z0-9_]*/i
 
     %import common.NUMBER
     %import common.WS
@@ -90,17 +116,12 @@ if __name__ == "__main__":
     sample_report = """
     TABLE FILE EMPDATA
     HEADING CENTER "Education Cost vs. Salary"
-    SUM EXPENSES AS 'Education,Cost' SALARY AS 'Current,Salary'
+    FOOTING "End of Report"
+    SUM AVE.EXPENSES AS 'Average Education Cost' MAX.SALARY AS 'Max Salary'
     BY DIV
     BY DEPT
     WHERE YEAR EQ 1991
     END
-    """
-
-    sample_master = """
-    FILENAME=EMPLOYEE, SUFFIX=FOC, $
-    SEGNAME=EMPINFO, SEGTYPE=S1, $
-    FIELDNAME=EMP_ID, ALIAS=EID, FORMAT=A9, $
     """
 
     parser = WebFocusParser()
@@ -112,6 +133,11 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"Error parsing report:\n{e}")
 
+    sample_master = """
+    FILENAME=EMPLOYEE, SUFFIX=FOC, $
+    SEGNAME=EMPINFO, SEGTYPE=S1, $
+    FIELDNAME=EMP_ID, ALIAS=EID, FORMAT=A9, $
+    """
     print("\n--- Parsing Master File ---")
     try:
         tree = parser.parse(sample_master)

--- a/test/test_prototype_parser.py
+++ b/test/test_prototype_parser.py
@@ -22,7 +22,8 @@ class TestWebFocusParser(unittest.TestCase):
 
         # Check table_file
         table_file = next(tree.find_data('table_file'))
-        self.assertIn('EMPDATA', [str(t) for t in table_file.children])
+        qn = next(table_file.find_data('qualified_name'))
+        self.assertIn('EMPDATA', [str(t) for t in qn.children])
 
     def test_complex_request(self):
         code = """
@@ -120,9 +121,64 @@ class TestWebFocusParser(unittest.TestCase):
         """
         tree = self.parser.parse(code)
         by_cmd = next(tree.find_data('by_command'))
-        self.assertTrue(list(by_cmd.find_data('as_phrase')))
+        field = next(by_cmd.find_data('field'))
+        self.assertTrue(list(field.find_data('as_phrase')))
         across_cmd = next(tree.find_data('across_command'))
-        self.assertTrue(list(across_cmd.find_data('as_phrase')))
+        field_across = next(across_cmd.find_data('field'))
+        self.assertTrue(list(field_across.find_data('as_phrase')))
+
+    def test_prefix_operators(self):
+        code = """
+        TABLE FILE EMPDATA
+        SUM AVE.EXPENSES AS 'Avg Exp' MAX.SALARY MIN.SALARY CNT.PIN
+        END
+        """
+        tree = self.parser.parse(code)
+        field_list = next(tree.find_data('field_list'))
+        prefixed_fields = list(field_list.find_data('field_or_prefixed'))
+        self.assertEqual(len(prefixed_fields), 4)
+
+        # Verify AVE.EXPENSES
+        f1 = prefixed_fields[0]
+        self.assertEqual(str(next(f1.find_data('prefix_operator')).children[0]), 'AVE')
+
+        # Verify multiple prefixes (WebFOCUS supports recursive prefixes)
+        code_multi = "TABLE FILE EMPDATA\nSUM TOT.AVE.SALARY\nEND"
+        tree_multi = self.parser.parse(code_multi)
+        f_multi = next(tree_multi.find_data('field_or_prefixed'))
+        prefixes = [str(p.children[0]) for p in f_multi.find_data('prefix_operator')]
+        self.assertEqual(prefixes, ['TOT', 'AVE'])
+
+    def test_footing_command(self):
+        code = """
+        TABLE FILE EMPDATA
+        PRINT SALARY
+        FOOTING CENTER "END OF REPORT"
+        END
+        """
+        tree = self.parser.parse(code)
+        footing_cmd = next(tree.find_data('footing_command'))
+        self.assertIn('FOOTING', [str(t) for t in footing_cmd.children if hasattr(t, 'type')])
+        self.assertIn('"END OF REPORT"', [str(t) for t in footing_cmd.children if hasattr(t, 'type')])
+
+    def test_qualified_names(self):
+        code = """
+        TABLE FILE SEG1.MASTER
+        PRINT SEG1.FIELD1 SEG2.FIELD2
+        WHERE SEG1.FIELD1 EQ 'VAL'
+        END
+        """
+        tree = self.parser.parse(code)
+        # Table name
+        table_file = next(tree.find_data('table_file'))
+        qn = next(table_file.find_data('qualified_name'))
+        self.assertEqual([str(t) for t in qn.children], ['SEG1', 'MASTER'])
+
+        # Fields
+        field_list = next(tree.find_data('field_list'))
+        qns = [next(f.find_data('qualified_name')) for f in field_list.find_data('field')]
+        self.assertEqual([str(t) for t in qns[0].children], ['SEG1', 'FIELD1'])
+        self.assertEqual([str(t) for t in qns[1].children], ['SEG2', 'FIELD2'])
 
     def test_samples(self):
         samples_dir = os.path.join(os.path.dirname(__file__), 'samples')


### PR DESCRIPTION
I have implemented a modest roadmap step by adding support for Prefix Operators and the FOOTING command to the WebFOCUS parser. I also introduced support for qualified names (e.g., `SEG.FIELD`), which is a common requirement in WebFOCUS reports.

Key changes:
- **`src/wf_parser.py`**: Updated the Lark grammar to include `prefix_operator` and `footing_command` rules. Refactored name handling to use a `qualified_name` rule and updated the `NAME` terminal to exclude new keywords.
- **`test/test_prototype_parser.py`**: Added new tests for prefix operators (including recursive ones), the `FOOTING` command, and qualified names. Updated existing tests to align with the new AST structure.
- **`ROADMAP.md`**: Marked "Support Prefix Operators" and "Support FOOTING command" as complete. Added granular tasks for `SUBHEAD`, `SUBFOOT`, `SUB-TOTAL`, `SUMMARIZE`, `ON TABLE` commands, and the phased migration to ANTLR4.

All tests passed successfully.

Fixes #31

---
*PR created automatically by Jules for task [6582961334741306511](https://jules.google.com/task/6582961334741306511) started by @chatelao*