### PR TITLE
Implement ASG builder for Virtual Fields (DEFINE FILE)

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -75,9 +75,9 @@ Move beyond syntax trees to an Abstract Semantic Graph (ASG) that understands th
     - [x] 2.4.5.1 Environment Commands:
       - [x] 2.4.5.1.1 JOIN command (CLEAR, LEFT OUTER, AS). (Implemented in `src/asg_builder.py`)
       - [x] 2.4.5.1.2 SET command for environment parameters. (Implemented in `src/asg_builder.py`)
-    - [ ] 2.4.5.2 Virtual Fields:
-      - [ ] 2.4.5.2.1 DEFINE FILE block structure.
-      - [ ] 2.4.5.2.2 DEFINE assignments with formats and expressions.
+    - [x] 2.4.5.2 Virtual Fields:
+      - [x] 2.4.5.2.1 DEFINE FILE block structure. (Implemented in `src/asg_builder.py`)
+      - [x] 2.4.5.2.2 DEFINE assignments with formats and expressions. (Implemented in `src/asg_builder.py`)
 
 ## Phase 3: Optimization (SSA-based IR)
 Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment (SSA) form to enable relational optimizations.

--- a/src/asg.py
+++ b/src/asg.py
@@ -183,6 +183,11 @@ class DefineFile(Statement):
     def __init__(self, filename, assignments=None, **kwargs):
         super().__init__(filename=filename, assignments=assignments or [], **kwargs)
 
+class DefineAssignment(ASGNode):
+    """Represents a single assignment within a DEFINE FILE block."""
+    def __init__(self, name, expression, format=None, **kwargs):
+        super().__init__(name=name, expression=expression, format=format, **kwargs)
+
 class DataModelNode(ASGNode):
     """Base class for nodes related to the data model (Master Files)."""
     pass

--- a/src/asg_builder.py
+++ b/src/asg_builder.py
@@ -309,6 +309,17 @@ class ReportASGBuilder(WebFocusReportVisitor):
             outer=outer
         )
 
+    def visitDefine_file(self, ctx: WebFocusReportParser.Define_fileContext):
+        filename = ctx.qualified_name().getText()
+        assignments = [self.visit(a) for a in ctx.define_assignment()]
+        return DefineFile(filename=filename, assignments=assignments)
+
+    def visitDefine_assignment(self, ctx: WebFocusReportParser.Define_assignmentContext):
+        name = ctx.qualified_name().getText()
+        format = ctx.format_name().getText() if ctx.format_name() else None
+        expression = self.visit(ctx.dm_expression())
+        return DefineAssignment(name=name, expression=expression, format=format)
+
     def visitSet_command(self, ctx: WebFocusReportParser.Set_commandContext):
         parameter = ctx.NAME(0).getText()
         if ctx.NAME(1):

--- a/test/test_asg_builder.py
+++ b/test/test_asg_builder.py
@@ -296,5 +296,29 @@ class TestASGBuilder(unittest.TestCase):
         node = asg_nodes[0]
         self.assertEqual(node.value, "66")
 
+    def test_define_file(self):
+        code = """
+        DEFINE FILE CAR
+        SALES_K/D12.2 = SALES / 1000;
+        TAX/D12.2 = SALES * 0.08;
+        END
+        """
+        asg_nodes = self.build_asg(code)
+        self.assertEqual(len(asg_nodes), 1)
+        node = asg_nodes[0]
+        self.assertTrue(isinstance(node, asg.DefineFile))
+        self.assertEqual(node.filename, "CAR")
+        self.assertEqual(len(node.assignments), 2)
+
+        a1 = node.assignments[0]
+        self.assertEqual(a1.name, "SALES_K")
+        self.assertEqual(a1.format, "D12.2")
+        self.assertTrue(isinstance(a1.expression, asg.BinaryOperation))
+
+        a2 = node.assignments[1]
+        self.assertEqual(a2.name, "TAX")
+        self.assertEqual(a2.format, "D12.2")
+        self.assertTrue(isinstance(a2.expression, asg.BinaryOperation))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change implements the ASG (Abstract Semantic Graph) construction for `DEFINE FILE` blocks. 

Key changes include:
- **`src/asg.py`**: Added `DefineAssignment` class to represent individual field assignments within a `DEFINE` block.
- **`src/asg_builder.py`**: Implemented `visitDefine_file` and `visitDefine_assignment` methods to translate the ANTLR4 parse tree into ASG nodes.
- **`test/test_asg_builder.py`**: Added `test_define_file` to verify the correct transformation of `DEFINE FILE` blocks with multiple assignments and formats.
- **`MIGRATION_ROADMAP.md`**: Updated to reflect the completion of Task 2.4.5.2.

All tests passed successfully.

Fixes #104

---
*PR created automatically by Jules for task [17560245233188830107](https://jules.google.com/task/17560245233188830107) started by @chatelao*