### PR TITLE
Implement Report Request and Environment ASG Nodes

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -45,7 +45,9 @@ Move beyond syntax trees to an Abstract Semantic Graph (ASG) that understands th
   - [x] 2.1.3 Procedural nodes:
     - [x] 2.1.3.1 DM Control Flow: Implement nodes for -GOTO, -IF, and -REPEAT. (Implemented in `src/asg.py`)
     - [x] 2.1.3.2 DM Actions: Implement nodes for -SET, -TYPE, and -INCLUDE. (Implemented in `src/asg.py`)
-  - [ ] 2.1.4 Report Request nodes: Implement nodes for TABLE FILE, Sort phrases, and Filters.
+  - [x] 2.1.4 Report Request nodes: Implement nodes for TABLE FILE, Verbs, Sort phrases, Filters, and Formatting. (Implemented in `src/asg.py`)
+  - [x] 2.1.5 Environment and Virtual Field nodes: Implement nodes for JOIN, SET, and DEFINE. (Implemented in `src/asg.py`)
+  - [ ] 2.1.6 Expression nodes: Implement nodes for arithmetic and logical operations.
 - [ ] **2.2 Symbol Table:**
   - [ ] 2.2.1 Scoping: Implement block-level and global scopes.
   - [ ] 2.2.2 Variable Resolution: Handle Dialogue Manager variables and field references.

--- a/src/asg.py
+++ b/src/asg.py
@@ -59,6 +59,66 @@ class ExitDM(Command):
     """Represents a Dialogue Manager -EXIT command."""
     pass
 
+class ReportRequest(Statement):
+    """Represents a TABLE FILE report request."""
+    def __init__(self, filename, components=None, **kwargs):
+        super().__init__(filename=filename, components=components or [], **kwargs)
+
+class VerbCommand(Command):
+    """Represents a report verb command (PRINT, SUM, etc.)."""
+    def __init__(self, verb, fields=None, **kwargs):
+        super().__init__(verb=verb, fields=fields or [], **kwargs)
+
+class FieldSelection(ASGNode):
+    """Represents a field selection in a verb or sort command."""
+    def __init__(self, name, prefix_operators=None, alias=None, **kwargs):
+        super().__init__(name=name, prefix_operators=prefix_operators or [], alias=alias, **kwargs)
+
+class SortCommand(Command):
+    """Represents a sort phrase (BY or ACROSS)."""
+    def __init__(self, sort_type, field, options=None, **kwargs):
+        super().__init__(sort_type=sort_type, field=field, options=options or {}, **kwargs)
+
+class WhereClause(Command):
+    """Represents a WHERE clause in a report request."""
+    def __init__(self, condition, is_total=False, **kwargs):
+        super().__init__(condition=condition, is_total=is_total, **kwargs)
+
+class Heading(Command):
+    """Represents a HEADING command."""
+    def __init__(self, text, centered=False, **kwargs):
+        super().__init__(text=text, centered=centered, **kwargs)
+
+class Footing(Command):
+    """Represents a FOOTING command."""
+    def __init__(self, text, centered=False, **kwargs):
+        super().__init__(text=text, centered=centered, **kwargs)
+
+class OnCommand(Command):
+    """Represents an ON command (ON TABLE or ON field)."""
+    def __init__(self, target, actions=None, **kwargs):
+        super().__init__(target=target, actions=actions or [], **kwargs)
+
+class ComputeCommand(Command):
+    """Represents a COMPUTE command."""
+    def __init__(self, name, expression, format=None, **kwargs):
+        super().__init__(name=name, expression=expression, format=format, **kwargs)
+
+class Join(Command):
+    """Represents a JOIN command."""
+    def __init__(self, left_file, left_field, right_file, right_field, join_as=None, outer=False, **kwargs):
+        super().__init__(left_file=left_file, left_field=left_field, right_file=right_file, right_field=right_field, join_as=join_as, outer=outer, **kwargs)
+
+class SetCommand(Command):
+    """Represents a SET (non-Dialogue Manager) command."""
+    def __init__(self, parameter, value, **kwargs):
+        super().__init__(parameter=parameter, value=value, **kwargs)
+
+class DefineFile(Statement):
+    """Represents a DEFINE FILE block."""
+    def __init__(self, filename, assignments=None, **kwargs):
+        super().__init__(filename=filename, assignments=assignments or [], **kwargs)
+
 class DataModelNode(ASGNode):
     """Base class for nodes related to the data model (Master Files)."""
     pass

