### PR TITLE
Implement SSA Phi-node Insertion

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -104,8 +104,10 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
       - [x] 3.1.4.2.3 Iterative Loops: TIMES/FOR support.
 - [ ] **3.2 SSA Transformation:**
   - [x] 3.2.1 Dominator Analysis: Compute dominator tree and frontiers. (Implemented in `src/dominators.py`)
-  - [ ] 3.2.2 Variable Renaming: Implement versioning for all variables.
-  - [ ] 3.2.3 Phi-node Insertion: Handle merge points in control flow.
+  - [x] 3.2.2 Phi-node Insertion: Handle merge points in control flow. (Implemented in `src/ssa_transformer.py`)
+    - [x] 3.2.2.1 Variable Discovery: Identify all variables and their defining blocks.
+    - [x] 3.2.2.2 Iterative Placement: Implement the algorithm to place `Phi` instructions in dominance frontiers.
+  - [ ] 3.2.3 Variable Renaming: Implement versioning for all variables.
 - [ ] **3.3 Relational Lifting:**
   - [ ] 3.3.1 Loop Analysis: Identify loops that iterate over data sources.
   - [ ] 3.3.2 Predicate Pushdown: Identify filters that can be moved to SQL WHERE.

--- a/src/ssa_transformer.py
+++ b/src/ssa_transformer.py
@@ -1,0 +1,79 @@
+import ir
+from dominators import DominatorAnalysis
+
+class SSATransformer:
+    """
+    Handles Transformation of a ControlFlowGraph into Static Single Assignment (SSA) form.
+    """
+    def __init__(self):
+        pass
+
+    def place_phi_nodes(self, cfg):
+        """
+        Inserts Phi instructions into the basic blocks of the CFG using the
+        iterative dominance frontier algorithm.
+        """
+        # 1. Compute dominators and frontiers if not already present or just always run for safety
+        analysis = DominatorAnalysis(cfg)
+        analysis.run()
+        frontiers = analysis.frontiers
+
+        # 2. Discovery: Find all variables and which blocks they are defined in
+        variables = self._get_all_variables(cfg)
+        defining_blocks = self._get_defining_blocks(cfg, variables)
+
+        # 3. Iterative placement
+        for var in variables:
+            phi_inserted_in = set()
+            added_to_worklist = set(defining_blocks[var])
+            worklist = list(defining_blocks[var])
+
+            while worklist:
+                n_name = worklist.pop(0)
+                # For each block m in the dominance frontier of n
+                for m_name in frontiers.get(n_name, []):
+                    if m_name not in phi_inserted_in:
+                        m_block = cfg.blocks[m_name]
+
+                        # Phi nodes must be at the beginning of the block.
+                        # We use the variable name itself as the source for now;
+                        # Renaming will replace these with versioned names.
+                        phi = ir.Phi(target=var, sources=[var] * len(m_block.predecessors))
+                        m_block.instructions.insert(0, phi)
+
+                        phi_inserted_in.add(m_name)
+                        if m_name not in added_to_worklist:
+                            added_to_worklist.add(m_name)
+                            worklist.append(m_name)
+
+    def _get_all_variables(self, cfg):
+        """Identifies all variables assigned in any block of the CFG."""
+        variables = set()
+        for block in cfg.blocks.values():
+            for instr in block.instructions:
+                target = self._get_target_variable(instr)
+                if target:
+                    variables.add(target)
+        return variables
+
+    def _get_defining_blocks(self, cfg, variables):
+        """Maps each variable to a set of block names where it is assigned."""
+        def_blocks = {var: set() for var in variables}
+        for block_name, block in cfg.blocks.items():
+            for instr in block.instructions:
+                target = self._get_target_variable(instr)
+                if target and target in def_blocks:
+                    def_blocks[target].add(block_name)
+        return def_blocks
+
+    def _get_target_variable(self, instr):
+        """Helper to extract the target variable name from an instruction."""
+        class_name = instr.__class__.__name__
+        if class_name in ('Assign', 'Phi'):
+            if isinstance(instr.target, str):
+                return instr.target
+            if hasattr(instr.target, 'name'):
+                return instr.target.name
+        # Note: In the future, other instructions like Define or Compute might be handled here
+        # if they are lowered or if we want to include them in SSA.
+        return None

