### PR TITLE
Implement COMPUTE Support and Granular Roadmap Breakdown

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -123,7 +123,11 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
   - [ ] 3.4.3 Projection Pruning: Identify unused fields.
   - [ ] 3.4.4 Aggregation Lifting: Identify and lift aggregations (SUM, AVG) to SQL.
   - [ ] 3.4.5 Virtual Field Lifting: Move DEFINE calculations to SQL.
+    - [ ] 3.4.5.1 Define Tracking: Track active `ir.Define` assignments in the emitter.
+    - [ ] 3.4.5.2 Expression Substitution: Substitute defined fields in SQL queries.
   - [ ] 3.4.6 Join Lifting: Translate JOIN commands to SQL JOINs.
+    - [ ] 3.4.6.1 Join Tracking: Track active `JOIN` commands.
+    - [ ] 3.4.6.2 Multi-table SQL: Generate SQL with multiple tables and JOIN clauses.
 
 ## Phase 4: Backend Emission (Jinja2)
 Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
@@ -153,7 +157,8 @@ Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
     - [x] 4.3.1.5 Aggregations: Mapping prefix operators (SUM., AVG., etc.) to SQL aggregate functions. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.6 Post-Aggregation Filtering: Mapping WHERE TOTAL to SQL `HAVING`. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.7 Sorting: Mapping sort options to SQL `ORDER BY`. (Implemented in `src/emitter.py`)
-  - [ ] 4.3.2 Data Source Mapping: Resolve TABLE FILE references to database tables/views.
+    - [ ] 4.3.1.8 Calculated Values/COMPUTE: Mapping COMPUTE commands to SQL SELECT expressions.
+  - [x] 4.3.2 Data Source Mapping: Resolve TABLE FILE references to database tables/views. (Implemented in `src/emitter.py`)
 
 ## Phase 5: Verification and Parity
 Ensure the new system produces correct results and maintains parity with the legacy parser.
@@ -162,6 +167,13 @@ Ensure the new system produces correct results and maintains parity with the leg
   - [ ] 5.1.1 Frontend Parity: Run the existing test suite against the new ANTLR4-based frontend.
   - [ ] 5.1.2 End-to-End Tests: Verify PL/pgSQL output for a subset of core features.
   - [ ] 5.1.3 Grammar Coverage: Ensure all core EBNF features are implemented and tested.
+    - [ ] 5.1.3.1 TABLE FILE: PRINT, SUM, COUNT, LIST, WRITE, ADD.
+    - [ ] 5.1.3.2 TABLE FILE: BY, ACROSS with options.
+    - [ ] 5.1.3.3 TABLE FILE: WHERE, WHERE TOTAL.
+    - [ ] 5.1.3.4 TABLE FILE: COMPUTE.
+    - [ ] 5.1.3.5 Environment: JOIN, JOIN CLEAR.
+    - [ ] 5.1.3.6 Environment: DEFINE FILE.
+    - [ ] 5.1.3.7 DM: -SET, -IF, -GOTO, -REPEAT.
   - [ ] 5.1.4 Semantic Parity: Verify that ASG and IR transformations preserve source semantics.
 - [ ] **5.2 Sample Validation:**
   - [ ] 5.2.1 Standard Samples: Validate transpiler output against samples in `test/samples/`.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -96,6 +96,10 @@ class PostgresEmitter:
         """
         Recursively discovers variables in instructions and ASG nodes.
         """
+        if isinstance(node, (asg.ComputeCommand, asg.DefineAssignment)):
+             self._discover_vars_in_expr(node.expression, variables)
+             return
+
         if node is None:
             return
 
@@ -162,7 +166,7 @@ class PostgresEmitter:
         elif class_name == 'IsMissingExpression':
             self._discover_vars_in_expr(node.expression, variables)
 
-    def emit_expression(self, expr):
+    def emit_expression(self, expr, in_query=False):
         """
         Translates ASG expression nodes to PostgreSQL SQL strings.
         """
@@ -183,11 +187,13 @@ class PostgresEmitter:
         elif class_name == 'Identifier':
             # Fields in SQL are usually handled in the context of a query,
             # but for expressions in procedural logic they might be variables.
+            if in_query:
+                return expr.name
             return self._sanitize_name(expr.name)
 
         elif class_name == 'BinaryOperation':
-            left = self.emit_expression(expr.left)
-            right = self.emit_expression(expr.right)
+            left = self.emit_expression(expr.left, in_query=in_query)
+            right = self.emit_expression(expr.right, in_query=in_query)
             op = expr.operator.upper()
 
             # Map WebFOCUS operators to SQL
@@ -206,7 +212,7 @@ class PostgresEmitter:
             return f"({left} {sql_op} {right})"
 
         elif class_name == 'UnaryOperation':
