### PR TITLE
Implement Verb Commands and Field List Enhancements (Task 1.2.2)

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -13,7 +13,7 @@ The frontend is split into two distinct ANTLR4 grammars to reflect the dual natu
 - [x] **1.1 Master File Grammar:** Complete the transition of Master File parsing from Lark to ANTLR4. (Completed: `src/MasterFile.g4` is implemented and used by `src/master_file_parser.py`)
 - [ ] **1.2 WebFOCUS Report Grammar:** Port the EBNF grammar from `src/wf_parser.py` to ANTLR4 (.g4) format.
   - [x] **1.2.1 Core request structure:** TABLE FILE verb, END command, and qualified names. (Implemented in `src/WebFocusReport.g4`)
-  - [ ] **1.2.2 Verb commands:** PRINT, SUM, LIST, COUNT, WRITE, ADD and field lists with AS phrases.
+  - [x] **1.2.2 Verb commands:** PRINT, SUM, LIST, COUNT, WRITE, ADD and field lists with AS phrases. (Implemented in `src/WebFocusReport.g4`)
   - [ ] **1.2.3 Sort phrases:** BY and ACROSS with sort options (HIGHEST, LOWEST, etc.).
   - [ ] **1.2.4 Formatting:** HEADING, FOOTING, and ON (SUBHEAD/SUBFOOT).
   - [ ] **1.2.5 Summarization and Output:** SUBTOTAL, SUMMARIZE, RECOMPUTE and ON TABLE (HOLD, PCHOLD, etc.).

--- a/src/WebFocusReport.g4
+++ b/src/WebFocusReport.g4
@@ -6,26 +6,65 @@ request: table_file verb_command* end_command;
 
 table_file: TABLE FILE qualified_name;
 
-verb_command: verb field_list;
+verb_command: verb (field_list | asterisk);
 
-verb: PRINT | SUM;
+verb: PRINT | SUM | LIST | COUNT | WRITE | ADD;
 
-field_list: field (COMMA? field)*;
+field_list: THE? field_or_prefixed (field_separator? field_or_prefixed)*;
 
-field: qualified_name;
+field_separator: COMMA | AND THE | AND | THE;
+
+field_or_prefixed: (prefix_operator DOT)* field;
+
+field: qualified_name as_phrase?;
+
+as_phrase: AS STRING;
+
+asterisk: '*';
 
 end_command: END;
 
 qualified_name: NAME (DOT NAME)*;
 
+prefix_operator: AVE | MIN | MAX | CNT | FST | LST | ASQ | MDN | MDE | PCT | RPCT | RNK | DST | TOT | SUM | CT;
+
+// Keywords
 TABLE: [tT][aA][bB][lL][eE];
 FILE: [fF][iI][lL][eE];
 END: [eE][nN][dD];
+
 PRINT: [pP][rR][iI][nN][tT];
 SUM: [sS][uU][mM];
+LIST: [lL][iI][sS][tT];
+COUNT: [cC][oO][uU][nN][tT];
+WRITE: [wW][rR][iI][tT][eE];
+ADD: [aA][dD][dD];
+
+AS: [aA][sS];
+THE: [tT][hH][eE];
+AND: [aA][nN][dD];
+
+AVE: [aA][vV][eE];
+MIN: [mM][iI][nN];
+MAX: [mM][aA][xX];
+CNT: [cC][nN][tT];
+FST: [fF][sS][tT];
+LST: [lL][sS][tT];
+ASQ: [aA][sS][qQ];
+MDN: [mM][dD][nN];
+MDE: [mM][dD][eE];
+PCT: [pP][cC][tT];
+RPCT: [rR][pP][cC][tT];
+RNK: [rR][nN][kK];
+DST: [dD][sS][tT];
+TOT: [tT][oO][tT];
+CT: [cC][tT];
 
 DOT: '.';
 COMMA: ',';
+
+STRING: '\'' ~[']* '\''
+      | '"' ~["]* '"';
 
 NAME: [a-zA-Z_] [a-zA-Z0-9_]*;
 


### PR DESCRIPTION
Implemented Task 1.2.2 of the `MIGRATION_ROADMAP.md`. Expanded the `src/WebFocusReport.g4` grammar to support a wider range of WebFOCUS verb commands and more complex field list syntax, including prefix operators and `AS` phrases. Verified the changes by running the test suite and reviewing the grammar content.

Fixes #51

---
*PR created automatically by Jules for task [7257585002302801678](https://jules.google.com/task/7257585002302801678) started by @chatelao*