### PR TITLE
Implement Join Context Management (Phase 3.4.6.1)

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -110,7 +110,7 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
   - [x] 3.2.3 Variable Renaming: Implement versioning for all variables. (Implemented in `src/ssa_transformer.py`)
     - [x] 3.2.3.1 Usage Analysis: Identify variable usages in expressions and instructions.
     - [x] 3.2.3.2 Renaming Algorithm: Implement recursive DFS over dominator tree for variable versioning.
-- [ ] **3.3 Optimization Passes:**
+- [x] **3.3 Optimization Passes:**
   - [x] 3.3.1 Constant Propagation: Substitute variables with literal values. (Implemented in `src/optimizer.py`)
   - [x] 3.3.2 Dead Code Elimination:
     - [x] 3.3.2.1 Reachability Analysis: Remove unreachable blocks from CFG.
@@ -122,12 +122,12 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
     - [ ] 3.4.2.2 Total Lifting: Move WHERE TOTAL conditions to SQL HAVING.
   - [ ] 3.4.3 Projection Pruning: Identify unused fields.
   - [ ] 3.4.4 Aggregation Lifting: Identify and lift aggregations (SUM, AVG) to SQL.
-  - [ ] 3.4.5 Virtual Field Lifting: Move DEFINE calculations to SQL.
-    - [ ] 3.4.5.1 Expression Tracking: Track virtual fields defined via `ir.Define`.
-    - [ ] 3.4.5.2 Selection Substitution: Inline virtual field expressions into `SELECT` statements.
-    - [ ] 3.4.5.3 Predicate Substitution: Inline virtual field expressions into `WHERE` clauses.
+  - [x] 3.4.5 Virtual Field Lifting: Move DEFINE calculations to SQL.
+    - [x] 3.4.5.1 Expression Tracking: Track virtual fields defined via `ir.Define`. (Implemented in `src/emitter.py`)
+    - [x] 3.4.5.2 Selection Substitution: Inline virtual field expressions into `SELECT` statements. (Implemented in `src/emitter.py`)
+    - [x] 3.4.5.3 Predicate Substitution: Inline virtual field expressions into `WHERE` clauses. (Implemented in `src/emitter.py`)
   - [ ] 3.4.6 Join Lifting: Translate JOIN commands to SQL JOINs.
-    - [ ] 3.4.6.1 Join Context Management: Maintain a mapping of joined tables and their join conditions.
+    - [x] 3.4.6.1 Join Context Management: Maintain a mapping of joined tables and their join conditions. (Implemented in `src/emitter.py`)
     - [ ] 3.4.6.2 SQL JOIN Generation: Emit `JOIN` clauses in the generated SQL queries.
     - [ ] 3.4.6.3 Field Qualification: Ensure fields are correctly qualified with table names in multi-table queries.
 
@@ -159,14 +159,14 @@ Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
     - [x] 4.3.1.5 Aggregations: Mapping prefix operators (SUM., AVG., etc.) to SQL aggregate functions. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.6 Post-Aggregation Filtering: Mapping WHERE TOTAL to SQL `HAVING`. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.7 Sorting: Mapping sort options to SQL `ORDER BY`. (Implemented in `src/emitter.py`)
-    - [ ] 4.3.1.8 Calculated Values: Mapping COMPUTE command to SQL expressions.
-  - [ ] 4.3.2 Data Source Mapping: Resolve TABLE FILE references to database tables/views.
+    - [x] 4.3.1.8 Calculated Values: Mapping COMPUTE command to SQL expressions. (Implemented in `src/emitter.py`)
+  - [x] 4.3.2 Data Source Mapping: Resolve TABLE FILE references to database tables/views. (Implemented in `src/emitter.py` via `MetadataRegistry`)
 
 ## Phase 5: Verification and Parity
 Ensure the new system produces correct results and maintains parity with the legacy parser.
 
 - [ ] **5.1 Regression Testing:**
-  - [ ] 5.1.1 Frontend Parity: Run the existing test suite against the new ANTLR4-based frontend.
+  - [x] 5.1.1 Frontend Parity: Run the existing test suite against the new ANTLR4-based frontend. (Verified via `test/test_antlr_wf_parser.py`)
   - [ ] 5.1.2 End-to-End Tests: Verify PL/pgSQL output for a subset of core features.
   - [ ] 5.1.3 Grammar Coverage: Ensure all core EBNF features are implemented and tested.
   - [ ] 5.1.4 Semantic Parity: Verify that ASG and IR transformations preserve source semantics.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -20,6 +20,7 @@ class PostgresEmitter:
         )
         self.metadata_registry = metadata_registry
         self.virtual_fields = {} # filename -> {field_name: asg.Expression}