-            operand = self.emit_expression(expr.operand)
+            operand = self.emit_expression(expr.operand, in_query=in_query)
             op = expr.operator.upper()
             op_mapping = {
                 'NOT': 'NOT ',
@@ -215,32 +221,32 @@ class PostgresEmitter:
             return f"{sql_op}({operand})"
 
         elif class_name == 'FunctionCall':
-            args = [self.emit_expression(arg) for arg in expr.arguments]
+            args = [self.emit_expression(arg, in_query=in_query) for arg in expr.arguments]
             return f"{expr.function_name}({', '.join(args)})"
 
         elif class_name == 'IfExpression':
-            cond = self.emit_expression(expr.condition)
-            then_e = self.emit_expression(expr.then_expr)
-            else_e = self.emit_expression(expr.else_expr)
+            cond = self.emit_expression(expr.condition, in_query=in_query)
+            then_e = self.emit_expression(expr.then_expr, in_query=in_query)
+            else_e = self.emit_expression(expr.else_expr, in_query=in_query)
             return f"(CASE WHEN {cond} THEN {then_e} ELSE {else_e} END)"
 
         elif class_name == 'BetweenExpression':
-            expr_val = self.emit_expression(expr.expression)
-            lower = self.emit_expression(expr.lower)
-            upper = self.emit_expression(expr.upper)
+            expr_val = self.emit_expression(expr.expression, in_query=in_query)
+            lower = self.emit_expression(expr.lower, in_query=in_query)
+            upper = self.emit_expression(expr.upper, in_query=in_query)
             return f"({expr_val} BETWEEN {lower} AND {upper})"
 
         elif class_name == 'InExpression':
-            expr_val = self.emit_expression(expr.expression)
+            expr_val = self.emit_expression(expr.expression, in_query=in_query)
             if hasattr(expr, 'filename') and expr.filename:
                 table_name = self._resolve_table_name(expr.filename)
                 return f"({expr_val} IN (SELECT * FROM {table_name}))"
             else:
-                values = [self.emit_expression(val) for val in expr.values]
+                values = [self.emit_expression(val, in_query=in_query) for val in expr.values]
                 return f"({expr_val} IN ({', '.join(values)}))"
 
         elif class_name == 'IsMissingExpression':
-            expr_val = self.emit_expression(expr.expression)
+            expr_val = self.emit_expression(expr.expression, in_query=in_query)
             op = "IS NOT NULL" if expr.inverted else "IS NULL"
             return f"({expr_val} {op})"
 
@@ -382,10 +388,21 @@ class PostgresEmitter:
 
                 select_fields.append(sql_expr)
 
+        # COMPUTE commands
+        compute_commands = [c for c in instr.components if c.__class__.__name__ == 'ComputeCommand']
+        for cc in compute_commands:
+            sql_expr = self.emit_expression(cc.expression, in_query=True)
+            if cc.format:
+                 # WebFOCUS formats don't map directly to SQL CASTs easily, but we can emit a comment
+                 sql_expr = f"({sql_expr}) /* {cc.format} */"
+
+            display_name = f"{sql_expr} AS \"{cc.name}\""
+            select_fields.append(display_name)
+
         # WHERE and HAVING
-        where_clauses = [self.emit_expression(c.condition) for c in instr.components
+        where_clauses = [self.emit_expression(c.condition, in_query=True) for c in instr.components
                          if c.__class__.__name__ == 'WhereClause' and not c.is_total]
-        having_clauses = [self.emit_expression(c.condition) for c in instr.components
+        having_clauses = [self.emit_expression(c.condition, in_query=True) for c in instr.components
                           if c.__class__.__name__ == 'WhereClause' and c.is_total]
 
         if not select_fields:

--- a/test/test_emitter.py
+++ b/test/test_emitter.py
@@ -228,10 +228,10 @@ class TestEmitter(unittest.TestCase):
 
         sql = emitter.emit_instruction(instr)
 
-        self.assertIn("WHERE (v_FIELD1 > 10)", sql)
-        self.assertIn("AND (v_FIELD2 BETWEEN 1 AND 100)", sql)
-        self.assertIn("AND (v_FIELD3 IN ('A', 'B'))", sql)
-        self.assertIn("AND (v_FIELD4 IS NULL)", sql)
+        self.assertIn("WHERE (FIELD1 > 10)", sql)
+        self.assertIn("AND (FIELD2 BETWEEN 1 AND 100)", sql)
+        self.assertIn("AND (FIELD3 IN ('A', 'B'))", sql)
+        self.assertIn("AND (FIELD4 IS NULL)", sql)
 
     def test_emit_instruction_report_advanced(self):
         emitter = PostgresEmitter()
@@ -279,7 +279,28 @@ class TestEmitter(unittest.TestCase):
 
         self.assertIn("SELECT REGION, SUM(SALES)", sql)
         self.assertIn("GROUP BY REGION", sql)
-        self.assertIn("HAVING (v_SALES > 1000)", sql)
+        self.assertIn("HAVING (SALES > 1000)", sql)
+
+    def test_emit_instruction_report_compute(self):
+        emitter = PostgresEmitter()
+        verb = asg.VerbCommand(verb="SUM", fields=[asg.FieldSelection(name="SALES")])
+
+        # COMPUTE RATIO = SALES / TARGET
+        compute = asg.ComputeCommand(
+            name="RATIO",
+            expression=asg.BinaryOperation(asg.Identifier("SALES"), "/", asg.Identifier("TARGET")),
+            format="D12.2"
+        )
+
+        # WHERE RATIO GT 0.5
+        where = asg.WhereClause(condition=asg.BinaryOperation(asg.Identifier("RATIO"), "GT", asg.Literal(0.5)))
+
+        instr = ir.Report(filename="DATA", components=[verb, compute, where])
+        sql = emitter.emit_instruction(instr)
+
+        # Check that identifiers in expressions are not prefixed with v_
+        self.assertIn("((SALES / TARGET)) /* D12.2 */ AS \"RATIO\"", sql)
+        self.assertIn("WHERE (RATIO > 0.5)", sql)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR implements support for the `COMPUTE` command in the PostgreSQL emitter and refines the SQL emission logic to distinguish between procedural logic (using prefixed `v_` variables) and SQL query contexts (using raw database field identifiers). Additionally, the `MIGRATION_ROADMAP.md` has been updated to provide a more granular breakdown of remaining tasks in Phases 3 and 5, helping to track future progress more effectively. All tests, including new test cases for `COMPUTE`, have been verified to pass.

Fixes #176

---
*PR created automatically by Jules for task [6402832049246566858](https://jules.google.com/task/6402832049246566858) started by @chatelao*