--- a/test/test_asg.py
+++ b/test/test_asg.py
@@ -1,7 +1,9 @@
 import unittest
 from src.asg import (
     Expression, Statement, Command, MasterFile, Segment, Field,
-    Goto, Label, IfDM, Repeat, SetDM, TypeDM, IncludeDM, RunDM, ExitDM
+    Goto, Label, IfDM, Repeat, SetDM, TypeDM, IncludeDM, RunDM, ExitDM,
+    ReportRequest, VerbCommand, FieldSelection, SortCommand, WhereClause,
+    Heading, Footing, OnCommand, ComputeCommand, Join, SetCommand, DefineFile
 )
 
 class TestASGNodes(unittest.TestCase):
@@ -79,6 +81,54 @@ class TestASGNodes(unittest.TestCase):
 
         exit_node = ExitDM()
         self.assertIsInstance(exit_node, ExitDM)
+
+    def test_report_request_nodes(self):
+        report = ReportRequest(filename="EMPLOYEE")
+        self.assertEqual(report.filename, "EMPLOYEE")
+        self.assertEqual(report.components, [])
+
+        verb = VerbCommand(verb="PRINT", fields=[FieldSelection(name="LASTNAME")])
+        self.assertEqual(verb.verb, "PRINT")
+        self.assertEqual(verb.fields[0].name, "LASTNAME")
+
+        sort = SortCommand(sort_type="BY", field=FieldSelection(name="DEPARTMENT"))
+        self.assertEqual(sort.sort_type, "BY")
+        self.assertEqual(sort.field.name, "DEPARTMENT")
+
+        where = WhereClause(condition="SALARY GT 50000", is_total=False)
+        self.assertEqual(where.condition, "SALARY GT 50000")
+        self.assertFalse(where.is_total)
+
+        heading = Heading(text="Employee Report", centered=True)
+        self.assertEqual(heading.text, "Employee Report")
+        self.assertTrue(heading.centered)
+
+        footing = Footing(text="End of Report")
+        self.assertEqual(footing.text, "End of Report")
+        self.assertFalse(footing.centered)
+
+        on_table = OnCommand(target="TABLE", actions=["COLUMN-TOTAL"])
+        self.assertEqual(on_table.target, "TABLE")
+        self.assertEqual(on_table.actions, ["COLUMN-TOTAL"])
+
+        compute = ComputeCommand(name="BONUS", expression="SALARY * 0.1", format="D12.2")
+        self.assertEqual(compute.name, "BONUS")
+        self.assertEqual(compute.expression, "SALARY * 0.1")
+        self.assertEqual(compute.format, "D12.2")
+
+    def test_environment_and_virtual_field_nodes(self):
+        join = Join(left_file="EMP", left_field="ID", right_file="SAL", right_field="ID", join_as="EMPSAL", outer=True)
+        self.assertEqual(join.left_file, "EMP")
+        self.assertEqual(join.join_as, "EMPSAL")
+        self.assertTrue(join.outer)
+
+        set_cmd = SetCommand(parameter="NODATA", value="MISSING")
+        self.assertEqual(set_cmd.parameter, "NODATA")
+        self.assertEqual(set_cmd.value, "MISSING")
+
+        define = DefineFile(filename="EMPLOYEE", assignments=[{"name": "FULLNAME", "expression": "FIRSTNAME || LASTNAME"}])
+        self.assertEqual(define.filename, "EMPLOYEE")
+        self.assertEqual(len(define.assignments), 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I have implemented the next significant steps in the migration roadmap (Phase 2.1.4 and 2.1.5). This involved breaking down the "Report Request nodes" task into more granular pieces and implementing the corresponding Abstract Semantic Graph (ASG) nodes in `src/asg.py`. I also implemented nodes for environment commands (`JOIN`, `SET`) and virtual field definitions (`DEFINE FILE`).

Specific nodes added:
- `ReportRequest`: Represents a full `TABLE FILE` request.
- `VerbCommand`: Represents report verbs like `PRINT`, `SUM`.
- `FieldSelection`: Represents fields within verbs or sort commands, including prefix operators and aliases.
- `SortCommand`: Represents `BY` and `ACROSS` phrases.
- `WhereClause`: Represents filtering logic.
- `Heading`/`Footing`: Represents report header and footer text.
- `OnCommand`: Represents `ON TABLE` or `ON field` actions.
- `ComputeCommand`: Represents calculated fields within a report.
- `Join`: Represents data source joins.
- `SetCommand`: Represents environment settings.
- `DefineFile`: Represents virtual field definition blocks.

I updated the unit test suite in `test/test_asg.py` to cover all new nodes and verified that the entire test suite passes. The `MIGRATION_ROADMAP.md` has been updated to reflect this progress.

Fixes #88

---
*PR created automatically by Jules for task [8342680012321429927](https://jules.google.com/task/8342680012321429927) started by @chatelao*