+        self.active_joins = []
 
     def render(self, template_name, **kwargs):
         """
@@ -322,6 +323,14 @@ class PostgresEmitter:
         elif class_name == 'Call':
             args = [self.emit_expression(arg) for arg in instr.arguments]
             return f"/* CALL {instr.target}({', '.join(args)}) */"
+
+        elif class_name == 'Join':
+            self.active_joins.append(instr)
+            return f"/* JOIN {instr.left_file}.{instr.left_field} TO {instr.right_file}.{instr.right_field} */"
+
+        elif class_name == 'JoinClear':
+            self.active_joins = []
+            return "/* JOIN CLEAR * */"
 
         elif class_name == 'SetEnv':
             return f"/* SET {instr.parameter} = {instr.value} */"

--- a/src/ir.py
+++ b/src/ir.py
@@ -48,6 +48,23 @@ class SetEnv(Instruction):
     def __init__(self, parameter, value, **kwargs):
         super().__init__(parameter=parameter, value=value, **kwargs)
 
+class Join(Instruction):
+    """Represents a JOIN command."""
+    def __init__(self, left_file, left_field, right_file, right_field, join_as=None, outer=False, **kwargs):
+        super().__init__(
+            left_file=left_file,
+            left_field=left_field,
+            right_file=right_file,
+            right_field=right_field,
+            join_as=join_as,
+            outer=outer,
+            **kwargs
+        )
+
+class JoinClear(Instruction):
+    """Represents a JOIN CLEAR * command."""
+    pass
+
 class Define(Instruction):
     """Represents a set of virtual field definitions (DEFINE FILE)."""
     def __init__(self, filename, assignments, **kwargs):

--- a/src/ir_builder.py
+++ b/src/ir_builder.py
@@ -176,14 +176,20 @@ class IRBuilder:
             elif class_name == 'SetCommand':
                 self.current_block.add_instruction(ir.SetEnv(parameter=node.parameter, value=node.value))
             elif class_name == 'Join':
-                args = [node.left_file, node.left_field, node.right_file, node.right_field]
-                self.current_block.add_instruction(ir.Call(target='JOIN', arguments=args))
+                self.current_block.add_instruction(ir.Join(
+                    left_file=node.left_file,
+                    left_field=node.left_field,
+                    right_file=node.right_file,
+                    right_field=node.right_field,
+                    join_as=node.join_as,
+                    outer=node.outer
+                ))
             elif class_name == 'DefineFile':
                 self.current_block.add_instruction(ir.Define(filename=node.filename, assignments=node.assignments))
             elif class_name == 'ReportRequest':
                 self.current_block.add_instruction(ir.Report(filename=node.filename, components=node.components))
             elif class_name == 'JoinClear':
-                self.current_block.add_instruction(ir.Call(target='JOIN CLEAR'))
+                self.current_block.add_instruction(ir.JoinClear())
             elif class_name == 'RunDM':
                 self.current_block.add_instruction(ir.Call(target='-RUN'))
             elif class_name == 'ExitDM':

--- a/test/test_emitter.py
+++ b/test/test_emitter.py
@@ -342,5 +342,20 @@ class TestEmitter(unittest.TestCase):
 
         self.assertIn("SELECT (SALARY + (SALES * 0.1)) AS \"TOTAL_COMP\"", sql)
 
+    def test_emit_instruction_join_context(self):
+        emitter = PostgresEmitter()
+
+        join1 = ir.Join(left_file="F1", left_field="FL1", right_file="F2", right_field="FL2", join_as="J1", outer=False)
+        emitter.emit_instruction(join1)
+        self.assertEqual(len(emitter.active_joins), 1)
+        self.assertEqual(emitter.active_joins[0].join_as, "J1")
+
+        join2 = ir.Join(left_file="F1", left_field="FL1", right_file="F3", right_field="FL3", join_as="J2", outer=True)
+        emitter.emit_instruction(join2)
+        self.assertEqual(len(emitter.active_joins), 2)
+
+        emitter.emit_instruction(ir.JoinClear())
+        self.assertEqual(len(emitter.active_joins), 0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_ir_builder.py
+++ b/test/test_ir_builder.py
@@ -274,5 +274,24 @@ class TestIRBuilder(unittest.TestCase):
         self.assertIsInstance(myloop_label_block.instructions[0], Jump)
         self.assertEqual(myloop_label_block.instructions[0].target, "LOOP_HEADER_MYLOOP")
 
+    def test_join_instructions(self):
+        # JOIN F1.FL1 TO F2.FL2 AS J1
+        # JOIN CLEAR *
+        asg_nodes = [
+            Join(left_file="F1", left_field="FL1", right_file="F2", right_field="FL2", join_as="J1", outer=True),
+            JoinClear()
+        ]
+
+        builder = IRBuilder()
+        cfg = builder.build(asg_nodes)
+
+        entry = cfg.blocks["ENTRY"]
+        self.assertEqual(len(entry.instructions), 2)
+        self.assertIsInstance(entry.instructions[0], Join)
+        self.assertEqual(entry.instructions[0].left_file, "F1")
+        self.assertEqual(entry.instructions[0].join_as, "J1")
+        self.assertTrue(entry.instructions[0].outer)
+        self.assertIsInstance(entry.instructions[1], JoinClear)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This task implemented Phase 3.4.6.1 (Join Context Management) of the MIGRATION_ROADMAP.md.

Key changes include:
1.  **IR Enhancements**: Added `ir.Join` and `ir.JoinClear` classes to `src/ir.py` to better represent join-related operations in the Intermediate Representation, preserving metadata like join aliases and outer join flags.
2.  **IR Builder Update**: Modified `src/ir_builder.py` to correctly transform `asg.Join` and `asg.JoinClear` nodes into their respective new IR instructions.
3.  **Emitter Integration**: Updated `PostgresEmitter` in `src/emitter.py` to manage a list of `active_joins`. This infrastructure allows the emitter to keep track of the current join context, which is a prerequisite for generating multi-table SQL queries.
4.  **Roadmap Alignment**: Synchronized `MIGRATION_ROADMAP.md` with the current codebase status, marking several previously completed or verified tasks (Optimization Passes, Virtual Field Lifting, etc.) as done, and specifically marking 3.4.6.1 as complete.
5.  **Verification**: Added targeted tests in `test/test_ir_builder.py` and `test/test_emitter.py` to verify the new IR instructions and state management. The full test suite (176 tests) remains passing.

Fixes #178

---
*PR created automatically by Jules for task [14618155677695649688](https://jules.google.com/task/14618155677695649688) started by @chatelao*