### PR TITLE
Implement ASG expression nodes

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -47,7 +47,7 @@ Move beyond syntax trees to an Abstract Semantic Graph (ASG) that understands th
     - [x] 2.1.3.2 DM Actions: Implement nodes for -SET, -TYPE, and -INCLUDE. (Implemented in `src/asg.py`)
   - [x] 2.1.4 Report Request nodes: Implement nodes for TABLE FILE, Verbs, Sort phrases, Filters, and Formatting. (Implemented in `src/asg.py`)
   - [x] 2.1.5 Environment and Virtual Field nodes: Implement nodes for JOIN, SET, and DEFINE. (Implemented in `src/asg.py`)
-  - [ ] 2.1.6 Expression nodes: Implement nodes for arithmetic and logical operations.
+  - [x] 2.1.6 Expression nodes: Implement nodes for arithmetic and logical operations. (Implemented in `src/asg.py`)
 - [ ] **2.2 Symbol Table:**
   - [ ] 2.2.1 Scoping: Implement block-level and global scopes.
   - [ ] 2.2.2 Variable Resolution: Handle Dialogue Manager variables and field references.

--- a/src/asg.py
+++ b/src/asg.py
@@ -8,6 +8,51 @@ class Expression(ASGNode):
     """Base class for all expression nodes in the ASG."""
     pass
 
+class Literal(Expression):
+    """Represents a literal value (number, string, etc.)."""
+    def __init__(self, value, **kwargs):
+        super().__init__(value=value, **kwargs)
+
+class Identifier(Expression):
+    """Represents a field or variable name."""
+    def __init__(self, name, **kwargs):
+        super().__init__(name=name, **kwargs)
+
+class AmperVar(Expression):
+    """Represents a Dialogue Manager variable (e.g., &VAR)."""
+    def __init__(self, name, **kwargs):
+        super().__init__(name=name, **kwargs)
+
+class BinaryOperation(Expression):
+    """Represents a binary operation (e.g., a + b, a AND b)."""
+    def __init__(self, left, operator, right, **kwargs):
+        super().__init__(left=left, operator=operator, right=right, **kwargs)
+
+class UnaryOperation(Expression):
+    """Represents a unary operation (e.g., -a, NOT a)."""
+    def __init__(self, operator, operand, **kwargs):
+        super().__init__(operator=operator, operand=operand, **kwargs)
+
+class FunctionCall(Expression):
+    """Represents a function call (e.g., ABS(field))."""
+    def __init__(self, function_name, arguments=None, **kwargs):
+        super().__init__(function_name=function_name, arguments=arguments or [], **kwargs)
+
+class IfExpression(Expression):
+    """Represents an inline IF expression (IF condition THEN expr1 ELSE expr2)."""
+    def __init__(self, condition, then_expr, else_expr, **kwargs):
+        super().__init__(condition=condition, then_expr=then_expr, else_expr=else_expr, **kwargs)
+
+class BetweenExpression(Expression):
+    """Represents a BETWEEN or FROM...TO expression."""
+    def __init__(self, expression, lower, upper, **kwargs):
+        super().__init__(expression=expression, lower=lower, upper=upper, **kwargs)
+
+class InExpression(Expression):
+    """Represents an IN expression (e.g., field IN (val1, val2))."""
+    def __init__(self, expression, values, **kwargs):
+        super().__init__(expression=expression, values=values, **kwargs)
+
 class Statement(ASGNode):
     """Base class for all statement nodes in the ASG."""
     pass

--- a/test/test_asg.py
+++ b/test/test_asg.py
@@ -3,7 +3,9 @@ from src.asg import (
     Expression, Statement, Command, MasterFile, Segment, Field,
     Goto, Label, IfDM, Repeat, SetDM, TypeDM, IncludeDM, RunDM, ExitDM,
     ReportRequest, VerbCommand, FieldSelection, SortCommand, WhereClause,
-    Heading, Footing, OnCommand, ComputeCommand, Join, SetCommand, DefineFile
+    Heading, Footing, OnCommand, ComputeCommand, Join, SetCommand, DefineFile,
+    Literal, Identifier, AmperVar, BinaryOperation, UnaryOperation, FunctionCall,
+    IfExpression, BetweenExpression, InExpression
 )
 
 class TestASGNodes(unittest.TestCase):
@@ -129,6 +131,43 @@ class TestASGNodes(unittest.TestCase):
         define = DefineFile(filename="EMPLOYEE", assignments=[{"name": "FULLNAME", "expression": "FIRSTNAME || LASTNAME"}])
         self.assertEqual(define.filename, "EMPLOYEE")
         self.assertEqual(len(define.assignments), 1)
+
+    def test_expression_nodes(self):
+        lit = Literal(value=100)
+        self.assertEqual(lit.value, 100)
+
+        ident = Identifier(name="SALARY")
+        self.assertEqual(ident.name, "SALARY")
+
+        amper = AmperVar(name="&DATE")
+        self.assertEqual(amper.name, "&DATE")
+
+        bin_op = BinaryOperation(left=ident, operator="+", right=lit)
+        self.assertEqual(bin_op.left, ident)
+        self.assertEqual(bin_op.operator, "+")
+        self.assertEqual(bin_op.right, lit)
+
+        un_op = UnaryOperation(operator="NOT", operand=bin_op)
+        self.assertEqual(un_op.operator, "NOT")
+        self.assertEqual(un_op.operand, bin_op)
+
+        func = FunctionCall(function_name="ABS", arguments=[lit])
+        self.assertEqual(func.function_name, "ABS")
+        self.assertEqual(func.arguments[0], lit)
+
+        if_expr = IfExpression(condition=ident, then_expr=lit, else_expr=Literal(value=0))
+        self.assertEqual(if_expr.condition, ident)
+        self.assertEqual(if_expr.then_expr, lit)
+        self.assertEqual(if_expr.else_expr.value, 0)
+
+        between = BetweenExpression(expression=ident, lower=Literal(value=10), upper=Literal(value=20))
+        self.assertEqual(between.expression, ident)
+        self.assertEqual(between.lower.value, 10)
+        self.assertEqual(between.upper.value, 20)
+
+        in_expr = InExpression(expression=ident, values=[Literal(value=1), Literal(value=2)])
+        self.assertEqual(in_expr.expression, ident)
+        self.assertEqual(len(in_expr.values), 2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change implements the Expression subclasses in src/asg.py to support semantic analysis of arithmetic and logical operations. It includes Literal, Identifier, AmperVar, BinaryOperation, UnaryOperation, FunctionCall, IfExpression, BetweenExpression, and InExpression. Tests have been added to test/test_asg.py and the MIGRATION_ROADMAP.md has been updated.

Fixes #90

---
*PR created automatically by Jules for task [18422645059537336618](https://jules.google.com/task/18422645059537336618) started by @chatelao*