### PR TITLE
Implement Conditional Branching in IR Builder and Refine Roadmap

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -97,8 +97,11 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
     - [x] 3.1.3.1 Linear Partitioning: Group sequential non-branching commands into basic blocks. (Implemented in `src/ir_builder.py`)
     - [x] 3.1.3.2 Label and Jump Mapping: Implement block splitting for `Label` nodes and block termination for `Goto` nodes. (Implemented in `src/ir_builder.py`)
   - [ ] 3.1.4 Control Flow Edges:
-    - [ ] 3.1.4.1 Conditional Branching: Implement edges and block splitting for `IfDM` nodes.
-    - [ ] 3.1.4.2 Loop Deconstruction: Implement edges and block structures for `Repeat` nodes.
+    - [x] 3.1.4.1 Conditional Branching: Implement edges and block splitting for `IfDM` nodes. (Implemented in `src/ir_builder.py`)
+    - [ ] 3.1.4.2 Loop Deconstruction:
+      - [ ] 3.1.4.2.1 Basic REPEAT structure (loop header, back edges).
+      - [ ] 3.1.4.2.2 Conditional Loops: WHILE/UNTIL support.
+      - [ ] 3.1.4.2.3 Iterative Loops: TIMES/FOR support.
 - [ ] **3.2 SSA Transformation:**
   - [ ] 3.2.1 Dominator Analysis: Compute dominator tree and frontiers.
   - [ ] 3.2.2 Variable Renaming: Implement versioning for all variables.

--- a/src/ir_builder.py
+++ b/src/ir_builder.py
@@ -61,6 +61,33 @@ class IRBuilder:
                 # Subsequent instructions go to a new anonymous block
                 self.current_block = self._new_block()
 
+            elif class_name == 'IfDM':
+                true_label = node.then_target
+                false_label = node.else_target
+
+                if false_label:
+                    self.current_block.add_instruction(ir.Branch(
+                        condition=node.condition,
+                        true_target=true_label,
+                        false_target=false_label
+                    ))
+                    if true_label in self.labels:
+                        self.cfg.add_edge(self.current_block.name, self.labels[true_label])
+                    if false_label in self.labels:
+                        self.cfg.add_edge(self.current_block.name, self.labels[false_label])
+                    self.current_block = self._new_block()
+                else:
+                    fallthrough_block = self._new_block()
+                    self.current_block.add_instruction(ir.Branch(
+                        condition=node.condition,
+                        true_target=true_label,
+                        false_target=fallthrough_block.name
+                    ))
+                    if true_label in self.labels:
+                        self.cfg.add_edge(self.current_block.name, self.labels[true_label])
+                    self.cfg.add_edge(self.current_block.name, fallthrough_block.name)
+                    self.current_block = fallthrough_block
+
             elif class_name == 'SetDM':
                 self.current_block.add_instruction(ir.Assign(target=node.variable, source=node.expression))
             elif class_name == 'TypeDM':

--- a/test/test_ir_builder.py
+++ b/test/test_ir_builder.py
@@ -87,5 +87,66 @@ class TestIRBuilder(unittest.TestCase):
         self.assertEqual(len(entry.instructions), 1)
         self.assertEqual(len(mylabel.instructions), 1)
 
+    def test_conditional_branch(self):
+        # -IF &X EQ 1 GOTO TRUE_LAB
+        # -TYPE False
+        # -TRUE_LAB
+        # -TYPE True
+        asg = [
+            IfDM(condition=BinaryOperation(AmperVar("&X"), "EQ", Literal(1)), then_target="TRUE_LAB"),
+            TypeDM(messages=[Literal("False")]),
+            Label(name="TRUE_LAB"),
+            TypeDM(messages=[Literal("True")])
+        ]
+
+        builder = IRBuilder()
+        cfg = builder.build(asg)
+
+        self.assertIn("ENTRY", cfg.blocks)
+        self.assertIn("TRUE_LAB", cfg.blocks)
+
+        entry = cfg.blocks["ENTRY"]
+        self.assertEqual(len(entry.instructions), 1)
+        self.assertIsInstance(entry.instructions[0], Branch)
+        self.assertEqual(entry.instructions[0].true_target, "TRUE_LAB")
+
+        # Fallthrough block (where -TYPE False is)
+        false_block_name = entry.instructions[0].false_target
+        self.assertIn(false_block_name, cfg.blocks)
+        false_block = cfg.blocks[false_block_name]
+        self.assertIsInstance(false_block.instructions[0], Type)
+
+        # Edges
+        self.assertIn(cfg.blocks["TRUE_LAB"], entry.successors)
+        self.assertIn(false_block, entry.successors)
+        self.assertIn(cfg.blocks["TRUE_LAB"], false_block.successors) # Fallthrough from FALSE to TRUE_LAB
+
+    def test_conditional_branch_with_else(self):
+        # -IF &X EQ 1 GOTO TRUE_LAB ELSE GOTO FALSE_LAB
+        # -TRUE_LAB
+        # -TYPE True
+        # -FALSE_LAB
+        # -TYPE False
+        asg = [
+            IfDM(condition=BinaryOperation(AmperVar("&X"), "EQ", Literal(1)),
+                 then_target="TRUE_LAB", else_target="FALSE_LAB"),
+            Label(name="TRUE_LAB"),
+            TypeDM(messages=[Literal("True")]),
+            Label(name="FALSE_LAB"),
+            TypeDM(messages=[Literal("False")])
+        ]
+
+        builder = IRBuilder()
+        cfg = builder.build(asg)
+
+        entry = cfg.blocks["ENTRY"]
+        self.assertEqual(len(entry.instructions), 1)
+        self.assertIsInstance(entry.instructions[0], Branch)
+        self.assertEqual(entry.instructions[0].true_target, "TRUE_LAB")
+        self.assertEqual(entry.instructions[0].false_target, "FALSE_LAB")
+
+        self.assertIn(cfg.blocks["TRUE_LAB"], entry.successors)
+        self.assertIn(cfg.blocks["FALSE_LAB"], entry.successors)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change implements conditional branching in the `IRBuilder`, which is a key component of the Phase 3.1 (CFG Generation) of the migration.

Specifically:
1.  **IRBuilder Implementation**: Added support for `IfDM` nodes in `src/ir_builder.py`. The builder now correctly generates `ir.Branch` instructions and manages the corresponding control flow edges in the graph. It handles both full `IF-THEN-ELSE` blocks and `IF-THEN` fallthrough scenarios.
2.  **Testing**: Added new test cases to `test/test_ir_builder.py` to verify the correctness of the generated CFG for various conditional structures, including edge verification and instruction types.
3.  **Roadmap Update**: Marked task 3.1.4.1 (Conditional Branching) as complete in `MIGRATION_ROADMAP.md` and further decomposed task 3.1.4.2 (Loop Deconstruction) into smaller, more manageable sub-tasks (Basic structure, Conditional loops, and Iterative loops) to facilitate incremental development.

All 135 tests in the suite passed successfully.

Fixes #122

---
*PR created automatically by Jules for task [14448972435120465827](https://jules.google.com/task/14448972435120465827) started by @chatelao*