### PR TITLE
Implement SUBHEAD and SUBFOOT support in WebFOCUS parser

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@
 - [ ] Migrate Lark grammar to ANTLR4 format
 - [ ] Support ON TABLE formatting commands (PCHOLD, etc.)
 - [ ] Support SUB-TOTAL and SUMMARIZE commands
-- [ ] Support SUBHEAD and SUBFOOT commands
+- [x] Support SUBHEAD and SUBFOOT commands (completed at 2026-04-25 05:00:17)
 - [x] Support FOOTING command (completed at 2026-04-25 04:40:54)
 - [x] Implement a next modest and reasonable roadmap step (#31) (completed at 2026-04-25 04:54:24)
 - [x] Rewrite all necessary documents, specifications and plans to align with the new target descirbed in WEBFOCUS_TO_POSTGRE.md (#29) (completed at 2026-04-25 04:22:00)

--- a/src/wf_parser.py
+++ b/src/wf_parser.py
@@ -16,6 +16,7 @@ wf_grammar = r"""
                  | where_command
                  | heading_command
                  | footing_command
+                 | on_command
 
     display_command: verb (field_list | asterisk)
 
@@ -38,8 +39,9 @@ wf_grammar = r"""
                 | NUMBER
 
     where_command: WHERE qualified_name EQ (qualified_name | NUMBER | STRING)
-    heading_command: HEADING CENTER? STRING
-    footing_command: FOOTING CENTER? STRING
+    heading_command: HEADING CENTER? STRING+
+    footing_command: FOOTING CENTER? STRING+
+    on_command: ON (qualified_name | TABLE) (SUBHEAD | SUBFOOT) CENTER? STRING+
 
     end_command: END
 
@@ -57,6 +59,7 @@ wf_grammar = r"""
     ADD_K: /ADD/i
     BY: /BY/i
     ACROSS: /ACROSS/i
+    ON: /ON/i
     RANKED: /RANKED/i
     HIGHEST: /HIGHEST/i
     LOWEST: /LOWEST/i
@@ -68,6 +71,8 @@ wf_grammar = r"""
     AS: /AS/i
     HEADING: /HEADING/i
     FOOTING: /FOOTING/i
+    SUBHEAD: /SUBHEAD/i
+    SUBFOOT: /SUBFOOT/i
     CENTER: /CENTER/i
     AND: /AND/i
     THE: /THE/i
@@ -89,7 +94,7 @@ wf_grammar = r"""
     TOT: /TOT/i
     CT: /CT/i
 
-    NAME: /(?!(TABLE|FILE|SUM|PRINT|LIST|COUNT|WRITE|ADD|BY|ACROSS|RANKED|HIGHEST|LOWEST|TOP|BOTTOM|NOPRINT|WHERE|EQ|AS|HEADING|FOOTING|CENTER|AND|THE|END|AVE|MIN|MAX|CNT|FST|LST|ASQ|MDN|MDE|PCT|RPCT|RNK|DST|TOT|CT)\b)[a-zA-Z_][a-zA-Z0-9_]*/i
+    NAME: /(?!(TABLE|FILE|SUM|PRINT|LIST|COUNT|WRITE|ADD|BY|ACROSS|ON|RANKED|HIGHEST|LOWEST|TOP|BOTTOM|NOPRINT|WHERE|EQ|AS|HEADING|FOOTING|SUBHEAD|SUBFOOT|CENTER|AND|THE|END|AVE|MIN|MAX|CNT|FST|LST|ASQ|MDN|MDE|PCT|RPCT|RNK|DST|TOT|CT)\b)[a-zA-Z_][a-zA-Z0-9_]*/i
 
     %import common.NUMBER
     %import common.WS

--- a/test/test_prototype_parser.py
+++ b/test/test_prototype_parser.py
@@ -153,13 +153,40 @@ class TestWebFocusParser(unittest.TestCase):
         code = """
         TABLE FILE EMPDATA
         PRINT SALARY
-        FOOTING CENTER "END OF REPORT"
+        FOOTING CENTER "END OF REPORT" "Line 2"
         END
         """
         tree = self.parser.parse(code)
         footing_cmd = next(tree.find_data('footing_command'))
         self.assertIn('FOOTING', [str(t) for t in footing_cmd.children if hasattr(t, 'type')])
         self.assertIn('"END OF REPORT"', [str(t) for t in footing_cmd.children if hasattr(t, 'type')])
+        self.assertIn('"Line 2"', [str(t) for t in footing_cmd.children if hasattr(t, 'type')])
+
+    def test_on_commands(self):
+        code = """
+        TABLE FILE EMPLOYEE
+        PRINT CURR_SAL
+        BY LAST_NAME
+        ON TABLE SUBHEAD
+        "CONFIDENTIAL"
+        ON LAST_NAME SUBHEAD
+        "ID: <EMP_ID"
+        ON LAST_NAME SUBFOOT
+        "End of Last Name"
+        ON TABLE SUBFOOT
+        "Grand Total"
+        END
+        """
+        tree = self.parser.parse(code)
+        on_cmds = list(tree.find_data('on_command'))
+        self.assertEqual(len(on_cmds), 4)
+
+        # Verify specific content
+        subheads = [c for c in on_cmds if any(t.type == 'SUBHEAD' for t in c.children if hasattr(t, 'type'))]
+        self.assertEqual(len(subheads), 2)
+
+        subfoots = [c for c in on_cmds if any(t.type == 'SUBFOOT' for t in c.children if hasattr(t, 'type'))]
+        self.assertEqual(len(subfoots), 2)
 
     def test_qualified_names(self):
         code = """


### PR DESCRIPTION
This change implements the roadmap step "Support SUBHEAD and SUBFOOT commands". 

Key changes:
1. **Grammar Update**: The Lark grammar in `src/wf_parser.py` now includes an `on_command` rule which allows for `ON <fieldname|TABLE> <SUBHEAD|SUBFOOT> <strings>`.
2. **Multi-line Support**: `HEADING`, `FOOTING`, `SUBHEAD`, and `SUBFOOT` now accept one or more strings, allowing them to capture multi-line headers and footers.
3. **Keyword Reservation**: `ON`, `SUBHEAD`, and `SUBFOOT` have been added to the `NAME` terminal's exclusion list to prevent them from being parsed as field names.
4. **Testing**: New test cases were added to `test/test_prototype_parser.py` to verify the parsing of these new commands and the multi-line string support.
5. **Roadmap**: Marked the corresponding task as completed in `ROADMAP.md`.

All tests passed successfully.

Fixes #34

---
*PR created automatically by Jules for task [11178527159560570257](https://jules.google.com/task/11178527159560570257) started by @chatelao*