### PR TITLE
Implement SQL WHERE clause emission

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -146,7 +146,7 @@ Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
   - [ ] 4.3.1 SQL Query Generation: Transform `ir.Report` nodes to optimized PostgreSQL queries.
     - [x] 4.3.1.1 Projection: Mapping PRINT/SUM and field selections. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.2 Data Sources: Mapping filenames to SQL tables (using `MetadataRegistry`). (Implemented in `src/emitter.py`)
-    - [ ] 4.3.1.3 Filtering: Mapping WHERE clauses to SQL `WHERE`.
+    - [x] 4.3.1.3 Filtering: Mapping WHERE clauses to SQL `WHERE`. (Implemented in `src/emitter.py`)
     - [ ] 4.3.1.4 Grouping: Mapping BY/ACROSS phrases to SQL `GROUP BY`.
     - [ ] 4.3.1.5 Aggregations: Mapping prefix operators (SUM., AVG., etc.) to SQL aggregate functions.
     - [ ] 4.3.1.6 Post-Aggregation Filtering: Mapping WHERE TOTAL to SQL `HAVING`.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -151,6 +151,16 @@ class PostgresEmitter:
             self._discover_vars_in_expr(node.condition, variables)
             self._discover_vars_in_expr(node.then_expr, variables)
             self._discover_vars_in_expr(node.else_expr, variables)
+        elif class_name == 'BetweenExpression':
+            self._discover_vars_in_expr(node.expression, variables)
+            self._discover_vars_in_expr(node.lower, variables)
+            self._discover_vars_in_expr(node.upper, variables)
+        elif class_name == 'InExpression':
+            self._discover_vars_in_expr(node.expression, variables)
+            for val in node.values:
+                self._discover_vars_in_expr(val, variables)
+        elif class_name == 'IsMissingExpression':
+            self._discover_vars_in_expr(node.expression, variables)
 
     def emit_expression(self, expr):
         """
@@ -213,6 +223,26 @@ class PostgresEmitter:
             then_e = self.emit_expression(expr.then_expr)
             else_e = self.emit_expression(expr.else_expr)
             return f"(CASE WHEN {cond} THEN {then_e} ELSE {else_e} END)"
+
+        elif class_name == 'BetweenExpression':
+            expr_val = self.emit_expression(expr.expression)
+            lower = self.emit_expression(expr.lower)
+            upper = self.emit_expression(expr.upper)
+            return f"({expr_val} BETWEEN {lower} AND {upper})"
+
+        elif class_name == 'InExpression':
+            expr_val = self.emit_expression(expr.expression)
+            if hasattr(expr, 'filename') and expr.filename:
+                table_name = self._resolve_table_name(expr.filename)
+                return f"({expr_val} IN (SELECT * FROM {table_name}))"
+            else:
+                values = [self.emit_expression(val) for val in expr.values]
+                return f"({expr_val} IN ({', '.join(values)}))"
+
+        elif class_name == 'IsMissingExpression':
+            expr_val = self.emit_expression(expr.expression)
+            op = "IS NOT NULL" if expr.inverted else "IS NULL"
+            return f"({expr_val} {op})"
 
         return f"/* Unknown expression: {class_name} */"
 
@@ -291,17 +321,25 @@ class PostgresEmitter:
         """
         table_name = self._resolve_table_name(instr.filename)
         fields = []
+        where_clauses = []
 
         for comp in instr.components:
-            if comp.__class__.__name__ == 'VerbCommand':
+            class_name = comp.__class__.__name__
+            if class_name == 'VerbCommand':
                 for field_sel in comp.fields:
                     fields.append(field_sel.name)
+            elif class_name == 'WhereClause' and not comp.is_total:
+                where_clauses.append(self.emit_expression(comp.condition))
 
         if not fields:
             fields = ['*']
 
         field_str = ", ".join(fields)
-        return f"/* {instr.filename} */\nSELECT {field_str} FROM {table_name};"
+        sql = f"/* {instr.filename} */\nSELECT {field_str} FROM {table_name}"
+        if where_clauses:
+            sql += "\nWHERE " + " AND ".join(where_clauses)
+        sql += ";"
+        return sql
 
     def _resolve_table_name(self, filename):
         """

--- a/test/test_emitter.py
+++ b/test/test_emitter.py
@@ -208,5 +208,30 @@ class TestEmitter(unittest.TestCase):
         self.assertIn("FROM MYTABLE", sql)
         self.assertIn("/* MYTABLE */", sql)
 
+    def test_emit_instruction_report_with_where(self):
+        emitter = PostgresEmitter()
+        verb = asg.VerbCommand(verb="PRINT", fields=[asg.FieldSelection(name="FIELD1")])
+
+        # Simple WHERE
+        where1 = asg.WhereClause(condition=asg.BinaryOperation(asg.Identifier("FIELD1"), "GT", asg.Literal(10)))
+
+        # BETWEEN
+        where2 = asg.WhereClause(condition=asg.BetweenExpression(asg.Identifier("FIELD2"), asg.Literal(1), asg.Literal(100)))
+
+        # IN
+        where3 = asg.WhereClause(condition=asg.InExpression(asg.Identifier("FIELD3"), [asg.Literal("A"), asg.Literal("B")]))
+
+        # IS MISSING
+        where4 = asg.WhereClause(condition=asg.IsMissingExpression(asg.Identifier("FIELD4")))
+
+        instr = ir.Report(filename="MYTABLE", components=[verb, where1, where2, where3, where4])
+
+        sql = emitter.emit_instruction(instr)
+
+        self.assertIn("WHERE (v_FIELD1 > 10)", sql)
+        self.assertIn("AND (v_FIELD2 BETWEEN 1 AND 100)", sql)
+        self.assertIn("AND (v_FIELD3 IN ('A', 'B'))", sql)
+        self.assertIn("AND (v_FIELD4 IS NULL)", sql)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implemented the next step in the migration roadmap (Phase 4.3.1.3: Filtering). The `PostgresEmitter` can now generate SQL `WHERE` clauses for `TABLE FILE` requests by translating `WhereClause` ASG nodes and supporting advanced WebFOCUS expression types like `BETWEEN`, `IN`, and `IS MISSING`. All tests passed, including new verification cases for complex filters.

Fixes #166

---
*PR created automatically by Jules for task [5622763237088222438](https://jules.google.com/task/5622763237088222438) started by @chatelao*