### PR TITLE
Improve Test Reporting and Documentation

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,4 +24,5 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m unittest discover test
+          export PYTHONPATH=$PYTHONPATH:$(pwd)/src
+          python -m unittest discover -v test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.coverage
+htmlcov/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,5 @@
 # ROADMAP
-- [ ] 0.17 Show some more details about the tests run (#70)
+- [x] 0.17 Show some more details about the tests run (#70) (completed at 2026-04-26 06:38:27)
 - [x] 0.16 Implement a next modest, feasible and reasonable MIGRATION_ROADMAP.md step (#68) (completed at 2026-04-26 06:20:00)
 - [x] 0.15 Implement a next modest, feasible and reasonable MIGRATION_ROADMAP.md step (#66) (completed at 2026-04-26 05:46:00)
 - [x] 0.14 Implement Dialogue Manager Labels and -GOTO in src/WebFocusReport.g4 (completed at 2026-04-26 05:21:15)

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,59 @@
+# WebFOCUS Transpiler Test Suite
+
+This directory contains the test suite for the WebFOCUS to PostgreSQL transpiler. The tests are designed to verify the correctness of the ANTLR4 grammars and the parser implementation.
+
+## Test Files Overview
+
+- **`test_antlr_wf_parser.py`**: Focuses on verifying the ANTLR4 parser for WebFOCUS report requests. It covers:
+    - Summarization commands (`SUMMARIZE`, `RECOMPUTE`, `SUBTOTAL`).
+    - Output commands (`HOLD`, `PCHOLD`, `SAVE`, `SAVB`).
+    - `WHERE` clauses and relational operators.
+    - Basic `TABLE FILE` requests and sort phrases (`BY`, `ACROSS`).
+    - Formatting commands (`HEADING`, `FOOTING`, `SUBHEAD`).
+    - Verification of all `.fex` files in `test/samples/`.
+
+- **`test_dm_commands.py`**: Tests procedural Dialogue Manager commands:
+    - Conditional logic (`-IF ... THEN ... ELSE`).
+    - Output and comments (`-TYPE`, `-*`).
+    - Interleaved Dialogue Manager and `TABLE FILE` requests.
+
+- **`test_dm_control_flow.py`**: Specifically targets control flow logic:
+    - Labels and `-GOTO` branching.
+    - Interleaved control flow within `TABLE FILE` blocks.
+
+- **`test_master_file_parser.py`**: Verifies the parsing of WebFOCUS Master Files (`.mas`):
+    - File, Segment, and Field declarations.
+    - Attribute parsing (ALIAS, USAGE, TITLE, etc.).
+    - `DEFINE` and `VARIABLE` declarations.
+
+- **`test_prototype_parser.py`**: Integration tests using the `WebFocusParser` dispatcher. It ensures that both Master Files and Report Requests are correctly identified and parsed.
+
+## Running Tests
+
+To run the full test suite, ensure the `src` directory is in your `PYTHONPATH`:
+
+```bash
+export PYTHONPATH=$PYTHONPATH:$(pwd)/src
+python3 -m unittest discover test
+```
+
+For verbose output:
+
+```bash
+python3 -m unittest discover -v test
+```
+
+## Coverage Report
+
+To generate a coverage report, install the `coverage` package:
+
+```bash
+pip install coverage
+export PYTHONPATH=$PYTHONPATH:$(pwd)/src
+coverage run -m unittest discover test
+coverage report -m
+```
+
+## Samples
+
+The `test/samples/` directory contains real-world WebFOCUS `.fex` files used for regression testing and grammar verification. New samples should be added here to expand coverage.

--- a/test/test_antlr_wf_parser.py
+++ b/test/test_antlr_wf_parser.py
@@ -34,10 +34,8 @@ class TestAntlrWebFocusParser(unittest.TestCase):
             "TABLE FILE EMPDATA SUM SALARY ON TABLE ROW-TOTAL END"
         ]
         for code in variations:
-            try:
+            with self.subTest(code=code):
                 self.parse(code)
-            except Exception as e:
-                self.fail(f"Failed to parse summarization command '{code}': {e}")
 
     def test_output_commands(self):
         variations = [
@@ -50,10 +48,8 @@ class TestAntlrWebFocusParser(unittest.TestCase):
             "TABLE FILE EMPDATA SUM SALARY ON TABLE HOLD AS MYFILE FORMAT FOCUS END"
         ]
         for code in variations:
-            try:
+            with self.subTest(code=code):
                 self.parse(code)
-            except Exception as e:
-                self.fail(f"Failed to parse output command '{code}': {e}")
 
     def test_where_clauses(self):
         variations = [
@@ -63,10 +59,8 @@ class TestAntlrWebFocusParser(unittest.TestCase):
             "TABLE FILE EMPDATA PRINT * WHERE DIV EQ 'NORTH' END"
         ]
         for code in variations:
-            try:
+            with self.subTest(code=code):
                 self.parse(code)
-            except Exception as e:
-                self.fail(f"Failed to parse WHERE clause '{code}': {e}")
 
     def test_basic_requests(self):
         variations = [
@@ -75,10 +69,8 @@ class TestAntlrWebFocusParser(unittest.TestCase):
             "TABLE FILE EMPDATA LIST * END"
         ]
         for code in variations:
-            try:
+            with self.subTest(code=code):
                 self.parse(code)
-            except Exception as e:
-                self.fail(f"Failed to parse basic request '{code}': {e}")
 
     def test_sort_phrases(self):
         variations = [
@@ -88,10 +80,8 @@ class TestAntlrWebFocusParser(unittest.TestCase):
             "TABLE FILE EMPDATA SUM SALARY BY LOWEST CURR_SAL END"
         ]
         for code in variations:
-            try:
+            with self.subTest(code=code):
                 self.parse(code)
-            except Exception as e:
-                self.fail(f"Failed to parse sort phrase '{code}': {e}")
 
     def test_formatting_commands(self):
         variations = [
@@ -100,24 +90,20 @@ class TestAntlrWebFocusParser(unittest.TestCase):
             "TABLE FILE EMPDATA SUM SALARY ON DEPT SUBHEAD 'Dept: <DEPT' END"
         ]
         for code in variations:
-            try:
+            with self.subTest(code=code):
                 self.parse(code)
-            except Exception as e:
-                self.fail(f"Failed to parse formatting command '{code}': {e}")
 
     def test_samples(self):
         samples_dir = 'test/samples'
         if not os.path.exists(samples_dir):
             return
-        for filename in os.listdir(samples_dir):
+        for filename in sorted(os.listdir(samples_dir)):
             if filename.endswith('.fex'):
                 filepath = os.path.join(samples_dir, filename)
                 with open(filepath, 'r') as f:
                     code = f.read()
-                try:
+                with self.subTest(filename=filename):
                     self.parse(code)
-                except Exception as e:
-                    self.fail(f"Failed to parse {filename}: {e}")
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_prototype_parser.py
+++ b/test/test_prototype_parser.py
@@ -199,15 +199,13 @@ class TestWebFocusParser(unittest.TestCase):
 
     def test_samples(self):
         samples_dir = os.path.join(os.path.dirname(__file__), 'samples')
-        for filename in os.listdir(samples_dir):
+        for filename in sorted(os.listdir(samples_dir)):
             if filename.endswith('.fex'):
                 filepath = os.path.join(samples_dir, filename)
                 with open(filepath, 'r') as f:
                     code = f.read()
-                try:
+                with self.subTest(filename=filename):
                     self.parser.parse(code)
-                except Exception as e:
-                    self.fail(f"Failed to parse {filename}: {e}")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change improves the visibility and granularity of the WebFOCUS transpiler's test suite. 

Key improvements:
- **Subtests:** Modified sample-based tests to use `unittest.subTest`, allowing the test runner to identify specifically which input string or file causes a failure without stopping the entire test run.
- **Verbose CI:** Updated `.github/workflows/cicd.yml` to use the `-v` flag, ensuring individual test methods and subtests are logged in GitHub Actions.
- **Documentation:** Added `test/README.md` to provide a clear map of the testing infrastructure and instructions for running tests locally with coverage.
- **Hygiene:** Cleaned up redundant `try-except` blocks in tests, ensured deterministic execution order for samples, and updated `.gitignore` to prevent committing binary coverage artifacts.
- **Roadmap:** Marked task 0.17 ("Show some more details about the tests run") as complete.

Fixes #70

---
*PR created automatically by Jules for task [1914169265840017738](https://jules.google.com/task/1914169265840017738) started by @chatelao*