### PR TITLE
Implement Advanced Filtering E2E Tests and Refine Roadmap

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -169,7 +169,7 @@ Ensure the new system produces correct results and maintains parity with the leg
   - [x] 5.1.1 Frontend Parity: Run the existing test suite against the new ANTLR4-based frontend. (Verified via `test/test_antlr_wf_parser.py`)
   - [ ] 5.1.2 End-to-End Tests: Verify PL/pgSQL output for a subset of core features.
     - [x] 5.1.2.1 Basic Reporting: PRINT/SUM requests with WHERE clauses. (Verified via `test/test_e2e_basic_reporting.py`)
-    - [ ] 5.1.2.2 Advanced Filtering: Complex WHERE clauses, BETWEEN, IN, MISSING.
+    - [x] 5.1.2.2 Advanced Filtering: Complex WHERE clauses, BETWEEN, IN, MISSING. (Verified via `test/test_e2e_advanced_filtering.py`)
     - [ ] 5.1.2.3 Calculated Fields: DEFINE and COMPUTE expression lifting.
     - [ ] 5.1.2.4 Data Integration: Multi-table JOINs and virtual field lifting from joined files.
     - [ ] 5.1.2.5 Control Flow: DM variable resolution and PL/pgSQL state machine execution.
@@ -177,6 +177,10 @@ Ensure the new system produces correct results and maintains parity with the leg
     - [x] 5.1.3.1 Support `ALL` keyword in `JOIN` commands.
     - [x] 5.1.3.2 Support hyphenated `SET` keywords (e.g., `ONLINE-FMT`).
     - [ ] 5.1.3.3 Support `COMPOUND LAYOUT` structure.
+      - [ ] 5.1.3.3.1 Grammar support for `COMPOUND LAYOUT` and `COMPOUND END`.
+      - [ ] 5.1.3.3.2 Grammar support for layout components (SECTION, PAGELAYOUT, COMPONENT).
+      - [ ] 5.1.3.3.3 ASG support for multi-component documents.
+      - [ ] 5.1.3.3.4 Emitter support for sequential component execution.
     - [x] 5.1.3.4 Support inline format specifications (e.g., `SUM FIELD/I08M`).
     - [x] 5.1.3.5 Support `RECAP` command in report requests.
     - [x] 5.1.3.6 Support `ACROSS-TOTAL` for cross-tabulation summaries.

--- a/test/test_e2e_advanced_filtering.py
+++ b/test/test_e2e_advanced_filtering.py
@@ -1,0 +1,99 @@
+import unittest
+import sys
+import os
+from antlr4 import CommonTokenStream, InputStream
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from ir_builder import IRBuilder
+from ssa_transformer import SSATransformer
+from optimizer import ConstantPropagator, DeadCodeEliminator
+from emitter import PostgresEmitter
+from metadata_registry import MetadataRegistry
+
+class TestE2EAdvancedFiltering(unittest.TestCase):
+    def _transpile(self, fex_code):
+        input_stream = InputStream(fex_code)
+        lexer = WebFocusReportLexer(input_stream)
+        token_stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(token_stream)
+        tree = parser.start()
+
+        builder = ReportASGBuilder()
+        asg_nodes = builder.visit(tree)
+
+        ir_builder = IRBuilder()
+        cfg = ir_builder.build(asg_nodes)
+
+        ssa_transformer = SSATransformer()
+        ssa_transformer.transform(cfg)
+
+        ConstantPropagator().run(cfg)
+        DeadCodeEliminator().run(cfg)
+
+        metadata = MetadataRegistry()
+        emitter = PostgresEmitter(metadata_registry=metadata)
+        return emitter.emit(cfg)
+
+    def test_between_filtering(self):
+        fex_code = """
+        TABLE FILE CAR
+        SUM SALES
+        BY COUNTRY
+        WHERE SALES FROM 1000 TO 5000
+        END
+        """
+        sql_output = self._transpile(fex_code)
+        self.assertIn("BETWEEN 1000 AND 5000", sql_output)
+
+    def test_in_list_filtering(self):
+        fex_code = """
+        TABLE FILE CAR
+        PRINT MODEL
+        BY COUNTRY
+        WHERE COUNTRY IN ('ENGLAND', 'FRANCE', 'ITALY')
+        END
+        """
+        sql_output = self._transpile(fex_code)
+        self.assertIn("COUNTRY IN ('ENGLAND', 'FRANCE', 'ITALY')", sql_output)
+
+    def test_in_file_filtering(self):
+        fex_code = """
+        TABLE FILE CAR
+        PRINT MODEL
+        BY COUNTRY
+        WHERE COUNTRY IN FILE TOP_COUNTRIES
+        END
+        """
+        sql_output = self._transpile(fex_code)
+        # Based on emitter.py, it should produce something like:
+        # (COUNTRY IN (SELECT * FROM TOP_COUNTRIES))
+        self.assertIn("COUNTRY IN (SELECT * FROM TOP_COUNTRIES)", sql_output)
+
+    def test_missing_filtering(self):
+        fex_code = """
+        TABLE FILE CAR
+        PRINT MODEL
+        BY COUNTRY
+        WHERE SALES IS MISSING
+        END
+        """
+        sql_output = self._transpile(fex_code)
+        self.assertIn("SALES IS NULL", sql_output)
+
+        fex_code_not = """
+        TABLE FILE CAR
+        PRINT MODEL
+        BY COUNTRY
+        WHERE SALES IS NOT MISSING
+        END
+        """
+        sql_output_not = self._transpile(fex_code_not)
+        self.assertIn("SALES IS NOT NULL", sql_output_not)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I have implemented a modest and feasible step in the migration roadmap by verifying advanced filtering features through a new end-to-end test suite (`test/test_e2e_advanced_filtering.py`). This test confirms that WebFOCUS predicates like `FROM...TO` (SQL `BETWEEN`), `IN` lists, `IN FILE` (SQL subqueries), and `MISSING` (SQL `NULL`) are correctly transpiled to PostgreSQL.

Additionally, I have refined the `MIGRATION_ROADMAP.md` by marking Phase 5.1.2.2 as completed and breaking down the complex `COMPOUND LAYOUT` task (Phase 5.1.3.3) into smaller, actionable steps covering grammar, ASG, and emitter support.

All 204 tests in the suite, plus the new E2E tests and standalone SSA tests, passed successfully.

Fixes #197

---
*PR created automatically by Jules for task [3210735605143971395](https://jules.google.com/task/3210735605143971395) started by @chatelao*