### PR TITLE
Add JOIN command example to RAILROAD_CONCEPT.md

### DIFF
--- a/RAILROAD_CONCEPT.md
+++ b/RAILROAD_CONCEPT.md
@@ -56,7 +56,25 @@ TABLE_REQUEST ::= 'TABLE' 'FILE' qualified_name ( VERB_PHRASE | SORT_PHRASE | ..
 ---
 
 ## Appendix: Examples
-<tbd>
+
+### `JOIN` Command
+
+#### 1. Source (ANTLR4)
+```antlr
+join_command: JOIN (CLEAR asterisk | (LEFT? OUTER)? qualified_name IN qualified_name TO ALL? qualified_name IN qualified_name (AS NAME)?) SEMI?;
+```
+
+#### 2. Intermediate (Pruned EBNF)
+Technical details like `asterisk` are inlined or simplified:
+```ebnf
+JOIN_COMMAND ::= 'JOIN' ( 'CLEAR' '*' | [ [ 'LEFT' ] 'OUTER' ] qualified_name 'IN' qualified_name 'TO' [ 'ALL' ] qualified_name 'IN' qualified_name [ 'AS' NAME ] ) ';'?
+```
+
+#### 3. Conceptual "Oracle Style" Output
+*   **Optional Clauses:** `LEFT`, `OUTER`, and `ALL` are shown as optional branches.
+*   **Choice:** The diagram branches between the `CLEAR` variant and the full `JOIN` syntax.
+*   **Terminals:** Keywords like `JOIN`, `CLEAR`, `IN`, `TO`, `AS` are in rounded boxes.
+*   **Non-Terminals:** `qualified_name` and `NAME` are in rectangular boxes.
 
 ## Appendix: Discarded Alternatives
 


### PR DESCRIPTION
This PR adds a concrete example to the `RAILROAD_CONCEPT.md` documentation. 

Specifically, it:
- Replaces the `<tbd>` placeholder in the "Appendix: Examples" section.
- Adds a three-part example for the `JOIN` command:
    1. **Source (ANTLR4)**: The raw grammar rule.
    2. **Intermediate (Pruned EBNF)**: The simplified EBNF used for rendering.
    3. **Conceptual "Oracle Style" Output**: A description of how the visual railroad diagram should appear.

This ensures the concept document provides actionable examples of how the grammar-to-diagram pipeline operates.

Fixes #190

---
*PR created automatically by Jules for task [16787651617946334966](https://jules.google.com/task/16787651617946334966) started by @chatelao*