### PR TITLE
Implement Procedural ASG nodes for Dialogue Manager

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -42,9 +42,9 @@ Move beyond syntax trees to an Abstract Semantic Graph (ASG) that understands th
 - [ ] **2.1 Custom Object Model:**
   - [x] 2.1.1 Base ASG nodes: Implement base classes for Expressions, Commands, and Statements. (Implemented in `src/asg.py`)
   - [x] 2.1.2 Data Model nodes: Implement nodes for Master Files, Segments, and Fields. (Implemented in `src/asg.py`)
-  - [ ] 2.1.3 Procedural nodes:
-    - [ ] 2.1.3.1 DM Control Flow: Implement nodes for -GOTO, -IF, and -REPEAT.
-    - [ ] 2.1.3.2 DM Actions: Implement nodes for -SET, -TYPE, and -INCLUDE.
+  - [x] 2.1.3 Procedural nodes:
+    - [x] 2.1.3.1 DM Control Flow: Implement nodes for -GOTO, -IF, and -REPEAT. (Implemented in `src/asg.py`)
+    - [x] 2.1.3.2 DM Actions: Implement nodes for -SET, -TYPE, and -INCLUDE. (Implemented in `src/asg.py`)
   - [ ] 2.1.4 Report Request nodes: Implement nodes for TABLE FILE, Sort phrases, and Filters.
 - [ ] **2.2 Symbol Table:**
   - [ ] 2.2.1 Scoping: Implement block-level and global scopes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # ROADMAP
 - [ ] 0.28 Implement a next modest, feasible and reasonable MIGRATION_ROADMAP.md step (#86)
-- [ ] 0.27 Implement a next modest, feasible and reasonable MIGRATION_ROADMAP.md step (#86)
+- [x] 0.27 Implement a next modest, feasible and reasonable MIGRATION_ROADMAP.md step (#86) (completed at 2026-04-26 14:38:49)
 - [x] 0.26 Implement a next modest, feasible and reasonable MIGRATION_ROADMAP.md step (#84) (completed at 2026-04-26 15:45:00)
 - [x] 0.25 Implement a next modest, feasible and reasonable MIGRATION_ROADMAP.md step (#82) (completed at 2026-04-26 14:14:19)
 - [x] 0.24 Implement a next modest, feasible and reasonable MIGRATION_ROADMAP.md step (#80) (completed at 2026-04-26 11:45:00)

--- a/SYSTEM_OVERVIEW.plantuml
+++ b/SYSTEM_OVERVIEW.plantuml
@@ -32,6 +32,7 @@ package "Semantic Analysis" {
         * Implement Abstract Semantic Graph (ASG) (4.1)
         * Define ASG node classes (4.1.1, 2.1)
         * Define Data Model ASG nodes (2.1.2) - [DONE]
+        * Define Procedural ASG nodes (2.1.3) - [DONE]
         * Implement Symbol Table for scope/type tracking (4.1.2, 2.2)
         * Implement ASG builder from ANTLR4 AST (4.1.3)
         * Implement Type Inference (2.3)

--- a/src/asg.py
+++ b/src/asg.py
@@ -16,6 +16,49 @@ class Command(ASGNode):
     """Base class for all command nodes in the ASG."""
     pass
 
+class Goto(Command):
+    """Represents a Dialogue Manager -GOTO command."""
+    def __init__(self, target, **kwargs):
+        super().__init__(target=target, **kwargs)
+
+class Label(Command):
+    """Represents a Dialogue Manager label."""
+    def __init__(self, name, **kwargs):
+        super().__init__(name=name, **kwargs)
+
+class IfDM(Command):
+    """Represents a Dialogue Manager -IF command."""
+    def __init__(self, condition, then_target, else_target=None, **kwargs):
+        super().__init__(condition=condition, then_target=then_target, else_target=else_target, **kwargs)
+
+class Repeat(Command):
+    """Represents a Dialogue Manager -REPEAT command."""
+    def __init__(self, label, **kwargs):
+        super().__init__(label=label, **kwargs)
+
+class SetDM(Command):
+    """Represents a Dialogue Manager -SET command."""
+    def __init__(self, variable, expression, **kwargs):
+        super().__init__(variable=variable, expression=expression, **kwargs)
+
+class TypeDM(Command):
+    """Represents a Dialogue Manager -TYPE command."""
+    def __init__(self, messages=None, **kwargs):
+        super().__init__(messages=messages or [], **kwargs)
+
+class IncludeDM(Command):
+    """Represents a Dialogue Manager -INCLUDE command."""
+    def __init__(self, filename, **kwargs):
+        super().__init__(filename=filename, **kwargs)
+
+class RunDM(Command):
+    """Represents a Dialogue Manager -RUN command."""
+    pass
+
+class ExitDM(Command):
+    """Represents a Dialogue Manager -EXIT command."""
+    pass
+
 class DataModelNode(ASGNode):
     """Base class for nodes related to the data model (Master Files)."""
     pass

--- a/test/test_asg.py
+++ b/test/test_asg.py
@@ -1,5 +1,8 @@
 import unittest
-from src.asg import Expression, Statement, Command, MasterFile, Segment, Field
+from src.asg import (
+    Expression, Statement, Command, MasterFile, Segment, Field,
+    Goto, Label, IfDM, Repeat, SetDM, TypeDM, IncludeDM, RunDM, ExitDM
+)
 
 class TestASGNodes(unittest.TestCase):
     def test_expression_instantiation(self):
@@ -44,6 +47,38 @@ class TestASGNodes(unittest.TestCase):
         self.assertEqual(mf.segments[0].name, "EMPDATA")
         self.assertEqual(len(mf.segments[0].fields), 1)
         self.assertEqual(mf.segments[0].fields[0].name, "LASTNAME")
+
+    def test_dm_control_flow_nodes(self):
+        goto_node = Goto(target="EXIT_REPORT")
+        self.assertEqual(goto_node.target, "EXIT_REPORT")
+
+        label_node = Label(name="EXIT_REPORT")
+        self.assertEqual(label_node.name, "EXIT_REPORT")
+
+        if_node = IfDM(condition="&VAR EQ 1", then_target="LABEL1", else_target="LABEL2")
+        self.assertEqual(if_node.condition, "&VAR EQ 1")
+        self.assertEqual(if_node.then_target, "LABEL1")
+        self.assertEqual(if_node.else_target, "LABEL2")
+
+        repeat_node = Repeat(label="LOOP_START")
+        self.assertEqual(repeat_node.label, "LOOP_START")
+
+    def test_dm_action_nodes(self):
+        set_node = SetDM(variable="&VAR", expression="100")
+        self.assertEqual(set_node.variable, "&VAR")
+        self.assertEqual(set_node.expression, "100")
+
+        type_node = TypeDM(messages=["Hello", "World"])
+        self.assertEqual(type_node.messages, ["Hello", "World"])
+
+        include_node = IncludeDM(filename="MYFEX.FEX")
+        self.assertEqual(include_node.filename, "MYFEX.FEX")
+
+        run_node = RunDM()
+        self.assertIsInstance(run_node, RunDM)
+
+        exit_node = ExitDM()
+        self.assertIsInstance(exit_node, ExitDM)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change implements the next step in the migration roadmap: defining Procedural ASG nodes for the Dialogue Manager. 

The following nodes were added to `src/asg.py`:
- `Goto`: Represents `-GOTO`
- `Label`: Represents DM labels
- `IfDM`: Represents `-IF ... THEN ... ELSE`
- `Repeat`: Represents `-REPEAT`
- `SetDM`: Represents `-SET`
- `TypeDM`: Represents `-TYPE`
- `IncludeDM`: Represents `-INCLUDE`
- `RunDM`: Represents `-RUN`
- `ExitDM`: Represents `-EXIT`

Unit tests were added to `test/test_asg.py` to ensure these nodes can be instantiated with their expected attributes. 

Documentation and roadmap files (`MIGRATION_ROADMAP.md`, `ROADMAP.md`, and `SYSTEM_OVERVIEW.plantuml`) were updated to mark these tasks as complete.

Fixes #86

---
*PR created automatically by Jules for task [6159838616264122751](https://jules.google.com/task/6159838616264122751) started by @chatelao*