### PR TITLE
Implement E2E basic reporting test and add facade methods

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -168,7 +168,7 @@ Ensure the new system produces correct results and maintains parity with the leg
 - [ ] **5.1 Regression Testing:**
   - [x] 5.1.1 Frontend Parity: Run the existing test suite against the new ANTLR4-based frontend. (Verified via `test/test_antlr_wf_parser.py`)
   - [ ] 5.1.2 End-to-End Tests: Verify PL/pgSQL output for a subset of core features.
-    - [ ] 5.1.2.1 Basic Reporting: PRINT/SUM requests with WHERE clauses.
+    - [x] 5.1.2.1 Basic Reporting: PRINT/SUM requests with WHERE clauses. (Verified via `test/test_e2e_basic_reporting.py`)
     - [ ] 5.1.2.2 Advanced Filtering: Complex WHERE clauses, BETWEEN, IN, MISSING.
     - [ ] 5.1.2.3 Calculated Fields: DEFINE and COMPUTE expression lifting.
     - [ ] 5.1.2.4 Data Integration: Multi-table JOINs and virtual field lifting from joined files.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -22,6 +22,14 @@ class PostgresEmitter:
         self.virtual_fields = {} # filename -> {field_name: asg.Expression}
         self.active_joins = []
 
+    def emit(self, cfg, procedure_name="webfocus_procedure"):
+        """
+        Performs full emission of a CFG to a PL/pgSQL function.
+        """
+        variables = self.get_variables_from_cfg(cfg)
+        body = self.emit_cfg(cfg)
+        return self.emit_procedure(procedure_name, body, variables)
+
     def render(self, template_name, **kwargs):
         """
         Renders a template with the given context.

--- a/src/ssa_transformer.py
+++ b/src/ssa_transformer.py
@@ -10,6 +10,13 @@ class SSATransformer:
     def __init__(self):
         pass
 
+    def transform(self, cfg):
+        """
+        Performs full SSA transformation: Phi placement and variable renaming.
+        """
+        self.place_phi_nodes(cfg)
+        self.rename_variables(cfg)
+
     def place_phi_nodes(self, cfg):
         """
         Inserts Phi instructions into the basic blocks of the CFG using the

--- a/test/test_e2e_basic_reporting.py
+++ b/test/test_e2e_basic_reporting.py
@@ -1,0 +1,117 @@
+import unittest
+import sys
+import os
+from antlr4 import CommonTokenStream, InputStream
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from ir_builder import IRBuilder
+from ssa_transformer import SSATransformer
+from optimizer import ConstantPropagator, DeadCodeEliminator
+from emitter import PostgresEmitter
+from metadata_registry import MetadataRegistry
+
+class TestE2EBasicReporting(unittest.TestCase):
+    def test_basic_print_report(self):
+        # 1. Setup
+        fex_code = """
+        -SET &MIN_PRICE = 10000;
+        TABLE FILE CAR
+        PRINT CAR MODEL PRICE
+        BY COUNTRY
+        WHERE PRICE GT &MIN_PRICE
+        END
+        """
+
+        # 2. Parse
+        input_stream = InputStream(fex_code)
+        lexer = WebFocusReportLexer(input_stream)
+        token_stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(token_stream)
+        tree = parser.start()
+
+        # 3. ASG Construction
+        builder = ReportASGBuilder()
+        asg_nodes = builder.visit(tree)
+
+        # 4. IR/CFG Construction
+        ir_builder = IRBuilder()
+        cfg = ir_builder.build(asg_nodes)
+
+        # 5. SSA Transformation
+        ssa_transformer = SSATransformer()
+        ssa_transformer.transform(cfg)
+
+        # 6. Optimization
+        ConstantPropagator().run(cfg)
+        DeadCodeEliminator().run(cfg)
+
+        # 7. Backend Emission
+        metadata = MetadataRegistry()
+        # Mocking some metadata if necessary, but PostgresEmitter should handle defaults
+        emitter = PostgresEmitter(metadata_registry=metadata)
+        sql_output = emitter.emit(cfg)
+
+        # 8. Verifications
+        self.assertIn("CREATE OR REPLACE PROCEDURE", sql_output)
+        self.assertIn("SELECT", sql_output)
+        self.assertIn("FROM CAR", sql_output) # It seems it's not quoted in current emitter implementation
+        self.assertIn("WHERE (PRICE > 10000)", sql_output)
+        self.assertIn("ORDER BY COUNTRY ASC", sql_output)
+        # Checking for the specific SQL generated for basic reporting
+        self.assertIn("CAR", sql_output)
+        self.assertIn("MODEL", sql_output)
+        self.assertIn("PRICE", sql_output)
+        self.assertIn("COUNTRY", sql_output)
+
+    def test_basic_sum_report(self):
+        # 1. Setup
+        fex_code = """
+        TABLE FILE SALES
+        SUM UNITS DOLLARS
+        BY REGION
+        BY MONTH
+        WHERE MONTH EQ 'JAN'
+        END
+        """
+
+        # 2. Parse
+        input_stream = InputStream(fex_code)
+        lexer = WebFocusReportLexer(input_stream)
+        token_stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(token_stream)
+        tree = parser.start()
+
+        # 3. ASG Construction
+        builder = ReportASGBuilder()
+        asg_nodes = builder.visit(tree)
+
+        # 4. IR/CFG Construction
+        ir_builder = IRBuilder()
+        cfg = ir_builder.build(asg_nodes)
+
+        # 5. SSA Transformation
+        ssa_transformer = SSATransformer()
+        ssa_transformer.transform(cfg)
+
+        # 6. Optimization (No constants here but good to run)
+        ConstantPropagator().run(cfg)
+        DeadCodeEliminator().run(cfg)
+
+        # 7. Backend Emission
+        emitter = PostgresEmitter()
+        sql_output = emitter.emit(cfg)
+
+        # 8. Verifications
+        self.assertIn("SUM(UNITS)", sql_output)
+        self.assertIn("SUM(DOLLARS)", sql_output)
+        self.assertIn("FROM SALES", sql_output)
+        self.assertIn("WHERE (MONTH = 'JAN')", sql_output)
+        self.assertIn("GROUP BY REGION, MONTH", sql_output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR implements the first step of Phase 5.1.2 (End-to-End Tests) by adding a comprehensive test for basic reporting (PRINT/SUM with WHERE). To support this, I've added facade methods to `SSATransformer` and `PostgresEmitter` to provide a cleaner API for the full transformation and emission processes. All existing and new tests pass (200 total).

Fixes #195

---
*PR created automatically by Jules for task [11728356596414422238](https://jules.google.com/task/11728356596414422238) started by @chatelao*