### PR TITLE
Implement Virtual Field Lifting and COMPUTE support

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -123,7 +123,13 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
   - [ ] 3.4.3 Projection Pruning: Identify unused fields.
   - [ ] 3.4.4 Aggregation Lifting: Identify and lift aggregations (SUM, AVG) to SQL.
   - [ ] 3.4.5 Virtual Field Lifting: Move DEFINE calculations to SQL.
+    - [ ] 3.4.5.1 Expression Tracking: Track virtual fields defined via `ir.Define`.
+    - [ ] 3.4.5.2 Selection Substitution: Inline virtual field expressions into `SELECT` statements.
+    - [ ] 3.4.5.3 Predicate Substitution: Inline virtual field expressions into `WHERE` clauses.
   - [ ] 3.4.6 Join Lifting: Translate JOIN commands to SQL JOINs.
+    - [ ] 3.4.6.1 Join Context Management: Maintain a mapping of joined tables and their join conditions.
+    - [ ] 3.4.6.2 SQL JOIN Generation: Emit `JOIN` clauses in the generated SQL queries.
+    - [ ] 3.4.6.3 Field Qualification: Ensure fields are correctly qualified with table names in multi-table queries.
 
 ## Phase 4: Backend Emission (Jinja2)
 Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
@@ -153,6 +159,7 @@ Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
     - [x] 4.3.1.5 Aggregations: Mapping prefix operators (SUM., AVG., etc.) to SQL aggregate functions. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.6 Post-Aggregation Filtering: Mapping WHERE TOTAL to SQL `HAVING`. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.7 Sorting: Mapping sort options to SQL `ORDER BY`. (Implemented in `src/emitter.py`)
+    - [ ] 4.3.1.8 Calculated Values: Mapping COMPUTE command to SQL expressions.
   - [ ] 4.3.2 Data Source Mapping: Resolve TABLE FILE references to database tables/views.
 
 ## Phase 5: Verification and Parity

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -19,6 +19,7 @@ class PostgresEmitter:
             lstrip_blocks=True
         )
         self.metadata_registry = metadata_registry
