### PR TITLE
Analyze Dual .g4 Files and Update Migration Roadmap

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -5,9 +5,14 @@ This document outlines the strategic transition from the legacy Lark-based parse
 ## Phase 1: Frontend Migration (Lark to ANTLR4)
 The current Lark-based parsers (`wf_parser.py` and `master_file_parser.py`) are legacy technical debt and must be replaced by ANTLR4 grammars.
 
-- [ ] **1.1 Master File Grammar:** Complete the transition of Master File parsing from Lark to ANTLR4 (already partially started with `src/MasterFile.g4`).
+**Note on Dual Grammar Architecture:**
+The frontend is split into two distinct ANTLR4 grammars to reflect the dual nature of WebFOCUS:
+1. `MasterFile.g4`: Handles data descriptions and metadata (Synonyms).
+2. `WebFocusReport.g4`: Handles procedural report logic and `TABLE FILE` requests.
+
+- [x] **1.1 Master File Grammar:** Complete the transition of Master File parsing from Lark to ANTLR4. (Completed: `src/MasterFile.g4` is implemented and used by `src/master_file_parser.py`)
 - [ ] **1.2 WebFOCUS Report Grammar:** Port the EBNF grammar from `src/wf_parser.py` to ANTLR4 (.g4) format.
-  - [x] **1.2.1 Core request structure:** TABLE FILE verb, END command, and qualified names.
+  - [x] **1.2.1 Core request structure:** TABLE FILE verb, END command, and qualified names. (Implemented in `src/WebFocusReport.g4`)
   - [ ] **1.2.2 Verb commands:** PRINT, SUM, LIST, COUNT, WRITE, ADD and field lists with AS phrases.
   - [ ] **1.2.3 Sort phrases:** BY and ACROSS with sort options (HIGHEST, LOWEST, etc.).
   - [ ] **1.2.4 Formatting:** HEADING, FOOTING, and ON (SUBHEAD/SUBFOOT).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,5 @@
 # ROADMAP
-- [ ] 0.5 Analyze why there are 2 .g4 files in `/src`and update MIGRATION_ROADMAP.md according the task open (#48)
+- [x] 0.5 Analyze why there are 2 .g4 files in `/src`and update MIGRATION_ROADMAP.md according the task open (#48) (completed at 2026-04-25 19:18:42)
 - [ ] 0.4 Erstelle ein .plantuml mit einer Systemübersicht, füge als "note" überall die offenen Punkte hinzug (#45)
 - [x] 0.3 Implement a next modest, feasible and reasonable MIGRATION_ROADMAP.md step (#44) (completed at 2026-04-25 19:01:32)
 - [x] 0.1 Add a MIGRATION_ROADMAP.md from the current system to the new antlr/ninja final solution (#41) (completed at 2026-04-25 18:41:52)


### PR DESCRIPTION
This submission provides an analysis of why there are two separate ANTLR4 grammar files in the `/src` directory and updates the project roadmaps accordingly.

The analysis confirms that the dual grammar architecture is intentional:
1. `MasterFile.g4` is dedicated to parsing WebFOCUS Master Files (Synonyms), which define the data structure and metadata.
2. `WebFocusReport.g4` is dedicated to parsing WebFOCUS Report Requests, including the `TABLE FILE` procedural logic.

This separation reflects the architectural distinction in WebFOCUS between data description and report generation.

Changes implemented:
- Modified `MIGRATION_ROADMAP.md` to:
    - Include a "Note on Dual Grammar Architecture" explaining the split.
    - Mark Task 1.1 (Master File Grammar) as completed, as `src/master_file_parser.py` already utilizes the ANTLR4 implementation.
    - Update Task 1.2.1 to show it is implemented in `src/WebFocusReport.g4`.
- Updated `ROADMAP.md` using `scripts/roadmap_manager.py` to mark task 0.5 as completed.
- Verified that all existing tests (20) pass after installing the required dependencies (`antlr4-python3-runtime` and `lark`).

Fixes #48

---
*PR created automatically by Jules for task [5479030171677716672](https://jules.google.com/task/5479030171677716672) started by @chatelao*