### PR TITLE
Implement SQL generation for grouping, aggregations, and sorting

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -147,10 +147,10 @@ Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
     - [x] 4.3.1.1 Projection: Mapping PRINT/SUM and field selections. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.2 Data Sources: Mapping filenames to SQL tables (using `MetadataRegistry`). (Implemented in `src/emitter.py`)
     - [x] 4.3.1.3 Filtering: Mapping WHERE clauses to SQL `WHERE`. (Implemented in `src/emitter.py`)
-    - [ ] 4.3.1.4 Grouping: Mapping BY/ACROSS phrases to SQL `GROUP BY`.
-    - [ ] 4.3.1.5 Aggregations: Mapping prefix operators (SUM., AVG., etc.) to SQL aggregate functions.
+    - [x] 4.3.1.4 Grouping: Mapping BY/ACROSS phrases to SQL `GROUP BY`. (Implemented in `src/emitter.py`)
+    - [x] 4.3.1.5 Aggregations: Mapping prefix operators (SUM., AVG., etc.) to SQL aggregate functions. (Implemented in `src/emitter.py`)
     - [ ] 4.3.1.6 Post-Aggregation Filtering: Mapping WHERE TOTAL to SQL `HAVING`.
-    - [ ] 4.3.1.7 Sorting: Mapping sort options to SQL `ORDER BY`.
+    - [x] 4.3.1.7 Sorting: Mapping sort options to SQL `ORDER BY`. (Implemented in `src/emitter.py`)
   - [ ] 4.3.2 Data Source Mapping: Resolve TABLE FILE references to database tables/views.
 
 ## Phase 5: Verification and Parity

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -320,24 +320,86 @@ class PostgresEmitter:
         Translates ir.Report instruction into a SQL SELECT statement.
         """
         table_name = self._resolve_table_name(instr.filename)
-        fields = []
+        select_fields = []
         where_clauses = []
+        group_by_fields = []
+        order_by_phrases = []
 
-        for comp in instr.components:
-            class_name = comp.__class__.__name__
-            if class_name == 'VerbCommand':
-                for field_sel in comp.fields:
-                    fields.append(field_sel.name)
-            elif class_name == 'WhereClause' and not comp.is_total:
-                where_clauses.append(self.emit_expression(comp.condition))
+        aggregating_verbs = ['SUM', 'COUNT']
+        is_aggregating = False
 
-        if not fields:
-            fields = ['*']
+        # Sort commands (BY, ACROSS)
+        sort_commands = [c for c in instr.components if c.__class__.__name__ == 'SortCommand']
+        for sc in sort_commands:
+            field_name = sc.field.name
+            direction = "DESC" if sc.options.get("order") == "HIGHEST" else "ASC"
 
-        field_str = ", ".join(fields)
-        sql = f"/* {instr.filename} */\nSELECT {field_str} FROM {table_name}"
+            # Use alias if present in FieldSelection
+            display_name = field_name
+            if sc.field.alias:
+                display_name = f"{field_name} AS \"{sc.field.alias}\""
+
+            if not sc.noprint:
+                select_fields.append(display_name)
+
+            group_by_fields.append(field_name)
+            order_by_phrases.append(f"{field_name} {direction}")
+
+        # Verbs and Fields
+        verb_commands = [c for c in instr.components if c.__class__.__name__ == 'VerbCommand']
+        for vc in verb_commands:
+            if vc.verb in aggregating_verbs:
+                is_aggregating = True
+
+            for field_sel in vc.fields:
+                if field_sel.name == '*':
+                    select_fields.append('*')
+                    continue
+
+                sql_expr = field_sel.name
+
+                # Prefix operators
+                prefix = field_sel.prefix_operators[0] if field_sel.prefix_operators else None
+                if prefix:
+                    prefix_map = {
+                        'AVE': 'AVG',
+                        'MIN': 'MIN',
+                        'MAX': 'MAX',
+                        'SUM': 'SUM',
+                        'CNT': 'COUNT',
+                        'TOT': 'SUM'
+                    }
+                    agg_func = prefix_map.get(prefix)
+                    if agg_func:
+                        sql_expr = f"{agg_func}({sql_expr})"
+                elif vc.verb == 'SUM':
+                    sql_expr = f"SUM({sql_expr})"
+                elif vc.verb == 'COUNT':
+                    sql_expr = f"COUNT({sql_expr})"
+
+                if field_sel.alias:
+                    sql_expr = f"{sql_expr} AS \"{field_sel.alias}\""
+
+                select_fields.append(sql_expr)
+
+        # WHERE
+        where_clauses = [self.emit_expression(c.condition) for c in instr.components
+                         if c.__class__.__name__ == 'WhereClause' and not c.is_total]
+
+        if not select_fields:
+            select_fields = ['*']
+
+        sql = f"/* {instr.filename} */\nSELECT {', '.join(select_fields)} FROM {table_name}"
+
         if where_clauses:
             sql += "\nWHERE " + " AND ".join(where_clauses)
+
+        if is_aggregating and group_by_fields:
+            sql += "\nGROUP BY " + ", ".join(group_by_fields)
+
+        if order_by_phrases:
+            sql += "\nORDER BY " + ", ".join(order_by_phrases)
+
         sql += ";"
         return sql
 

--- a/test/test_emitter.py
+++ b/test/test_emitter.py
@@ -233,5 +233,34 @@ class TestEmitter(unittest.TestCase):
         self.assertIn("AND (v_FIELD3 IN ('A', 'B'))", sql)
         self.assertIn("AND (v_FIELD4 IS NULL)", sql)
 
+    def test_emit_instruction_report_advanced(self):
+        emitter = PostgresEmitter()
+
+        # BY REGION
+        s1 = asg.SortCommand(sort_type="BY", field=asg.FieldSelection(name="REGION"))
+        # BY HIGHEST DATE
+        s2 = asg.SortCommand(sort_type="BY", field=asg.FieldSelection(name="DATE"), options={"order": "HIGHEST"})
+        # BY DEPT NOPRINT
+        s3 = asg.SortCommand(sort_type="BY", field=asg.FieldSelection(name="DEPT"), noprint=True)
+
+        # SUM SALES AS 'Total Sales'
+        f1 = asg.FieldSelection(name="SALES", alias="Total Sales")
+        # AVE.COST
+        f2 = asg.FieldSelection(name="COST", prefix_operators=["AVE"])
+        verb = asg.VerbCommand(verb="SUM", fields=[f1, f2])
+
+        instr = ir.Report(filename="SALES_DATA", components=[s1, s2, s3, verb])
+
+        sql = emitter.emit_instruction(instr)
+
+        # SELECT should include non-noprint sort fields and verb fields
+        # Note: sort fields come first in my implementation
+        self.assertIn("SELECT REGION, DATE, SUM(SALES) AS \"Total Sales\", AVG(COST)", sql)
+        self.assertIn("FROM SALES_DATA", sql)
+        # GROUP BY should include all sort fields
+        self.assertIn("GROUP BY REGION, DATE, DEPT", sql)
+        # ORDER BY
+        self.assertIn("ORDER BY REGION ASC, DATE DESC, DEPT ASC", sql)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change implements three key features in the SQL emission logic (`src/emitter.py`):

1. **Sorting (`ORDER BY`)**: Properly translates `BY` and `ACROSS` sort commands into SQL `ORDER BY` clauses, including support for descending order (`HIGHEST`) and the `NOPRINT` option.
2. **Grouping (`GROUP BY`)**: Automatically generates a `GROUP BY` clause when aggregating verbs (like `SUM` or `COUNT`) are used, including all sort fields as grouping keys.
3. **Aggregations**:
   - Maps aggregating verbs (`SUM`, `COUNT`) to their SQL counterparts.
   - Implements support for prefix operators (e.g., `AVE.`, `MIN.`, `MAX.`, `SUM.`, `CNT.`, `TOT.`) and maps them to standard SQL aggregate functions.
   - Supports field aliasing in the `SELECT` clause for both sort fields and verb fields.

The `MIGRATION_ROADMAP.md` has been updated to mark tasks 4.3.1.4, 4.3.1.5, and 4.3.1.7 as completed. Verification was performed using a new comprehensive test case in `test/test_emitter.py` and running the full project test suite.

Fixes #168

---
*PR created automatically by Jules for task [9721608209162946519](https://jules.google.com/task/9721608209162946519) started by @chatelao*