### PR TITLE
Add on-the-fly rendered SYSTEM_OVERVIEW diagram to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project implements a Multi-Pass Source-to-Source Compiler (Transpiler) to m
 
 ## Overview
 
+![System Overview](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/web-focus-benf/main/SYSTEM_OVERVIEW.plantuml)
+
 The transpiler moves beyond simple syntax parsing to understand the semantic context of WebFOCUS requests, including Dialogue Manager state and procedural logic, optimizing them for set-based execution in PostgreSQL.
 
 ## Structure


### PR DESCRIPTION
This change integrates the `SYSTEM_OVERVIEW.plantuml` diagram into the `README.md` file by using a PlantUML proxy URL. 

- Added a Markdown image link in the 'Overview' section of `README.md`.
- Used the `https://www.plantuml.com/plantuml/proxy` service to ensure on-the-fly rendering from the repository's raw content on GitHub.
- Verified that the diagram renders correctly via the proxy.
- Confirmed that existing tests pass.
- Addressed code review feedback by using HTTPS and pointing to the 'main' branch for stable rendering in the README.

Fixes #49

---
*PR created automatically by Jules for task [13529360050443957906](https://jules.google.com/task/13529360050443957906) started by @chatelao*