### PR TITLE
Implement Variable Mapping and Declaration Emission

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -121,6 +121,7 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
     - [ ] 3.4.2.1 Filter Lifting: Move WHERE conditions to SQL.
     - [ ] 3.4.2.2 Total Lifting: Move WHERE TOTAL conditions to SQL HAVING.
   - [ ] 3.4.3 Projection Pruning: Identify unused fields.
+  - [ ] 3.4.4 Aggregation Lifting: Identify and lift aggregations (SUM, AVG) to SQL.
 
 ## Phase 4: Backend Emission (Jinja2)
 Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
@@ -128,16 +129,28 @@ Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
 - [ ] **4.1 PL/pgSQL Emission Infrastructure:**
   - [x] 4.1.1 Template Environment: Setup Jinja2 and base layout templates.
   - [ ] 4.1.2 Variable Mapping: Implement mapping between SSA versions and PL/pgSQL variables.
+    - [ ] 4.1.2.1 Variable Discovery: Identify all unique SSA variables in the CFG.
+    - [ ] 4.1.2.2 Name Sanitization: Map WebFOCUS/SSA names to SQL-safe identifiers.
+    - [ ] 4.1.2.3 Type Mapping: Map WebFOCUS types (I, F, A) to PostgreSQL types.
 - [ ] **4.2 Procedural Logic Emission:**
-  - [ ] 4.2.1 Assignments and Expressions: Generate code for -SET and calculated fields.
-  - [ ] 4.2.2 Control Flow: Generate code for labels, jumps, branches, and loops.
+  - [ ] 4.2.1 Variable Declaration: Generate `DECLARE` section for all discovered variables.
+  - [ ] 4.2.2 Expression Translation: Transform WebFOCUS expressions to PostgreSQL-compatible SQL.
+  - [ ] 4.2.3 Statement Emission:
+    - [ ] 4.2.3.1 Assignments: Generate `v_target := expression;` for `ir.Assign`.
+    - [ ] 4.2.3.2 Phi Resolution: Generate move instructions to resolve Phi nodes at block entries.
+    - [ ] 4.2.3.3 Messaging: Generate `RAISE NOTICE` for `ir.Type`.
+  - [ ] 4.2.4 Control Flow (State Machine):
+    - [ ] 4.2.4.1 Block Dispatcher: Implement a `WHILE` loop and `CASE` statement to navigate basic blocks.
+    - [ ] 4.2.4.2 Jump/Branch Translation: Update the next block state variable based on `ir.Jump` and `ir.Branch`.
 - [ ] **4.3 Relational Request Emission:**
   - [ ] 4.3.1 SQL Query Generation: Transform `ir.Report` nodes to optimized PostgreSQL queries.
     - [ ] 4.3.1.1 Projection: Mapping PRINT/SUM and field selections.
-    - [ ] 4.3.1.2 Data Sources: Mapping filenames to SQL tables.
-    - [ ] 4.3.1.3 Filtering: Mapping WHERE clauses.
-    - [ ] 4.3.1.4 Grouping: Mapping BY/ACROSS phrases.
-    - [ ] 4.3.1.5 Aggregations: Mapping prefix operators (SUM., AVG., etc.).
+    - [ ] 4.3.1.2 Data Sources: Mapping filenames to SQL tables (using `MetadataRegistry`).
+    - [ ] 4.3.1.3 Filtering: Mapping WHERE clauses to SQL `WHERE`.
+    - [ ] 4.3.1.4 Grouping: Mapping BY/ACROSS phrases to SQL `GROUP BY`.
+    - [ ] 4.3.1.5 Aggregations: Mapping prefix operators (SUM., AVG., etc.) to SQL aggregate functions.
+    - [ ] 4.3.1.6 Post-Aggregation Filtering: Mapping WHERE TOTAL to SQL `HAVING`.
+    - [ ] 4.3.1.7 Sorting: Mapping sort options to SQL `ORDER BY`.
   - [ ] 4.3.2 Data Source Mapping: Resolve TABLE FILE references to database tables/views.
 
 ## Phase 5: Verification and Parity

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -24,8 +24,65 @@ class PostgresEmitter:
         template = self.env.get_template(template_name)
         return template.render(**kwargs)
 
-    def emit_procedure(self, name, body):
+    def emit_procedure(self, name, body, variables=None):
         """
         Helper to emit a full PL/pgSQL procedure.
         """
