### PR TITLE
Implement SQL JOIN Generation and Update Migration Roadmap

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -118,10 +118,10 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
 - [ ] **3.4 Relational Lifting:**
   - [ ] 3.4.1 Loop Analysis: Identify loops that iterate over data sources.
   - [ ] 3.4.2 Predicate Pushdown:
-    - [ ] 3.4.2.1 Filter Lifting: Move WHERE conditions to SQL.
-    - [ ] 3.4.2.2 Total Lifting: Move WHERE TOTAL conditions to SQL HAVING.
+    - [x] 3.4.2.1 Filter Lifting: Move WHERE conditions to SQL. (Implemented in `src/emitter.py`)
+    - [x] 3.4.2.2 Total Lifting: Move WHERE TOTAL conditions to SQL HAVING. (Implemented in `src/emitter.py`)
   - [ ] 3.4.3 Projection Pruning: Identify unused fields.
-  - [ ] 3.4.4 Aggregation Lifting: Identify and lift aggregations (SUM, AVG) to SQL.
+  - [x] 3.4.4 Aggregation Lifting: Identify and lift aggregations (SUM, AVG) to SQL. (Implemented in `src/emitter.py`)
   - [x] 3.4.5 Virtual Field Lifting: Move DEFINE calculations to SQL.
     - [x] 3.4.5.1 Expression Tracking: Track virtual fields defined via `ir.Define`. (Implemented in `src/emitter.py`)
     - [x] 3.4.5.2 Selection Substitution: Inline virtual field expressions into `SELECT` statements. (Implemented in `src/emitter.py`)
@@ -150,8 +150,8 @@ Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
   - [x] 4.2.4 Control Flow (State Machine):
     - [x] 4.2.4.1 Block Dispatcher: Implement a `WHILE` loop and `CASE` statement to navigate basic blocks. (Implemented in `src/emitter.py`)
     - [x] 4.2.4.2 Jump/Branch Translation: Update the next block state variable based on `ir.Jump` and `ir.Branch`. (Implemented in `src/emitter.py`)
-- [ ] **4.3 Relational Request Emission:**
-  - [ ] 4.3.1 SQL Query Generation: Transform `ir.Report` nodes to optimized PostgreSQL queries.
+- [x] **4.3 Relational Request Emission:**
+  - [x] 4.3.1 SQL Query Generation: Transform `ir.Report` nodes to optimized PostgreSQL queries.
     - [x] 4.3.1.1 Projection: Mapping PRINT/SUM and field selections. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.2 Data Sources: Mapping filenames to SQL tables (using `MetadataRegistry`). (Implemented in `src/emitter.py`)
     - [x] 4.3.1.3 Filtering: Mapping WHERE clauses to SQL `WHERE`. (Implemented in `src/emitter.py`)
@@ -169,6 +169,12 @@ Ensure the new system produces correct results and maintains parity with the leg
   - [x] 5.1.1 Frontend Parity: Run the existing test suite against the new ANTLR4-based frontend. (Verified via `test/test_antlr_wf_parser.py`)
   - [ ] 5.1.2 End-to-End Tests: Verify PL/pgSQL output for a subset of core features.
   - [ ] 5.1.3 Grammar Coverage: Ensure all core EBNF features are implemented and tested.
+    - [ ] 5.1.3.1 Support `ALL` keyword in `JOIN` commands.
+    - [ ] 5.1.3.2 Support hyphenated `SET` keywords (e.g., `ONLINE-FMT`).
+    - [ ] 5.1.3.3 Support `COMPOUND LAYOUT` structure.
+    - [ ] 5.1.3.4 Support inline format specifications (e.g., `SUM FIELD/I08M`).
+    - [ ] 5.1.3.5 Support `RECAP` command in report requests.
+    - [ ] 5.1.3.6 Support `ACROSS-TOTAL` for cross-tabulation summaries.
   - [ ] 5.1.4 Semantic Parity: Verify that ASG and IR transformations preserve source semantics.
 - [ ] **5.2 Sample Validation:**
   - [ ] 5.2.1 Standard Samples: Validate transpiler output against samples in `test/samples/`.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -164,7 +164,7 @@ class PostgresEmitter:
         elif class_name == 'IsMissingExpression':
             self._discover_vars_in_expr(node.expression, variables)
 
-    def emit_expression(self, expr, in_query=False, virtual_fields=None):
+    def emit_expression(self, expr, in_query=False, virtual_fields=None, qualifier=None):
         """
         Translates ASG expression nodes to PostgreSQL SQL strings.
         """