+        self.virtual_fields = {} # filename -> {field_name: asg.Expression}
 
     def render(self, template_name, **kwargs):
         """
@@ -162,7 +163,7 @@ class PostgresEmitter:
         elif class_name == 'IsMissingExpression':
             self._discover_vars_in_expr(node.expression, variables)
 
-    def emit_expression(self, expr):
+    def emit_expression(self, expr, in_query=False, virtual_fields=None):
         """
         Translates ASG expression nodes to PostgreSQL SQL strings.
         """
@@ -183,11 +184,16 @@ class PostgresEmitter:
         elif class_name == 'Identifier':
             # Fields in SQL are usually handled in the context of a query,
             # but for expressions in procedural logic they might be variables.
+            if in_query:
+                if virtual_fields and expr.name in virtual_fields:
+                    # Recursively emit the virtual field expression
+                    return self.emit_expression(virtual_fields[expr.name], in_query=True, virtual_fields=virtual_fields)
+                return expr.name
             return self._sanitize_name(expr.name)
 
         elif class_name == 'BinaryOperation':
-            left = self.emit_expression(expr.left)
-            right = self.emit_expression(expr.right)
+            left = self.emit_expression(expr.left, in_query=in_query, virtual_fields=virtual_fields)
+            right = self.emit_expression(expr.right, in_query=in_query, virtual_fields=virtual_fields)
             op = expr.operator.upper()
 
             # Map WebFOCUS operators to SQL
@@ -206,7 +212,7 @@ class PostgresEmitter:
             return f"({left} {sql_op} {right})"
 
         elif class_name == 'UnaryOperation':
-            operand = self.emit_expression(expr.operand)
+            operand = self.emit_expression(expr.operand, in_query=in_query, virtual_fields=virtual_fields)
             op = expr.operator.upper()
             op_mapping = {
                 'NOT': 'NOT ',
@@ -215,32 +221,32 @@ class PostgresEmitter:
             return f"{sql_op}({operand})"
 
         elif class_name == 'FunctionCall':
-            args = [self.emit_expression(arg) for arg in expr.arguments]
+            args = [self.emit_expression(arg, in_query=in_query, virtual_fields=virtual_fields) for arg in expr.arguments]
             return f"{expr.function_name}({', '.join(args)})"
 
         elif class_name == 'IfExpression':
-            cond = self.emit_expression(expr.condition)
-            then_e = self.emit_expression(expr.then_expr)
-            else_e = self.emit_expression(expr.else_expr)
+            cond = self.emit_expression(expr.condition, in_query=in_query, virtual_fields=virtual_fields)
+            then_e = self.emit_expression(expr.then_expr, in_query=in_query, virtual_fields=virtual_fields)
+            else_e = self.emit_expression(expr.else_expr, in_query=in_query, virtual_fields=virtual_fields)
             return f"(CASE WHEN {cond} THEN {then_e} ELSE {else_e} END)"
 
         elif class_name == 'BetweenExpression':
-            expr_val = self.emit_expression(expr.expression)
-            lower = self.emit_expression(expr.lower)
-            upper = self.emit_expression(expr.upper)
+            expr_val = self.emit_expression(expr.expression, in_query=in_query, virtual_fields=virtual_fields)
+            lower = self.emit_expression(expr.lower, in_query=in_query, virtual_fields=virtual_fields)
+            upper = self.emit_expression(expr.upper, in_query=in_query, virtual_fields=virtual_fields)
             return f"({expr_val} BETWEEN {lower} AND {upper})"
 
         elif class_name == 'InExpression':
-            expr_val = self.emit_expression(expr.expression)
+            expr_val = self.emit_expression(expr.expression, in_query=in_query, virtual_fields=virtual_fields)
             if hasattr(expr, 'filename') and expr.filename:
                 table_name = self._resolve_table_name(expr.filename)
                 return f"({expr_val} IN (SELECT * FROM {table_name}))"
             else:
-                values = [self.emit_expression(val) for val in expr.values]
+                values = [self.emit_expression(val, in_query=in_query, virtual_fields=virtual_fields) for val in expr.values]
                 return f"({expr_val} IN ({', '.join(values)}))"
 
         elif class_name == 'IsMissingExpression':
-            expr_val = self.emit_expression(expr.expression)
+            expr_val = self.emit_expression(expr.expression, in_query=in_query, virtual_fields=virtual_fields)
             op = "IS NOT NULL" if expr.inverted else "IS NULL"
             return f"({expr_val} {op})"
 
@@ -313,13 +319,32 @@ class PostgresEmitter:
         elif class_name == 'Report':
             return self._emit_report(instr)
 
+        elif class_name == 'Call':
+            args = [self.emit_expression(arg) for arg in instr.arguments]
+            return f"/* CALL {instr.target}({', '.join(args)}) */"
+
+        elif class_name == 'SetEnv':
+            return f"/* SET {instr.parameter} = {instr.value} */"
+
+        elif class_name == 'Define':
+            # Store virtual fields for relational lifting
+            if instr.filename not in self.virtual_fields:
+                self.virtual_fields[instr.filename] = {}
+            for assignment in instr.assignments:
+                self.virtual_fields[instr.filename][assignment.name] = assignment.expression
+            return f"/* DEFINE FILE {instr.filename} ... */"
+
         return f"/* Unsupported instruction: {class_name} */"
 
     def _emit_report(self, instr):
         """
         Translates ir.Report instruction into a SQL SELECT statement.
         """
-        table_name = self._resolve_table_name(instr.filename)
+        filename = instr.filename
+        table_name = self._resolve_table_name(filename)
+
+        # Get virtual fields for this file
+        file_virtual_fields = self.virtual_fields.get(filename, {})
         select_fields = []
         where_clauses = []
         group_by_fields = []
@@ -332,18 +357,25 @@ class PostgresEmitter:
         sort_commands = [c for c in instr.components if c.__class__.__name__ == 'SortCommand']
         for sc in sort_commands:
             field_name = sc.field.name
+            sql_field_expr = field_name
+            if field_name in file_virtual_fields:
+                 sql_field_expr = self.emit_expression(file_virtual_fields[field_name], in_query=True, virtual_fields=file_virtual_fields)
+
             direction = "DESC" if sc.options.get("order") == "HIGHEST" else "ASC"
 
             # Use alias if present in FieldSelection
-            display_name = field_name
+            display_name = sql_field_expr
             if sc.field.alias:
-                display_name = f"{field_name} AS \"{sc.field.alias}\""
+                display_name = f"{sql_field_expr} AS \"{sc.field.alias}\""
+            elif field_name in file_virtual_fields:
+                # If it's a virtual field, use its name as alias for the expression
+                display_name = f"{sql_field_expr} AS \"{field_name}\""
 
             if not sc.noprint:
                 select_fields.append(display_name)
 
-            group_by_fields.append(field_name)
-            order_by_phrases.append(f"{field_name} {direction}")
+            group_by_fields.append(sql_field_expr)
+            order_by_phrases.append(f"{sql_field_expr} {direction}")
 
         # Verbs and Fields
         verb_commands = [c for c in instr.components if c.__class__.__name__ == 'VerbCommand']
@@ -356,7 +388,13 @@ class PostgresEmitter:
                     select_fields.append('*')
                     continue
 
-                sql_expr = field_sel.name
+                field_name = field_sel.name
+                sql_expr = field_name
+
+                # Relational Lifting: Virtual Field Substitution
+                is_virtual = field_name in file_virtual_fields
+                if is_virtual:
+                    sql_expr = self.emit_expression(file_virtual_fields[field_name], in_query=True, virtual_fields=file_virtual_fields)
 
                 # Prefix operators
                 prefix = field_sel.prefix_operators[0] if field_sel.prefix_operators else None
@@ -379,13 +417,24 @@ class PostgresEmitter:
 
                 if field_sel.alias:
                     sql_expr = f"{sql_expr} AS \"{field_sel.alias}\""
+                elif is_virtual:
+                    # If it's a virtual field, use its name as alias for the expression
+                    sql_expr = f"{sql_expr} AS \"{field_name}\""
 
                 select_fields.append(sql_expr)
 
+        # COMPUTE commands
+        compute_commands = [c for c in instr.components if c.__class__.__name__ == 'ComputeCommand']
+        for cc in compute_commands:
+            sql_expr = self.emit_expression(cc.expression, in_query=True, virtual_fields=file_virtual_fields)
+            if cc.name:
+                sql_expr = f"{sql_expr} AS \"{cc.name}\""
+            select_fields.append(sql_expr)
+
         # WHERE and HAVING
-        where_clauses = [self.emit_expression(c.condition) for c in instr.components
+        where_clauses = [self.emit_expression(c.condition, in_query=True, virtual_fields=file_virtual_fields) for c in instr.components
                          if c.__class__.__name__ == 'WhereClause' and not c.is_total]
-        having_clauses = [self.emit_expression(c.condition) for c in instr.components
+        having_clauses = [self.emit_expression(c.condition, in_query=True, virtual_fields=file_virtual_fields) for c in instr.components
                           if c.__class__.__name__ == 'WhereClause' and c.is_total]
 
         if not select_fields:

--- a/test/test_emitter.py
+++ b/test/test_emitter.py
@@ -228,10 +228,10 @@ class TestEmitter(unittest.TestCase):
 
         sql = emitter.emit_instruction(instr)
 
-        self.assertIn("WHERE (v_FIELD1 > 10)", sql)
-        self.assertIn("AND (v_FIELD2 BETWEEN 1 AND 100)", sql)
-        self.assertIn("AND (v_FIELD3 IN ('A', 'B'))", sql)
-        self.assertIn("AND (v_FIELD4 IS NULL)", sql)
+        self.assertIn("WHERE (FIELD1 > 10)", sql)
+        self.assertIn("AND (FIELD2 BETWEEN 1 AND 100)", sql)
+        self.assertIn("AND (FIELD3 IN ('A', 'B'))", sql)
+        self.assertIn("AND (FIELD4 IS NULL)", sql)
 
     def test_emit_instruction_report_advanced(self):
         emitter = PostgresEmitter()
@@ -279,7 +279,68 @@ class TestEmitter(unittest.TestCase):
 
         self.assertIn("SELECT REGION, SUM(SALES)", sql)
         self.assertIn("GROUP BY REGION", sql)
-        self.assertIn("HAVING (v_SALES > 1000)", sql)
+        self.assertIn("HAVING (SALES > 1000)", sql)
+
+    def test_emit_instruction_report_with_compute(self):
+        emitter = PostgresEmitter()
+        verb = asg.VerbCommand(verb="SUM", fields=[asg.FieldSelection(name="SALES")])
+        compute = asg.ComputeCommand(
+            name="RATIO",
+            expression=asg.BinaryOperation(asg.Identifier("SALES"), "/", asg.Literal(1000))
+        )
+
+        instr = ir.Report(filename="SALES_DATA", components=[verb, compute])
+
+        sql = emitter.emit_instruction(instr)
+
+        self.assertIn("SELECT SUM(SALES), (SALES / 1000) AS \"RATIO\"", sql)
+
+    def test_emit_instruction_define_and_lift(self):
+        emitter = PostgresEmitter()
+
+        # DEFINE FILE SALES_DATA
+        #   BONUS = SALES * 0.1;
+        # END
+        define = ir.Define(filename="SALES_DATA", assignments=[
+            asg.DefineAssignment(name="BONUS", expression=asg.BinaryOperation(asg.Identifier("SALES"), "*", asg.Literal(0.1)))
+        ])
+        emitter.emit_instruction(define)
+
+        # TABLE FILE SALES_DATA
+        #   SUM SALES BONUS
+        # END
+        verb = asg.VerbCommand(verb="SUM", fields=[
+            asg.FieldSelection(name="SALES"),
+            asg.FieldSelection(name="BONUS")
+        ])
+        report = ir.Report(filename="SALES_DATA", components=[verb])
+
+        sql = emitter.emit_instruction(report)
+
+        self.assertIn("SELECT SUM(SALES), SUM((SALES * 0.1)) AS \"BONUS\"", sql)
+
+    def test_emit_instruction_define_recursive_lifting(self):
+        emitter = PostgresEmitter()
+
+        # DEFINE FILE SALES_DATA
+        #   BONUS = SALES * 0.1;
+        #   TOTAL_COMP = SALARY + BONUS;
+        # END
+        define = ir.Define(filename="SALES_DATA", assignments=[
+            asg.DefineAssignment(name="BONUS", expression=asg.BinaryOperation(asg.Identifier("SALES"), "*", asg.Literal(0.1))),
+            asg.DefineAssignment(name="TOTAL_COMP", expression=asg.BinaryOperation(asg.Identifier("SALARY"), "+", asg.Identifier("BONUS")))
+        ])
+        emitter.emit_instruction(define)
+
+        # TABLE FILE SALES_DATA
+        #   PRINT TOTAL_COMP
+        # END
+        verb = asg.VerbCommand(verb="PRINT", fields=[asg.FieldSelection(name="TOTAL_COMP")])
+        report = ir.Report(filename="SALES_DATA", components=[verb])
+
+        sql = emitter.emit_instruction(report)
+
+        self.assertIn("SELECT (SALARY + (SALES * 0.1)) AS \"TOTAL_COMP\"", sql)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change implements the first steps of relational lifting by supporting the substitution of virtual fields (defined via DEFINE FILE) into SQL queries. It also adds support for the COMPUTE command within report requests and provides basic emission for Call, SetEnv, and Define instructions. Additionally, the MIGRATION_ROADMAP.md has been updated with more granular sub-tasks for Phase 3.4 and 4.3.

Fixes #173

---
*PR created automatically by Jules for task [3887876492845871315](https://jules.google.com/task/3887876492845871315) started by @chatelao*