### PR TITLE
Implement Master File Registry

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -54,7 +54,7 @@ Move beyond syntax trees to an Abstract Semantic Graph (ASG) that understands th
     - [x] 2.2.2.1 Dialogue Manager variables. (Implemented in `src/symbol_resolver.py`)
     - [ ] 2.2.2.2 Field references.
   - [ ] 2.2.3 Metadata Integration:
-    - [ ] 2.2.3.1 Master File Registry: Management of loaded Master Files.
+    - [x] 2.2.3.1 Master File Registry: Management of loaded Master Files. (Implemented in `src/metadata_registry.py`)
     - [ ] 2.2.3.2 Schema Binding: Resolving field names to Master File segments.
 - [ ] **2.3 Type Inference:**
   - [ ] 2.3.1 Literal Typing: Infer types for numeric and string constants.

--- a/src/metadata_registry.py
+++ b/src/metadata_registry.py
@@ -1,0 +1,66 @@
+import os
+from master_file_parser import MasterFileParser
+from master_file_asg_builder import MasterFileASGBuilder
+
+class MetadataRegistry:
+    """
+    Manages and caches Master File ASG nodes.
+    Supports searching for .mas files in multiple directories.
+    """
+    def __init__(self, search_paths=None):
+        self.search_paths = search_paths or []
+        self.cache = {}
+        self.parser = MasterFileParser()
+        self.builder = MasterFileASGBuilder()
+
+    def add_search_path(self, path):
+        """Adds a directory to the search paths for Master Files."""
+        if path not in self.search_paths:
+            self.search_paths.append(path)
+
+    def get_master_file(self, name):
+        """
+        Retrieves a MasterFile ASG node by name.
+        Searches in search_paths and caches the result.
+        """
+        name_upper = name.upper()
+        if name_upper in self.cache:
+            return self.cache[name_upper]
+
+        file_path = self._find_mas_file(name)
+        if not file_path:
+            return None
+
+        try:
+            with open(file_path, 'r') as f:
+                content = f.read()
+
+            tree = self.parser.parse(content)
+            # Reset builder state if needed, although current implementation seems safe
+            # but usually it's better to use a fresh one or clear it if it has state.
+            # MasterFileASGBuilder has self.master_file and self.current_segment
+            self.builder.master_file = None
+            self.builder.current_segment = None
+
+            master_file = self.builder.visit(tree)
+            if master_file:
+                self.cache[name_upper] = master_file
+            return master_file
+        except Exception as e:
+            # In a real system we might want to log this or raise a custom exception
+            print(f"Error loading Master File {name} from {file_path}: {e}")
+            return None
+
+    def _find_mas_file(self, name):
+        """Searches for <name>.mas in the configured search paths."""
+        filenames = [f"{name}.mas", f"{name.lower()}.mas", f"{name.upper()}.mas"]
+        for path in self.search_paths:
+            for filename in filenames:
+                full_path = os.path.join(path, filename)
+                if os.path.isfile(full_path):
+                    return full_path
+        return None
+
+    def clear_cache(self):
+        """Clears the internal cache of Master Files."""
+        self.cache.clear()

--- a/test/test_metadata_registry.py
+++ b/test/test_metadata_registry.py
@@ -1,0 +1,80 @@
+import unittest
+import os
+import tempfile
+import shutil
+import sys
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from metadata_registry import MetadataRegistry
+from asg import MasterFile
+
+class TestMetadataRegistry(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.registry = MetadataRegistry([self.test_dir])
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def create_mas_file(self, name, content):
+        path = os.path.join(self.test_dir, f"{name}.mas")
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def test_load_from_path(self):
+        content = "FILENAME=CAR, SUFFIX=FOC,$"
+        self.create_mas_file("CAR", content)
+
+        mf = self.registry.get_master_file("CAR")
+        self.assertIsNotNone(mf)
+        self.assertIsInstance(mf, MasterFile)
+        self.assertEqual(mf.name, "CAR")
+
+    def test_caching(self):
+        content = "FILENAME=CAR, SUFFIX=FOC,$"
+        self.create_mas_file("CAR", content)
+
+        mf1 = self.registry.get_master_file("CAR")
+        mf2 = self.registry.get_master_file("CAR")
+
+        self.assertIs(mf1, mf2) # Should be the same object from cache
+
+    def test_case_insensitivity(self):
+        content = "FILENAME=CAR, SUFFIX=FOC,$"
+        self.create_mas_file("CAR", content)
+
+        mf = self.registry.get_master_file("car")
+        self.assertIsNotNone(mf)
+        self.assertEqual(mf.name, "CAR")
+
+    def test_multiple_paths(self):
+        dir2 = tempfile.mkdtemp()
+        try:
+            self.registry.add_search_path(dir2)
+            content = "FILENAME=EMPLOYEE, SUFFIX=FOC,$"
+            path = os.path.join(dir2, "EMPLOYEE.mas")
+            with open(path, 'w') as f:
+                f.write(content)
+
+            mf = self.registry.get_master_file("EMPLOYEE")
+            self.assertIsNotNone(mf)
+            self.assertEqual(mf.name, "EMPLOYEE")
+        finally:
+            shutil.rmtree(dir2)
+
+    def test_missing_file(self):
+        mf = self.registry.get_master_file("NONEXISTENT")
+        self.assertIsNone(mf)
+
+    def test_invalid_file(self):
+        # Create a file that will fail parsing
+        self.create_mas_file("INVALID", "THIS IS NOT A VALID MASTER FILE")
+
+        mf = self.registry.get_master_file("INVALID")
+        self.assertIsNone(mf) # get_master_file catches the exception and returns None
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented the Master File Registry (Task 2.2.3.1 in MIGRATION_ROADMAP.md). This involved creating a central registry (`MetadataRegistry`) to manage, load, and cache Master File ASG nodes. This is a crucial step for subsequent tasks such as field reference resolution and schema binding. The implementation includes support for multiple search paths and case-insensitive lookups, and is fully tested.

Fixes #112

---
*PR created automatically by Jules for task [1410282200383389897](https://jules.google.com/task/1410282200383389897) started by @chatelao*