### PR TITLE
Roadmap Breakdown and Core ANTLR4 Grammar Implementation

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -7,6 +7,11 @@ The current Lark-based parsers (`wf_parser.py` and `master_file_parser.py`) are 
 
 - [ ] **1.1 Master File Grammar:** Complete the transition of Master File parsing from Lark to ANTLR4 (already partially started with `src/MasterFile.g4`).
 - [ ] **1.2 WebFOCUS Report Grammar:** Port the EBNF grammar from `src/wf_parser.py` to ANTLR4 (.g4) format.
+  - [x] **1.2.1 Core request structure:** TABLE FILE verb, END command, and qualified names.
+  - [ ] **1.2.2 Verb commands:** PRINT, SUM, LIST, COUNT, WRITE, ADD and field lists with AS phrases.
+  - [ ] **1.2.3 Sort phrases:** BY and ACROSS with sort options (HIGHEST, LOWEST, etc.).
+  - [ ] **1.2.4 Formatting:** HEADING, FOOTING, and ON (SUBHEAD/SUBFOOT).
+  - [ ] **1.2.5 Summarization and Output:** SUBTOTAL, SUMMARIZE, RECOMPUTE and ON TABLE (HOLD, PCHOLD, etc.).
 - [ ] **1.3 Dialogue Manager Grammar:** Define ANTLR4 grammar rules for procedural Dialogue Manager commands (-SET, -IF, -GOTO, etc.).
 - [ ] **1.4 Unified Lexer/Parser:** Ensure the ANTLR4 frontend can handle the context-sensitive nature of WebFOCUS where Dialogue Manager and TABLE FILE requests are interleaved.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,5 @@
 # ROADMAP
-- [ ] 0.3 Implement a next modest, feasible and reasonable MIGRATION_ROADMAP.md step (#44)
+- [x] 0.3 Implement a next modest, feasible and reasonable MIGRATION_ROADMAP.md step (#44) (completed at 2026-04-25 19:01:32)
 - [x] 0.1 Add a MIGRATION_ROADMAP.md from the current system to the new antlr/ninja final solution (#41) (completed at 2026-04-25 18:41:52)
 - [ ] 0.2 Implement a next modest and reasonable roadmap step (#27)
 

--- a/src/WebFocusReport.g4
+++ b/src/WebFocusReport.g4
@@ -1,0 +1,32 @@
+grammar WebFocusReport;
+
+start: request EOF;
+
+request: table_file verb_command* end_command;
+
+table_file: TABLE FILE qualified_name;
+
+verb_command: verb field_list;
+
+verb: PRINT | SUM;
+
+field_list: field (COMMA? field)*;
+
+field: qualified_name;
+
+end_command: END;
+
+qualified_name: NAME (DOT NAME)*;
+
+TABLE: [tT][aA][bB][lL][eE];
+FILE: [fF][iI][lL][eE];
+END: [eE][nN][dD];
+PRINT: [pP][rR][iI][nN][tT];
+SUM: [sS][uU][mM];
+
+DOT: '.';
+COMMA: ',';
+
+NAME: [a-zA-Z_] [a-zA-Z0-9_]*;
+
+WS: [ \t\r\n]+ -> skip;


### PR DESCRIPTION
I have updated the `MIGRATION_ROADMAP.md` to provide a more granular breakdown of the WebFOCUS Report Grammar migration (Phase 1.2). Additionally, I implemented the first sub-task (1.2.1) by creating `src/WebFocusReport.g4`, which includes the core structure for `TABLE FILE` requests, `PRINT`/`SUM` verbs, and `END` commands. `ROADMAP.md` was also updated to reflect the completion of this roadmap refinement step.

Fixes #44

---
*PR created automatically by Jules for task [13704590021933690456](https://jules.google.com/task/13704590021933690456) started by @chatelao*