@@ -188,13 +188,15 @@ class PostgresEmitter:
             if in_query:
                 if virtual_fields and expr.name in virtual_fields:
                     # Recursively emit the virtual field expression
-                    return self.emit_expression(virtual_fields[expr.name], in_query=True, virtual_fields=virtual_fields)
+                    return self.emit_expression(virtual_fields[expr.name], in_query=True, virtual_fields=virtual_fields, qualifier=qualifier)
+                if qualifier:
+                    return qualifier(expr.name)
                 return expr.name
             return self._sanitize_name(expr.name)
 
         elif class_name == 'BinaryOperation':
-            left = self.emit_expression(expr.left, in_query=in_query, virtual_fields=virtual_fields)
-            right = self.emit_expression(expr.right, in_query=in_query, virtual_fields=virtual_fields)
+            left = self.emit_expression(expr.left, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
+            right = self.emit_expression(expr.right, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
             op = expr.operator.upper()
 
             # Map WebFOCUS operators to SQL
@@ -213,7 +215,7 @@ class PostgresEmitter:
             return f"({left} {sql_op} {right})"
 
         elif class_name == 'UnaryOperation':
-            operand = self.emit_expression(expr.operand, in_query=in_query, virtual_fields=virtual_fields)
+            operand = self.emit_expression(expr.operand, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
             op = expr.operator.upper()
             op_mapping = {
                 'NOT': 'NOT ',
@@ -222,32 +224,32 @@ class PostgresEmitter:
             return f"{sql_op}({operand})"
 
         elif class_name == 'FunctionCall':
-            args = [self.emit_expression(arg, in_query=in_query, virtual_fields=virtual_fields) for arg in expr.arguments]
+            args = [self.emit_expression(arg, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier) for arg in expr.arguments]
             return f"{expr.function_name}({', '.join(args)})"
 
         elif class_name == 'IfExpression':
-            cond = self.emit_expression(expr.condition, in_query=in_query, virtual_fields=virtual_fields)
-            then_e = self.emit_expression(expr.then_expr, in_query=in_query, virtual_fields=virtual_fields)
-            else_e = self.emit_expression(expr.else_expr, in_query=in_query, virtual_fields=virtual_fields)
+            cond = self.emit_expression(expr.condition, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
+            then_e = self.emit_expression(expr.then_expr, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
+            else_e = self.emit_expression(expr.else_expr, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
             return f"(CASE WHEN {cond} THEN {then_e} ELSE {else_e} END)"
 
         elif class_name == 'BetweenExpression':
-            expr_val = self.emit_expression(expr.expression, in_query=in_query, virtual_fields=virtual_fields)
-            lower = self.emit_expression(expr.lower, in_query=in_query, virtual_fields=virtual_fields)
-            upper = self.emit_expression(expr.upper, in_query=in_query, virtual_fields=virtual_fields)
+            expr_val = self.emit_expression(expr.expression, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
+            lower = self.emit_expression(expr.lower, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
+            upper = self.emit_expression(expr.upper, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
             return f"({expr_val} BETWEEN {lower} AND {upper})"
 
         elif class_name == 'InExpression':
-            expr_val = self.emit_expression(expr.expression, in_query=in_query, virtual_fields=virtual_fields)
+            expr_val = self.emit_expression(expr.expression, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
             if hasattr(expr, 'filename') and expr.filename:
                 table_name = self._resolve_table_name(expr.filename)
                 return f"({expr_val} IN (SELECT * FROM {table_name}))"
             else:
-                values = [self.emit_expression(val, in_query=in_query, virtual_fields=virtual_fields) for val in expr.values]
+                values = [self.emit_expression(val, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier) for val in expr.values]
                 return f"({expr_val} IN ({', '.join(values)}))"
 
         elif class_name == 'IsMissingExpression':
-            expr_val = self.emit_expression(expr.expression, in_query=in_query, virtual_fields=virtual_fields)
+            expr_val = self.emit_expression(expr.expression, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
             op = "IS NOT NULL" if expr.inverted else "IS NULL"
             return f"({expr_val} {op})"
 
@@ -351,9 +353,33 @@ class PostgresEmitter:
         """
         filename = instr.filename
         table_name = self._resolve_table_name(filename)
+        alias_map = {filename: table_name}
+
+        # Handle joins
+        join_clauses = []
+        # Local copy of virtual fields for this report, merged from joined files
+        # Map: field_name -> (expression, original_filename)
+        report_virtual_fields = {f: (e, filename) for f, e in self.virtual_fields.get(filename, {}).items()}
+
+        for join in instr.joins:
+            join_type = "LEFT OUTER JOIN" if join.outer else "JOIN"
+            right_table = self._resolve_table_name(join.right_file)
+            right_alias = join.join_as if join.join_as else right_table
+            alias_map[join.right_file] = right_alias
+
+            # Merge virtual fields from joined file
+            if join.right_file in self.virtual_fields:
+                for f, e in self.virtual_fields[join.right_file].items():
+                    report_virtual_fields[f] = (e, join.right_file)
+
+            # Resolve left field - might need qualification if multiple tables
+            left_table_alias = alias_map.get(join.left_file, join.left_file)
+            alias_part = f" {right_alias}" if right_alias != right_table else ""
+
+            join_clauses.append(f"{join_type} {right_table}{alias_part} ON {left_table_alias}.{join.left_field} = {right_alias}.{join.right_field}")
 
         # Get virtual fields for this file
-        file_virtual_fields = self.virtual_fields.get(filename, {})
+        file_virtual_fields = {f: e for f, (e, fn) in report_virtual_fields.items()}
         select_fields = []
         where_clauses = []
         group_by_fields = []
@@ -362,13 +388,38 @@ class PostgresEmitter:
         aggregating_verbs = ['SUM', 'COUNT']
         is_aggregating = False
 
+        # Helper to qualify field names if joins are present
+        def qualify_field(fname, source_fn=None):
+            if '.' in fname:
+                parts = fname.split('.')
+                # Qualify with alias if file name is known
+                if parts[0] in alias_map:
+                    return f"{alias_map[parts[0]]}.{parts[1]}"
+                return fname
+            if not instr.joins:
+                return fname
+
+            # If a source_fn is explicitly provided (e.g. from a virtual field context)
+            if source_fn:
+                source_alias = alias_map.get(source_fn, source_fn)
+                return f"{source_alias}.{fname}"
+
+            # If it's a virtual field, we don't qualify the name itself,
+            # but we will need to qualify its contents.
+            if fname in report_virtual_fields:
+                return fname
+
+            # For now, let's assume it belongs to the primary table if not found in virtual fields.
+            return f"{table_name}.{fname}"
+
         # Sort commands (BY, ACROSS)
         sort_commands = [c for c in instr.components if c.__class__.__name__ == 'SortCommand']
         for sc in sort_commands:
             field_name = sc.field.name
-            sql_field_expr = field_name
-            if field_name in file_virtual_fields:
-                 sql_field_expr = self.emit_expression(file_virtual_fields[field_name], in_query=True, virtual_fields=file_virtual_fields)
+            sql_field_expr = qualify_field(field_name)
+            if field_name in report_virtual_fields:
+                 expr, source_fn = report_virtual_fields[field_name]
+                 sql_field_expr = self.emit_expression(expr, in_query=True, virtual_fields=file_virtual_fields, qualifier=lambda f: qualify_field(f, source_fn))
 
             direction = "DESC" if sc.options.get("order") == "HIGHEST" else "ASC"
 
@@ -398,12 +449,13 @@ class PostgresEmitter:
                     continue
 
                 field_name = field_sel.name
-                sql_expr = field_name
+                sql_expr = qualify_field(field_name)
 
                 # Relational Lifting: Virtual Field Substitution
-                is_virtual = field_name in file_virtual_fields
+                is_virtual = field_name in report_virtual_fields
                 if is_virtual:
-                    sql_expr = self.emit_expression(file_virtual_fields[field_name], in_query=True, virtual_fields=file_virtual_fields)
+                    expr, source_fn = report_virtual_fields[field_name]
+                    sql_expr = self.emit_expression(expr, in_query=True, virtual_fields=file_virtual_fields, qualifier=lambda f: qualify_field(f, source_fn))
 
                 # Prefix operators
                 prefix = field_sel.prefix_operators[0] if field_sel.prefix_operators else None
@@ -435,21 +487,23 @@ class PostgresEmitter:
         # COMPUTE commands
         compute_commands = [c for c in instr.components if c.__class__.__name__ == 'ComputeCommand']
         for cc in compute_commands:
-            sql_expr = self.emit_expression(cc.expression, in_query=True, virtual_fields=file_virtual_fields)
+            sql_expr = self.emit_expression(cc.expression, in_query=True, virtual_fields=file_virtual_fields, qualifier=qualify_field)
             if cc.name:
                 sql_expr = f"{sql_expr} AS \"{cc.name}\""
             select_fields.append(sql_expr)
 
         # WHERE and HAVING
-        where_clauses = [self.emit_expression(c.condition, in_query=True, virtual_fields=file_virtual_fields) for c in instr.components
+        where_clauses = [self.emit_expression(c.condition, in_query=True, virtual_fields=file_virtual_fields, qualifier=qualify_field) for c in instr.components
                          if c.__class__.__name__ == 'WhereClause' and not c.is_total]
-        having_clauses = [self.emit_expression(c.condition, in_query=True, virtual_fields=file_virtual_fields) for c in instr.components
+        having_clauses = [self.emit_expression(c.condition, in_query=True, virtual_fields=file_virtual_fields, qualifier=qualify_field) for c in instr.components
                           if c.__class__.__name__ == 'WhereClause' and c.is_total]
 
         if not select_fields:
             select_fields = ['*']
 
         sql = f"/* {instr.filename} */\nSELECT {', '.join(select_fields)} FROM {table_name}"
+        if join_clauses:
+            sql += "\n" + "\n".join(join_clauses)
 
         if where_clauses:
             sql += "\nWHERE " + " AND ".join(where_clauses)

--- a/src/ir.py
+++ b/src/ir.py
@@ -72,8 +72,8 @@ class Define(Instruction):
 
 class Report(Instruction):
     """Represents a report request (TABLE FILE)."""
-    def __init__(self, filename, components, **kwargs):
-        super().__init__(filename=filename, components=components, **kwargs)
+    def __init__(self, filename, components, joins=None, **kwargs):
+        super().__init__(filename=filename, components=components, joins=joins or [], **kwargs)
 
 class BasicBlock(IRNode):
     """Represents a basic block: a linear sequence of instructions."""

--- a/src/ir_builder.py
+++ b/src/ir_builder.py
@@ -11,6 +11,7 @@ class IRBuilder:
         self.current_block = None
         self.labels = {} # label_name -> block_name
         self.active_loops = [] # stack of {label, header_block, after_block, repeat_node}
+        self.active_joins = []
 
     def _new_block(self, name=None):
         if not name:
@@ -176,20 +177,27 @@ class IRBuilder:
             elif class_name == 'SetCommand':
                 self.current_block.add_instruction(ir.SetEnv(parameter=node.parameter, value=node.value))
             elif class_name == 'Join':
-                self.current_block.add_instruction(ir.Join(
+                instr = ir.Join(
                     left_file=node.left_file,
                     left_field=node.left_field,
                     right_file=node.right_file,
                     right_field=node.right_field,
                     join_as=node.join_as,
                     outer=node.outer
-                ))
+                )
+                self.current_block.add_instruction(instr)
+                self.active_joins.append(instr)
             elif class_name == 'DefineFile':
                 self.current_block.add_instruction(ir.Define(filename=node.filename, assignments=node.assignments))
             elif class_name == 'ReportRequest':
-                self.current_block.add_instruction(ir.Report(filename=node.filename, components=node.components))
+                self.current_block.add_instruction(ir.Report(
+                    filename=node.filename,
+                    components=node.components,
+                    joins=list(self.active_joins)
+                ))
             elif class_name == 'JoinClear':
                 self.current_block.add_instruction(ir.JoinClear())
+                self.active_joins = []
             elif class_name == 'RunDM':
                 self.current_block.add_instruction(ir.Call(target='-RUN'))
             elif class_name == 'ExitDM':

--- a/test/test_emitter.py
+++ b/test/test_emitter.py
@@ -357,5 +357,82 @@ class TestEmitter(unittest.TestCase):
         emitter.emit_instruction(ir.JoinClear())
         self.assertEqual(len(emitter.active_joins), 0)
 
+    def test_emit_instruction_report_with_join(self):
+        emitter = PostgresEmitter()
+
+        # JOIN LEFT_FILE.FLD1 TO RIGHT_FILE.FLD2 AS J1
+        join = ir.Join(left_file="LEFT_FILE", left_field="FLD1", right_file="RIGHT_FILE", right_field="FLD2", join_as="J1")
+
+        # TABLE FILE LEFT_FILE
+        #   PRINT FLD1 RIGHT_FILE.FLD2
+        # END
+        verb = asg.VerbCommand(verb="PRINT", fields=[
+            asg.FieldSelection(name="FLD1"),
+            asg.FieldSelection(name="RIGHT_FILE.FLD2")
+        ])
+
+        report = ir.Report(filename="LEFT_FILE", components=[verb], joins=[join])
+
+        sql = emitter.emit_instruction(report)
+
+        self.assertIn("SELECT LEFT_FILE.FLD1, J1.FLD2", sql)
+        self.assertIn("FROM LEFT_FILE", sql)
+        self.assertIn("JOIN RIGHT_FILE J1 ON LEFT_FILE.FLD1 = J1.FLD2", sql)
+
+    def test_emit_instruction_report_with_outer_join(self):
+        emitter = PostgresEmitter()
+
+        # JOIN LEFT OUTER LEFT_FILE.FLD1 TO RIGHT_FILE.FLD2
+        join = ir.Join(left_file="LEFT_FILE", left_field="FLD1", right_file="RIGHT_FILE", right_field="FLD2", outer=True)
+
+        verb = asg.VerbCommand(verb="PRINT", fields=[asg.FieldSelection(name="FLD1")])
+        report = ir.Report(filename="LEFT_FILE", components=[verb], joins=[join])
+
+        sql = emitter.emit_instruction(report)
+
+        self.assertIn("LEFT OUTER JOIN RIGHT_FILE ON LEFT_FILE.FLD1 = RIGHT_FILE.FLD2", sql)
+
+    def test_emit_instruction_report_with_chained_joins(self):
+        emitter = PostgresEmitter()
+
+        # JOIN F1.A TO F2.B
+        # JOIN F2.C TO F3.D
+        j1 = ir.Join(left_file="F1", left_field="A", right_file="F2", right_field="B")
+        j2 = ir.Join(left_file="F2", left_field="C", right_file="F3", right_field="D")
+
+        verb = asg.VerbCommand(verb="PRINT", fields=[asg.FieldSelection(name="A")])
+        report = ir.Report(filename="F1", components=[verb], joins=[j1, j2])
+
+        sql = emitter.emit_instruction(report)
+
+        self.assertIn("JOIN F2 ON F1.A = F2.B", sql)
+        self.assertIn("JOIN F3 ON F2.C = F3.D", sql)
+
+    def test_emit_instruction_report_with_join_and_virtual_lifting(self):
+        emitter = PostgresEmitter()
+
+        # DEFINE FILE RIGHT_FILE
+        #   CALC = FLD2 * 2;
+        # END
+        define = ir.Define(filename="RIGHT_FILE", assignments=[
+            asg.DefineAssignment(name="CALC", expression=asg.BinaryOperation(asg.Identifier("FLD2"), "*", asg.Literal(2)))
+        ])
+        emitter.emit_instruction(define)
+
+        # JOIN LEFT_FILE.FLD1 TO RIGHT_FILE.FLD2
+        join = ir.Join(left_file="LEFT_FILE", left_field="FLD1", right_file="RIGHT_FILE", right_field="FLD2")
+
+        # TABLE FILE LEFT_FILE
+        #   PRINT CALC
+        # END
+        verb = asg.VerbCommand(verb="PRINT", fields=[asg.FieldSelection(name="CALC")])
+        report = ir.Report(filename="LEFT_FILE", components=[verb], joins=[join])
+
+        sql = emitter.emit_instruction(report)
+
+        # Should lift CALC from RIGHT_FILE and qualify FLD2
+        self.assertIn("(RIGHT_FILE.FLD2 * 2) AS \"CALC\"", sql)
+        self.assertIn("JOIN RIGHT_FILE ON LEFT_FILE.FLD1 = RIGHT_FILE.FLD2", sql)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR implements SQL JOIN generation in the transpiler's backend, completing several key items on the migration roadmap.

### Key Changes:
1.  **Roadmap Progress:** Updated `MIGRATION_ROADMAP.md` to mark Filter Lifting, Total Lifting, Aggregation Lifting, and SQL Query Generation as completed. Added specific sub-tasks for future grammar coverage work.
2.  **IR Enhancement:** Modified the `ir.Report` instruction to store a list of active joins, ensuring this context is preserved through the optimization passes to the emission phase.
3.  **IR Builder:** Updated `IRBuilder` to track `Join` and `JoinClear` instructions and automatically attach the current join state to each report request.
4.  **SQL Emission:**
    *   `PostgresEmitter` now generates appropriate `JOIN` or `LEFT OUTER JOIN` clauses.
    *   Introduced a `qualify_field` helper to handle table/alias qualification for field references.
    *   Enhanced virtual field lifting to merge definitions from joined files and apply correct table qualification within lifted expressions.
5.  **Testing:** Added new tests in `test/test_emitter.py` covering single joins, aliased joins, chained joins, and the interaction between joins and virtual fields. All 180 tests in the suite passed.

Fixes #180

---
*PR created automatically by Jules for task [4844064092509382778](https://jules.google.com/task/4844064092509382778) started by @chatelao*