-        return self.render('base.sql.j2', procedure_name=name, procedure_body=body)
+        return self.render('base.sql.j2', procedure_name=name, procedure_body=body, variables=variables)
+
+    def get_variables_from_cfg(self, cfg):
+        """
+        Discovers all variables in the CFG and maps them to SQL-safe names and types.
+        Returns a dictionary of {sql_name: postgres_type}.
+        """
+        variables = {}
+        for block in cfg.blocks.values():
+            for instr in block.instructions:
+                target = getattr(instr, 'target', None)
+                if target:
+                    sql_name = self._sanitize_name(target)
+
+                    # Try to get data type from instruction, then from source expression
+                    data_type = getattr(instr, 'data_type', None)
+                    if not data_type and hasattr(instr, 'source'):
+                        data_type = getattr(instr.source, 'data_type', None)
+
+                    if not data_type:
+                        data_type = 'A' # Default to Alpha
+
+                    variables[sql_name] = self._map_type(data_type)
+
+                # Also check expressions for variables that might not be assigned (though SSA should handle this)
+                self._discover_vars_in_expr(instr, variables)
+        return variables
+
+    def _sanitize_name(self, name):
+        """
+        Converts WebFOCUS/SSA variable names to SQL-safe identifiers.
+        Example: &X_1 -> v_X_1
+        """
+        if isinstance(name, str):
+            clean_name = name.lstrip('&')
+            # Replace common invalid chars with underscore
+            clean_name = clean_name.replace('-', '_').replace('.', '_')
+            return f"v_{clean_name}"
+        return name
+
+    def _map_type(self, data_type):
+        """
+        Maps WebFOCUS types to PostgreSQL types.
+        """
+        mapping = {
+            'I': 'INTEGER',
+            'F': 'NUMERIC',
+            'A': 'TEXT',
+            'LOGICAL': 'BOOLEAN'
+        }
+        return mapping.get(data_type, 'TEXT')
+
+    def _discover_vars_in_expr(self, instr, variables):
+        """
+        Placeholder for discovering variables in expressions if needed.
+        Currently assuming SSA renaming has identified all variables as targets.
+        """
+        pass

--- a/src/templates/base.sql.j2
+++ b/src/templates/base.sql.j2
@@ -1,6 +1,12 @@
 CREATE OR REPLACE PROCEDURE {{ procedure_name }}()
 LANGUAGE plpgsql
 AS $$
+{% if variables %}
+DECLARE
+{% for name, type in variables.items() %}
+    {{ name }} {{ type }};
+{% endfor %}
+{% endif %}
 BEGIN
 {{ procedure_body | indent(4, first=True) }}
 END;

--- a/test/test_emitter.py
+++ b/test/test_emitter.py
@@ -6,6 +6,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 
 from emitter import PostgresEmitter
+import ir
 
 class TestEmitter(unittest.TestCase):
     def test_emitter_basic_render(self):
@@ -22,6 +23,43 @@ class TestEmitter(unittest.TestCase):
 
         self.assertIn('CREATE OR REPLACE PROCEDURE my_procedure()', output)
         self.assertIn('    SELECT 1;', output)  # Testing indentation
+
+    def test_emit_procedure_with_variables(self):
+        emitter = PostgresEmitter()
+        vars = {'v_X': 'INTEGER', 'v_Y': 'TEXT'}
+        output = emitter.emit_procedure('var_proc', 'v_X := 10;', variables=vars)
+
+        self.assertIn('DECLARE', output)
+        self.assertIn('v_X INTEGER;', output)
+        self.assertIn('v_Y TEXT;', output)
+        self.assertIn('BEGIN', output)
+        self.assertIn('v_X := 10;', output)
+
+    def test_get_variables_from_cfg(self):
+        emitter = PostgresEmitter()
+        cfg = ir.ControlFlowGraph()
+        block = ir.BasicBlock('B1')
+
+        # Mocking instruction with data_type
+        instr1 = ir.Assign(target='&VAR1', source=None)
+        instr1.data_type = 'I'
+
+        instr2 = ir.Assign(target='&VAR2', source=None)
+        instr2.data_type = 'F'
+
+        instr3 = ir.Assign(target='&VAR3', source=None)
+        instr3.data_type = 'LOGICAL'
+
+        block.add_instruction(instr1)
+        block.add_instruction(instr2)
+        block.add_instruction(instr3)
+        cfg.add_block(block)
+
+        variables = emitter.get_variables_from_cfg(cfg)
+
+        self.assertEqual(variables['v_VAR1'], 'INTEGER')
+        self.assertEqual(variables['v_VAR2'], 'NUMERIC')
+        self.assertEqual(variables['v_VAR3'], 'BOOLEAN')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change implements the "Variable Mapping" step (Phase 4.1.2) of the migration roadmap. 

Key changes:
1. **Roadmap Refinement**: `MIGRATION_ROADMAP.md` was updated to break down the Relational Lifting and Backend Emission phases into smaller, actionable steps.
2. **Variable Mapping**: The `PostgresEmitter` class now includes logic to traverse a Control Flow Graph (CFG) and identify all unique variables. It sanitizes WebFOCUS variable names (e.g., `&VAR_1` to `v_VAR_1`) and maps WebFOCUS types (I, F, A, LOGICAL) to their PostgreSQL equivalents (INTEGER, NUMERIC, TEXT, BOOLEAN).
3. **Template Enhancement**: The `base.sql.j2` template was updated to include a `DECLARE` section, which is conditionally rendered if variables are provided.
4. **Verification**: Comprehensive tests were added to `test/test_emitter.py` to ensure that variable discovery, name sanitization, and declaration rendering work as expected. All existing tests passed, ensuring no regressions.

Fixes #158

---
*PR created automatically by Jules for task [13546643995012355943](https://jules.google.com/task/13546643995012355943) started by @chatelao*