### PR TITLE
Implement Field Resolution and Schema Binding

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -52,10 +52,10 @@ Move beyond syntax trees to an Abstract Semantic Graph (ASG) that understands th
   - [x] 2.2.1 Scoping: Implement block-level and global scopes. (Implemented in `src/symbol_table.py`)
   - [ ] 2.2.2 Variable Resolution:
     - [x] 2.2.2.1 Dialogue Manager variables. (Implemented in `src/symbol_resolver.py`)
-    - [ ] 2.2.2.2 Field references.
+    - [x] 2.2.2.2 Field references. (Implemented in `src/symbol_resolver.py`)
   - [ ] 2.2.3 Metadata Integration:
     - [x] 2.2.3.1 Master File Registry: Management of loaded Master Files. (Implemented in `src/metadata_registry.py`)
-    - [ ] 2.2.3.2 Schema Binding: Resolving field names to Master File segments.
+    - [x] 2.2.3.2 Schema Binding: Resolving field names to Master File segments. (Implemented in `src/symbol_resolver.py`)
 - [ ] **2.3 Type Inference:**
   - [ ] 2.3.1 Literal Typing: Infer types for numeric and string constants.
   - [ ] 2.3.2 Expression Typing:

--- a/src/symbol_resolver.py
+++ b/src/symbol_resolver.py
@@ -4,10 +4,11 @@ from symbol_table import SymbolTable
 class SymbolResolver:
     """
     Traverses the Abstract Semantic Graph (ASG) to resolve symbols and populate the SymbolTable.
-    Currently focuses on Dialogue Manager (DM) variable resolution.
+    Handles Dialogue Manager (DM) variables and Field references.
     """
-    def __init__(self, symbol_table=None):
+    def __init__(self, symbol_table=None, metadata_registry=None):
         self.symbol_table = symbol_table or SymbolTable()
+        self.metadata_registry = metadata_registry
 
     def resolve(self, nodes):
         """Main entry point for resolving symbols in a list of ASG nodes or a single node."""
@@ -39,8 +40,6 @@ class SymbolResolver:
 
     def visit_SetDM(self, node):
         """Registers a Dialogue Manager variable definition from -SET."""
-        # Define the variable in the symbol table if it doesn't exist
-        # Metadata could eventually store the expression or evaluated value
         self.symbol_table.define(node.variable, symbol_type='DM_VAR')
         self.visit(node.expression)
 
@@ -57,9 +56,63 @@ class SymbolResolver:
     def visit_AmperVar(self, node):
         """Resolves a Dialogue Manager variable usage."""
         symbol = self.symbol_table.lookup(node.name)
-        # We attach the symbol to the node for later stages (IR generation, etc.)
         node.symbol = symbol
