### PR TITLE
Implement Report Request Builder core, verbs, and sort phrases in ASG

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -60,8 +60,15 @@ Move beyond syntax trees to an Abstract Semantic Graph (ASG) that understands th
   - [x] 2.4.1 Visitor Infrastructure: Base visitor class and dispatcher. (Implemented in `src/asg_builder.py`)
   - [ ] 2.4.2 Expression Builder: Support all arithmetic and logical expressions.
   - [x] 2.4.3 Dialogue Manager Builder: Support -SET, -IF, -GOTO, -REPEAT, etc. (Implemented in `src/asg_builder.py`)
-  - [ ] 2.4.4 Report Request Builder: Support TABLE FILE, Verbs, BY/ACROSS, WHERE.
-  - [ ] 2.4.5 Environment Builder: Support JOIN, SET, and DEFINE.
+  - [ ] 2.4.4 Report Request Builder:
+    - [x] 2.4.4.1 Core structure: TABLE FILE and END command. (Implemented in `src/asg_builder.py`)
+    - [x] 2.4.4.2 Verbs and Fields: PRINT, SUM, etc., with AS phrases and prefix operators. (Implemented in `src/asg_builder.py`)
+    - [x] 2.4.4.3 Sort phrases: BY and ACROSS with sort options. (Implemented in `src/asg_builder.py`)
+    - [ ] 2.4.4.4 Filtering: WHERE and WHERE TOTAL clauses.
+    - [ ] 2.4.4.5 Formatting and Summarization: HEADING, FOOTING, ON, COMPUTE.
+  - [ ] 2.4.5 Environment Builder:
+    - [ ] 2.4.5.1 Environment Commands: Support JOIN and SET.
+    - [ ] 2.4.5.2 Virtual Fields: Support DEFINE FILE blocks.
 
 ## Phase 3: Optimization (SSA-based IR)
 Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment (SSA) form to enable relational optimizations.

--- a/src/asg_builder.py
+++ b/src/asg_builder.py
@@ -22,6 +22,80 @@ class ReportASGBuilder(WebFocusReportVisitor):
                         nodes.append(node)
         return nodes
 
+    def visitRequest(self, ctx: WebFocusReportParser.RequestContext):
+        filename = self.visit(ctx.table_file())
+        components = []
+        # Iterate through all children except table_file (first) and end_command (last)
+        for i in range(1, ctx.getChildCount() - 1):
+            child = ctx.getChild(i)
+            if isinstance(child, TerminalNode):
+                continue
+            node = self.visit(child)
+            if node:
+                if isinstance(node, list):
+                    components.extend(node)
+                else:
+                    components.append(node)
+        return ReportRequest(filename=filename, components=components)
+
+    def visitTable_file(self, ctx: WebFocusReportParser.Table_fileContext):
+        return ctx.qualified_name().getText()
+
+    def visitVerb_command(self, ctx: WebFocusReportParser.Verb_commandContext):
+        verb = self.visit(ctx.verb())
+        if ctx.field_list():
+            fields = self.visit(ctx.field_list())
+        else:
+            fields = [self.visit(ctx.asterisk())]
+        return VerbCommand(verb=verb, fields=fields)
+
+    def visitVerb(self, ctx: WebFocusReportParser.VerbContext):
+        return ctx.getText().upper()
+
+    def visitField_list(self, ctx: WebFocusReportParser.Field_listContext):
+        return [self.visit(f) for f in ctx.field_or_prefixed()]
+
+    def visitField_or_prefixed(self, ctx: WebFocusReportParser.Field_or_prefixedContext):
+        prefixes = [p.getText().upper() for p in ctx.prefix_operator()]
+        field_selection = self.visit(ctx.field())
+        field_selection.prefix_operators = prefixes
+        return field_selection
+
+    def visitField(self, ctx: WebFocusReportParser.FieldContext):
+        name = ctx.qualified_name().getText()
+        alias = self.visit(ctx.as_phrase()) if ctx.as_phrase() else None
+        return FieldSelection(name=name, alias=alias)
+
+    def visitAs_phrase(self, ctx: WebFocusReportParser.As_phraseContext):
+        val = ctx.STRING().getText()
+        return val[1:-1]
+
+    def visitAsterisk(self, ctx: WebFocusReportParser.AsteriskContext):
+        return FieldSelection(name='*')
+
+    def visitBy_command(self, ctx: WebFocusReportParser.By_commandContext):
+        sort_type = "BY"
+        options = self.visit(ctx.sort_options()) if ctx.sort_options() else {}
+        field = self.visit(ctx.field())
+        # Note: summarize_command and NOPRINT are not yet fully implemented in ASG
+        return SortCommand(sort_type=sort_type, field=field, options=options)
+
+    def visitAcross_command(self, ctx: WebFocusReportParser.Across_commandContext):
+        sort_type = "ACROSS"
+        options = self.visit(ctx.sort_options()) if ctx.sort_options() else {}
+        field = self.visit(ctx.field())
+        return SortCommand(sort_type=sort_type, field=field, options=options)
+
+    def visitSort_options(self, ctx: WebFocusReportParser.Sort_optionsContext):
+        options = {}
+        if ctx.HIGHEST(): options["order"] = "HIGHEST"
+        if ctx.LOWEST(): options["order"] = "LOWEST"
+        if ctx.TOP(): options["order"] = "TOP"
+        if ctx.BOTTOM(): options["order"] = "BOTTOM"
+        if ctx.NUMBER():
+            options["limit"] = int(ctx.NUMBER().getText())
+        return options
+
     def visitDm_set(self, ctx: WebFocusReportParser.Dm_setContext):
         variable = ctx.amper_var().getText()
         expression = self.visit(ctx.dm_expression())

