### PR TITLE
Implement summarization and output commands in WebFOCUS parser

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,12 @@
 # ROADMAP
-- [ ] Implement a next modest, feasible and reasonable roadmap step (#37)
+- [x] Implement a next modest, feasible and reasonable roadmap step (#37) (completed at 2026-04-25 08:53:59)
 - [x] Implement a next modest, feasible and reasonable roadmap step (#34) (completed at 2026-04-25 08:47:08)
 - [x] Solve the technical debts in modest and reasonable steps (#33) (completed at 2026-04-25 08:46:43)
 - [ ] Integrate ANTLR4 parser into WebFocusParser dispatcher
 - [ ] Implement ANTLR4 Lexer and Parser in Python
 - [ ] Migrate Lark grammar to ANTLR4 format
-- [ ] Support ON TABLE formatting commands (PCHOLD, etc.)
-- [ ] Support SUB-TOTAL and SUMMARIZE commands
+- [x] Support ON TABLE formatting commands (PCHOLD, etc.) (completed at 2026-04-25 08:53:59)
+- [x] Support SUB-TOTAL and SUMMARIZE commands (completed at 2026-04-25 08:54:11)
 - [x] Support SUBHEAD and SUBFOOT commands (completed at 2026-04-25 05:00:17)
 - [x] Support FOOTING command (completed at 2026-04-25 04:40:54)
 - [x] Implement a next modest and reasonable roadmap step (#31) (completed at 2026-04-25 04:54:24)

--- a/src/wf_parser.py
+++ b/src/wf_parser.py
@@ -32,7 +32,7 @@ wf_grammar = r"""
 
     as_phrase: AS STRING
 
-    by_command: [RANKED] BY sort_options? field [NOPRINT]
+    by_command: [RANKED] BY sort_options? field [summarize_command] [NOPRINT]
     across_command: ACROSS sort_options? field [NOPRINT]
 
     sort_options: (HIGHEST | LOWEST | TOP | BOTTOM) NUMBER?
@@ -42,6 +42,15 @@ wf_grammar = r"""
     heading_command: HEADING CENTER? STRING+
     footing_command: FOOTING CENTER? STRING+
     on_command: ON (qualified_name | TABLE) (SUBHEAD | SUBFOOT) CENTER? STRING+
+              | ON (qualified_name | TABLE) summarize_command
+              | ON TABLE (COLUMN_TOTAL | ROW_TOTAL)
+              | ON TABLE output_command
+
+    summarize_command: (SUBTOTAL | SUB_TOTAL | SUMMARIZE | RECOMPUTE) (ROLL_DOT? (prefix_operator ".")*)? field? (as_phrase)?
+
+    ROLL_DOT: /ROLL\./i
+
+    output_command: (HOLD | PCHOLD | SAVE | SAVB) [AS qualified_name] [FORMAT NAME]
 
     end_command: END
 
@@ -78,6 +87,18 @@ wf_grammar = r"""
     THE: /THE/i
     END: /END/i
 
+    SUBTOTAL: /SUBTOTAL/i
+    SUB_TOTAL: /SUB-TOTAL/i
+    SUMMARIZE: /SUMMARIZE/i
+    RECOMPUTE: /RECOMPUTE/i
+    COLUMN_TOTAL: /COLUMN-TOTAL/i
+    ROW_TOTAL: /ROW-TOTAL/i
+    HOLD: /HOLD/i
+    PCHOLD: /PCHOLD/i
+    SAVE: /SAVE/i
+    SAVB: /SAVB/i
+    FORMAT: /FORMAT/i
+
     AVE: /AVE/i
     MIN: /MIN/i
     MAX: /MAX/i
@@ -94,7 +115,7 @@ wf_grammar = r"""
     TOT: /TOT/i
     CT: /CT/i
 
-    NAME: /(?!(TABLE|FILE|SUM|PRINT|LIST|COUNT|WRITE|ADD|BY|ACROSS|ON|RANKED|HIGHEST|LOWEST|TOP|BOTTOM|NOPRINT|WHERE|EQ|AS|HEADING|FOOTING|SUBHEAD|SUBFOOT|CENTER|AND|THE|END|AVE|MIN|MAX|CNT|FST|LST|ASQ|MDN|MDE|PCT|RPCT|RNK|DST|TOT|CT)\b)[a-zA-Z_][a-zA-Z0-9_]*/i
+    NAME: /(?!(TABLE|FILE|SUM|PRINT|LIST|COUNT|WRITE|ADD|BY|ACROSS|ON|RANKED|HIGHEST|LOWEST|TOP|BOTTOM|NOPRINT|WHERE|EQ|AS|HEADING|FOOTING|SUBHEAD|SUBFOOT|CENTER|AND|THE|END|AVE|MIN|MAX|CNT|FST|LST|ASQ|MDN|MDE|PCT|RPCT|RNK|DST|TOT|CT|SUBTOTAL|SUB-TOTAL|SUMMARIZE|RECOMPUTE|COLUMN-TOTAL|ROW-TOTAL|HOLD|PCHOLD|SAVE|SAVB|FORMAT)\b)[a-zA-Z_][a-zA-Z0-9_]*/i
 
     %import common.NUMBER
     %import common.WS

--- a/test/test_prototype_parser.py
+++ b/test/test_prototype_parser.py
@@ -207,6 +207,47 @@ class TestWebFocusParser(unittest.TestCase):
         self.assertEqual([str(t) for t in qns[0].children], ['SEG1', 'FIELD1'])
         self.assertEqual([str(t) for t in qns[1].children], ['SEG2', 'FIELD2'])
 
+    def test_summarization_commands(self):
+        variations = [
+            "BY DEPARTMENT SUBTOTAL",
+            "BY DEPARTMENT SUB-TOTAL",
+            "BY DEPARTMENT SUMMARIZE",
+            "BY DEPARTMENT RECOMPUTE",
+            "ON DEPARTMENT SUBTOTAL",
+            "ON DEPARTMENT SUB-TOTAL",
+            "ON DEPARTMENT SUMMARIZE",
+            "ON DEPARTMENT RECOMPUTE",
+            "ON DEPARTMENT SUBTOTAL AVE. SALARY",
+            "ON DEPARTMENT SUBTOTAL AVE. SALARY AS 'Average'",
+            "ON DEPARTMENT SUBTOTAL ROLL.AVE. SALARY",
+            "ON TABLE SUBTOTAL",
+            "ON TABLE COLUMN-TOTAL",
+            "ON TABLE ROW-TOTAL"
+        ]
+        for var in variations:
+            code = f"TABLE FILE EMPDATA\nSUM SALARY\n{var}\nEND"
+            try:
+                self.parser.parse(code)
+            except Exception as e:
+                self.fail(f"Failed to parse summarization command '{var}': {e}")
+
+    def test_output_commands(self):
+        variations = [
+            "ON TABLE HOLD",
+            "ON TABLE PCHOLD",
+            "ON TABLE SAVE",
+            "ON TABLE SAVB",
+            "ON TABLE HOLD AS MYFILE",
+            "ON TABLE HOLD FORMAT ALPHA",
+            "ON TABLE HOLD AS MYFILE FORMAT FOCUS"
+        ]
+        for var in variations:
+            code = f"TABLE FILE EMPDATA\nSUM SALARY\n{var}\nEND"
+            try:
+                self.parser.parse(code)
+            except Exception as e:
+                self.fail(f"Failed to parse output command '{var}': {e}")
+
     def test_samples(self):
         samples_dir = os.path.join(os.path.dirname(__file__), 'samples')
         for filename in os.listdir(samples_dir):


### PR DESCRIPTION
This PR enhances the WebFOCUS parser grammar to support key reporting features:
1.  **Summarization Commands:** Added support for `SUBTOTAL`, `SUB-TOTAL`, `SUMMARIZE`, and `RECOMPUTE`. These can be used within `BY` sort phrases or `ON` field phrases. It also handles the `ROLL.` modifier and prefix operators within these commands.
2.  **Totaling Commands:** Added support for `COLUMN-TOTAL` and `ROW-TOTAL` via the `ON TABLE` command.
3.  **Output Commands:** Added support for generating output files using `HOLD`, `PCHOLD`, `SAVE`, and `SAVB`, including `AS <filename>` and `FORMAT <format>` options.
4.  **Keyword Management:** Updated the `NAME` terminal regex to include the new keywords in the exclusion list, preventing parsing ambiguity.
5.  **Testing:** Added detailed unit tests in `test/test_prototype_parser.py` covering various syntax variations for all new features.

All tests passed successfully, and the project roadmap has been updated.

Fixes #37

---
*PR created automatically by Jules for task [17757214147336249972](https://jules.google.com/task/17757214147336249972) started by @chatelao*