-        if not symbol:
-            # For WebFOCUS, variables might be external parameters.
-            # We can still track them as potential external dependencies.
-            pass
+
+    def visit_ReportRequest(self, node):
+        """Resolves field references within a TABLE FILE request."""
+        if self.metadata_registry:
+            master_file = self.metadata_registry.get_master_file(node.filename)
+            node.master_file = master_file # Schema Binding
+
+            if master_file:
+                self.symbol_table.enter_scope()
+                # Register fields from the Master File
+                for segment in master_file.segments:
+                    for field in segment.fields:
+                        # Register both short name and qualified name
+                        self.symbol_table.define(field.name, symbol_type='FIELD', metadata={'field': field, 'segment': segment})
+                        self.symbol_table.define(f"{segment.name}.{field.name}", symbol_type='FIELD', metadata={'field': field, 'segment': segment})
+
+                    for vf in segment.virtual_fields:
+                        self.symbol_table.define(vf.name, symbol_type='VIRTUAL_FIELD', metadata={'define': vf, 'segment': segment})
+                        self.symbol_table.define(f"{segment.name}.{vf.name}", symbol_type='VIRTUAL_FIELD', metadata={'define': vf, 'segment': segment})
+
+                for vf in master_file.virtual_fields:
+                    self.symbol_table.define(vf.name, symbol_type='VIRTUAL_FIELD', metadata={'define': vf})
+
+                # Visit components (verbs, WHERE, COMPUTE, etc.)
+                for component in node.components:
+                    self.visit(component)
+
+                self.symbol_table.exit_scope()
+                return
+
+        # If no metadata registry or master file not found, still visit components but symbols might not resolve
+        self.generic_visit(node)
+
+    def visit_Identifier(self, node):
+        """Resolves a field name usage."""
+        symbol = self.symbol_table.lookup(node.name)
+        node.symbol = symbol
+
+    def visit_FieldSelection(self, node):
+        """Resolves a field selection in a report."""
+        symbol = self.symbol_table.lookup(node.name)
+        node.symbol = symbol
+
+    def visit_DefineFile(self, node):
+        """Registers virtual fields from a DEFINE FILE block."""
+        # For now, we define these in the current scope.
+        # In a more complex implementation, we'd associate them with the specific MasterFile.
+        for assignment in node.assignments:
+            self.visit(assignment)
+
+    def visit_DefineAssignment(self, node):
+        """Registers a single virtual field definition."""
+        self.symbol_table.define(node.name, symbol_type='VIRTUAL_FIELD', metadata={'definition': node})
+        self.visit(node.expression)
+
+    def visit_ComputeCommand(self, node):
+        """Registers a COMPUTE field definition within a report request."""
+        self.symbol_table.define(node.name, symbol_type='VIRTUAL_FIELD', metadata={'compute': node})
+        self.visit(node.expression)