--- a/test/test_asg_builder.py
+++ b/test/test_asg_builder.py
@@ -138,5 +138,51 @@ class TestASGBuilder(unittest.TestCase):
         self.assertTrue(isinstance(expr.left, asg.BinaryOperation))
         self.assertEqual(expr.left.operator, "|")
 
+    def test_table_request_basic(self):
+        code = "TABLE FILE CAR\nPRINT MODEL\nEND"
+        asg_nodes = self.build_asg(code)
+        self.assertEqual(len(asg_nodes), 1)
+        node = asg_nodes[0]
+        self.assertTrue(isinstance(node, asg.ReportRequest))
+        self.assertEqual(node.filename, "CAR")
+        self.assertEqual(len(node.components), 1)
+        verb = node.components[0]
+        self.assertTrue(isinstance(verb, asg.VerbCommand))
+        self.assertEqual(verb.verb, "PRINT")
+        self.assertEqual(len(verb.fields), 1)
+        self.assertEqual(verb.fields[0].name, "MODEL")
+
+    def test_table_request_with_as_and_prefix(self):
+        code = "TABLE FILE CAR\nSUM AVE.PRICE AS 'Average Price'\nEND"
+        asg_nodes = self.build_asg(code)
+        verb = asg_nodes[0].components[0]
+        self.assertEqual(verb.verb, "SUM")
+        field = verb.fields[0]
+        self.assertEqual(field.name, "PRICE")
+        self.assertEqual(field.prefix_operators, ["AVE"])
+        self.assertEqual(field.alias, "Average Price")
+
+    def test_table_request_with_sort(self):
+        code = "TABLE FILE CAR\nPRINT MODEL\nBY COUNTRY\nACROSS HIGHEST 3 BODYTYPE\nEND"
+        asg_nodes = self.build_asg(code)
+        node = asg_nodes[0]
+        self.assertEqual(len(node.components), 3)
+        by_node = node.components[1]
+        across_node = node.components[2]
+        self.assertTrue(isinstance(by_node, asg.SortCommand))
+        self.assertEqual(by_node.sort_type, "BY")
+        self.assertEqual(by_node.field.name, "COUNTRY")
+        self.assertTrue(isinstance(across_node, asg.SortCommand))
+        self.assertEqual(across_node.sort_type, "ACROSS")
+        self.assertEqual(across_node.field.name, "BODYTYPE")
+        self.assertEqual(across_node.options["order"], "HIGHEST")
+        self.assertEqual(across_node.options["limit"], 3)
+
+    def test_table_request_with_asterisk(self):
+        code = "TABLE FILE CAR\nPRINT *\nEND"
+        asg_nodes = self.build_asg(code)
+        verb = asg_nodes[0].components[0]
+        self.assertEqual(verb.fields[0].name, "*")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I have implemented the next modest step in the `MIGRATION_ROADMAP.md` by enhancing the `ReportASGBuilder` in `src/asg_builder.py`. 

First, I broke down the large tasks 2.4.4 (Report Request Builder) and 2.4.5 (Environment Builder) into smaller, manageable sub-tasks in `MIGRATION_ROADMAP.md`.

Then, I implemented the following visitor methods in `src/asg_builder.py`:
- `visitRequest` and `visitTable_file` for the overall `TABLE FILE ... END` structure.
- `visitVerb_command`, `visitVerb`, `visitField_list`, `visitField_or_prefixed`, `visitField`, `visitAs_phrase`, and `visitAsterisk` to support report verbs (PRINT, SUM, etc.) and field selections including prefix operators (AVE., MAX., etc.) and AS aliases.
- `visitBy_command`, `visitAcross_command`, and `visitSort_options` to support sort phrases with options like HIGHEST and LIMIT.

I also added comprehensive unit tests to `test/test_asg_builder.py` to verify these changes and ensured that all 81 tests in the repository pass. Finally, I updated `MIGRATION_ROADMAP.md` to mark the completed sub-tasks.

Fixes #98

---
*PR created automatically by Jules for task [15106653099611580724](https://jules.google.com/task/15106653099611580724) started by @chatelao*