--- a/test/test_ssa_phi_insertion.py
+++ b/test/test_ssa_phi_insertion.py
@@ -1,0 +1,99 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+import ir
+from ssa_transformer import SSATransformer
+import asg
+
+def test_phi_insertion_diamond():
+    # Diamond: B0 -> B1, B0 -> B2, B1 -> B3, B2 -> B3
+    # X defined in B1 and B2. Phi(X) should be in B3.
+    cfg = ir.ControlFlowGraph()
+    b0 = ir.BasicBlock("B0")
+    b1 = ir.BasicBlock("B1")
+    b2 = ir.BasicBlock("B2")
+    b3 = ir.BasicBlock("B3")
+
+    cfg.add_block(b0)
+    cfg.add_block(b1)
+    cfg.add_block(b2)
+    cfg.add_block(b3)
+
+    cfg.add_edge("B0", "B1")
+    cfg.add_edge("B0", "B2")
+    cfg.add_edge("B1", "B3")
+    cfg.add_edge("B2", "B3")
+
+    b1.add_instruction(ir.Assign(target="X", source=asg.Literal(1)))
+    b2.add_instruction(ir.Assign(target="X", source=asg.Literal(2)))
+
+    transformer = SSATransformer()
+    transformer.place_phi_nodes(cfg)
+
+    # Check B3 has a Phi node for X
+    phi_instrs = [i for i in b3.instructions if i.__class__.__name__ == 'Phi']
+    assert len(phi_instrs) == 1
+    assert phi_instrs[0].target == "X"
+    assert len(phi_instrs[0].sources) == 2
+
+def test_phi_insertion_loop():
+    # Loop: ENTRY -> HEADER, HEADER -> BODY, BODY -> HEADER, HEADER -> EXIT
+    # X defined in ENTRY and BODY. Phi(X) should be in HEADER.
+    cfg = ir.ControlFlowGraph()
+    entry = ir.BasicBlock("ENTRY")
+    header = ir.BasicBlock("HEADER")
+    body = ir.BasicBlock("BODY")
+    exit_b = ir.BasicBlock("EXIT")
+
+    cfg.add_block(entry)
+    cfg.add_block(header)
+    cfg.add_block(body)
+    cfg.add_block(exit_b)
+
+    cfg.add_edge("ENTRY", "HEADER")
+    cfg.add_edge("HEADER", "BODY")
+    cfg.add_edge("BODY", "HEADER")
+    cfg.add_edge("HEADER", "EXIT")
+
+    entry.add_instruction(ir.Assign(target="X", source=asg.Literal(0)))
+    body.add_instruction(ir.Assign(target="X", source=asg.BinaryOperation(asg.AmperVar("X"), "+", asg.Literal(1))))
+
+    transformer = SSATransformer()
+    transformer.place_phi_nodes(cfg)
+
+    # Check HEADER has a Phi node for X
+    phi_instrs = [i for i in header.instructions if i.__class__.__name__ == 'Phi']
+    assert len(phi_instrs) == 1
+    assert phi_instrs[0].target == "X"
+    assert len(phi_instrs[0].sources) == 2 # Predecessors: ENTRY and BODY
+
+def test_phi_insertion_no_phi_needed():
+    # Linear: B0 -> B1 -> B2
+    # X defined in B0. No Phi needed.
+    cfg = ir.ControlFlowGraph()
+    b0 = ir.BasicBlock("B0")
+    b1 = ir.BasicBlock("B1")
+    b2 = ir.BasicBlock("B2")
+
+    cfg.add_block(b0)
+    cfg.add_block(b1)
+    cfg.add_block(b2)
+
+    cfg.add_edge("B0", "B1")
+    cfg.add_edge("B1", "B2")
+
+    b0.add_instruction(ir.Assign(target="X", source=asg.Literal(1)))
+
+    transformer = SSATransformer()
+    transformer.place_phi_nodes(cfg)
+
+    for block in cfg.blocks.values():
+        phi_instrs = [i for i in block.instructions if i.__class__.__name__ == 'Phi']
+        assert len(phi_instrs) == 0
+
+if __name__ == "__main__":
+    test_phi_insertion_diamond()
+    test_phi_insertion_loop()
+    test_phi_insertion_no_phi_needed()
+    print("All tests passed!")


### PR DESCRIPTION
I have implemented the next step in the SSA Transformation phase: Phi-node insertion.

Key changes:
1.  **Roadmap Update**: Modified `MIGRATION_ROADMAP.md` to reorder the SSA steps, placing Phi-node insertion (3.2.2) before Variable Renaming (3.2.3), which is the standard order for SSA construction. I also broke down 3.2.2 into granular sub-tasks for variable discovery and iterative placement.
2.  **SSA Transformer**: Created `src/ssa_transformer.py` containing the `SSATransformer` class. This class implements:
    *   Variable discovery across the Control Flow Graph.
    *   The iterative dominance frontier algorithm to place `Phi` instructions at merge points.
3.  **Testing**: Added `test/test_ssa_phi_insertion.py` with unit tests covering:
    *   Diamond topologies (if-else branching).
    *   Loop topologies.
    *   Linear flows (verifying no unnecessary Phi nodes are added).

All tests passed successfully.

Fixes #134

---
*PR created automatically by Jules for task [15740967955917709297](https://jules.google.com/task/15740967955917709297) started by @chatelao*