--- a/test/test_field_resolution.py
+++ b/test/test_field_resolution.py
@@ -1,0 +1,176 @@
+import unittest
+import os
+import tempfile
+import shutil
+import sys
+from antlr4 import *
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from symbol_resolver import SymbolResolver
+from metadata_registry import MetadataRegistry
+from symbol_table import SymbolTable
+import asg
+
+class TestFieldResolution(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.registry = MetadataRegistry([self.test_dir])
+
+        # Create a sample Master File
+        mas_content = """
+FILENAME=CAR, SUFFIX=FOC,$
+  SEGNAME=ORIGIN, SEGTYPE=S1,$
+    FIELDNAME=COUNTRY, ALIAS=COUNTRY, FORMAT=A10,$
+  SEGNAME=COMP, PARENT=ORIGIN, SEGTYPE=S1,$
+    FIELDNAME=CAR, ALIAS=C, FORMAT=A16,$
+    FIELDNAME=MODEL, ALIAS=M, FORMAT=A24,$
+"""
+        with open(os.path.join(self.test_dir, "CAR.mas"), 'w') as f:
+            f.write(mas_content)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def build_asg(self, text):
+        input_stream = InputStream(text)
+        lexer = WebFocusReportLexer(input_stream)
+        stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(stream)
+        tree = parser.start()
+        builder = ReportASGBuilder()
+        return builder.visit(tree)
+
+    def test_basic_field_resolution(self):
+        code = """
+        TABLE FILE CAR
+        PRINT CAR AND MODEL
+        END
+        """
+        asg_nodes = self.build_asg(code)
+        resolver = SymbolResolver(metadata_registry=self.registry)
+        resolver.resolve(asg_nodes)
+
+        report = asg_nodes[0]
+        self.assertIsInstance(report, asg.ReportRequest)
+        self.assertIsNotNone(report.master_file)
+        self.assertEqual(report.master_file.name, "CAR")
+
+        verb = report.components[0]
+        self.assertIsInstance(verb, asg.VerbCommand)
+
+        car_field = verb.fields[0]
+        self.assertEqual(car_field.name, "CAR")
+        self.assertIsNotNone(car_field.symbol)
+        self.assertEqual(car_field.symbol.symbol_type, "FIELD")
+
+        model_field = verb.fields[1]
+        self.assertEqual(model_field.name, "MODEL")
+        self.assertIsNotNone(model_field.symbol)
+
+    def test_qualified_field_resolution(self):
+        code = """
+        TABLE FILE CAR
+        PRINT ORIGIN.COUNTRY AND COMP.CAR
+        END
+        """
+        asg_nodes = self.build_asg(code)
+        resolver = SymbolResolver(metadata_registry=self.registry)
+        resolver.resolve(asg_nodes)
+
+        report = asg_nodes[0]
+        verb = report.components[0]
+
+        country_field = verb.fields[0]
+        self.assertEqual(country_field.name, "ORIGIN.COUNTRY")
+        self.assertIsNotNone(country_field.symbol)
+
+        car_field = verb.fields[1]
+        self.assertEqual(car_field.name, "COMP.CAR")
+        self.assertIsNotNone(car_field.symbol)
+
+    def test_define_file_resolution(self):
+        code = """
+        DEFINE FILE CAR
+        MY_VIRTUAL = CAR;
+        END
+        TABLE FILE CAR
+        PRINT MY_VIRTUAL
+        END
+        """
+        asg_nodes = self.build_asg(code)
+        resolver = SymbolResolver(metadata_registry=self.registry)
+        resolver.resolve(asg_nodes)
+
+        # First node is DefineFile
+        define_file = asg_nodes[0]
+        self.assertIsInstance(define_file, asg.DefineFile)
+
+        # Second node is ReportRequest
+        report = asg_nodes[1]
+        verb = report.components[0]
+        virtual_field_usage = verb.fields[0]
+
+        self.assertEqual(virtual_field_usage.name, "MY_VIRTUAL")
+        self.assertIsNotNone(virtual_field_usage.symbol)
+        self.assertEqual(virtual_field_usage.symbol.symbol_type, "VIRTUAL_FIELD")
+
+    def test_compute_resolution(self):
+        code = """
+        TABLE FILE CAR
+        SUM SALES
+        COMPUTE MY_CALC = SALES * 2;
+        PRINT MY_CALC
+        END
+        """
+        # Note: 'SALES' is not in my CAR.mas above, but COMPUTE will define 'MY_CALC'
+        # Let's add SALES to CAR.mas for completeness
+        with open(os.path.join(self.test_dir, "CAR.mas"), 'a') as f:
+            f.write("    FIELDNAME=SALES, ALIAS=S, FORMAT=I8,$\n")
+
+        # Need to clear cache or use a fresh registry because I modified the file
+        self.registry.clear_cache()
+
+        asg_nodes = self.build_asg(code)
+        resolver = SymbolResolver(metadata_registry=self.registry)
+        resolver.resolve(asg_nodes)
+
+        report = asg_nodes[0]
+
+        # Components: 0: Verb(SUM), 1: ComputeCommand, 2: Verb(PRINT)
+        compute_cmd = report.components[1]
+        self.assertIsInstance(compute_cmd, asg.ComputeCommand)
+
+        print_cmd = report.components[2]
+        calc_usage = print_cmd.fields[0]
+
+        self.assertEqual(calc_usage.name, "MY_CALC")
+        self.assertIsNotNone(calc_usage.symbol)
+        self.assertEqual(calc_usage.symbol.symbol_type, "VIRTUAL_FIELD")
+
+    def test_compute_scoping(self):
+        code = """
+        TABLE FILE CAR
+        COMPUTE LOCAL_VAR = 1;
+        END
+        TABLE FILE CAR
+        PRINT LOCAL_VAR
+        END
+        """
+        asg_nodes = self.build_asg(code)
+        resolver = SymbolResolver(metadata_registry=self.registry)
+        resolver.resolve(asg_nodes)
+
+        report2 = asg_nodes[1]
+        print_cmd = report2.components[0]
+        local_var_usage = print_cmd.fields[0]
+
+        self.assertEqual(local_var_usage.name, "LOCAL_VAR")
+        self.assertIsNone(local_var_usage.symbol) # Should be None because it was defined in another request's scope
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change implements field resolution and schema binding, advancing Phase 2.2 of the Migration Roadmap. The `SymbolResolver` now correctly resolves field references within `TABLE FILE` requests by looking up Master File metadata via the `MetadataRegistry`. It also handles the registration of virtual fields from `DEFINE FILE` and `COMPUTE` blocks, respecting their respective scopes.

Fixes #114

---
*PR created automatically by Jules for task [4268305745561817875](https://jules.google.com/task/4268305745561817875) started by @chatelao*