### PR TITLE
Implement Calculated Fields lifting and verification

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -170,7 +170,7 @@ Ensure the new system produces correct results and maintains parity with the leg
   - [ ] 5.1.2 End-to-End Tests: Verify PL/pgSQL output for a subset of core features.
     - [x] 5.1.2.1 Basic Reporting: PRINT/SUM requests with WHERE clauses. (Verified via `test/test_e2e_basic_reporting.py`)
     - [x] 5.1.2.2 Advanced Filtering: Complex WHERE clauses, BETWEEN, IN, MISSING. (Verified via `test/test_e2e_advanced_filtering.py`)
-    - [ ] 5.1.2.3 Calculated Fields: DEFINE and COMPUTE expression lifting.
+    - [x] 5.1.2.3 Calculated Fields: DEFINE and COMPUTE expression lifting. (Verified via `test/test_e2e_calculated_fields.py`)
     - [ ] 5.1.2.4 Data Integration: Multi-table JOINs and virtual field lifting from joined files.
     - [ ] 5.1.2.5 Control Flow: DM variable resolution and PL/pgSQL state machine execution.
   - [ ] 5.1.3 Grammar Coverage: Ensure all core EBNF features are implemented and tested.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -172,12 +172,18 @@ class PostgresEmitter:
         elif class_name == 'IsMissingExpression':
             self._discover_vars_in_expr(node.expression, variables)
 
-    def emit_expression(self, expr, in_query=False, virtual_fields=None, qualifier=None):
+    def emit_expression(self, expr, **kwargs):
         """
         Translates ASG expression nodes to PostgreSQL SQL strings.
         """
         if expr is None:
             return "NULL"
+
+        in_query = kwargs.get('in_query', False)
+        virtual_fields = kwargs.get('virtual_fields')
+        qualifier = kwargs.get('qualifier')
+        aggregate = kwargs.get('aggregate', False)
+        group_by_fields = kwargs.get('group_by_fields', [])
 
         class_name = expr.__class__.__name__
 
@@ -195,16 +201,24 @@ class PostgresEmitter:
             # but for expressions in procedural logic they might be variables.
             if in_query:
                 if virtual_fields and expr.name in virtual_fields:
-                    # Recursively emit the virtual field expression
-                    return self.emit_expression(virtual_fields[expr.name], in_query=True, virtual_fields=virtual_fields, qualifier=qualifier)
-                if qualifier:
-                    return qualifier(expr.name)
-                return expr.name
+                    # Recursively emit the virtual field expression.
+                    # We expand it WITHOUT internal aggregation, then wrap the result if needed.
+                    new_kwargs = kwargs.copy()
+                    new_kwargs['aggregate'] = False
+                    expanded = self.emit_expression(virtual_fields[expr.name], **new_kwargs)
+                    if aggregate:
+                        return f"SUM({expanded})"
+                    return expanded
+
+                sql_f = qualifier(expr.name) if qualifier else expr.name
+                if aggregate and group_by_fields is not None and sql_f not in group_by_fields:
+                    return f"SUM({sql_f})"
+                return sql_f
             return self._sanitize_name(expr.name)
 
         elif class_name == 'BinaryOperation':
-            left = self.emit_expression(expr.left, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
-            right = self.emit_expression(expr.right, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
+            left = self.emit_expression(expr.left, **kwargs)
+            right = self.emit_expression(expr.right, **kwargs)
             op = expr.operator.upper()
 
             # Map WebFOCUS operators to SQL
@@ -223,7 +237,7 @@ class PostgresEmitter:
             return f"({left} {sql_op} {right})"
 
         elif class_name == 'UnaryOperation':
-            operand = self.emit_expression(expr.operand, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
+            operand = self.emit_expression(expr.operand, **kwargs)
             op = expr.operator.upper()
             op_mapping = {
                 'NOT': 'NOT ',
@@ -232,32 +246,32 @@ class PostgresEmitter:
             return f"{sql_op}({operand})"
 
         elif class_name == 'FunctionCall':
-            args = [self.emit_expression(arg, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier) for arg in expr.arguments]
+            args = [self.emit_expression(arg, **kwargs) for arg in expr.arguments]
             return f"{expr.function_name}({', '.join(args)})"
 
         elif class_name == 'IfExpression':
-            cond = self.emit_expression(expr.condition, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
-            then_e = self.emit_expression(expr.then_expr, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
-            else_e = self.emit_expression(expr.else_expr, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
+            cond = self.emit_expression(expr.condition, **kwargs)
+            then_e = self.emit_expression(expr.then_expr, **kwargs)
+            else_e = self.emit_expression(expr.else_expr, **kwargs)
             return f"(CASE WHEN {cond} THEN {then_e} ELSE {else_e} END)"
 
         elif class_name == 'BetweenExpression':
-            expr_val = self.emit_expression(expr.expression, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
-            lower = self.emit_expression(expr.lower, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
-            upper = self.emit_expression(expr.upper, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
+            expr_val = self.emit_expression(expr.expression, **kwargs)
+            lower = self.emit_expression(expr.lower, **kwargs)
+            upper = self.emit_expression(expr.upper, **kwargs)
             return f"({expr_val} BETWEEN {lower} AND {upper})"
 
         elif class_name == 'InExpression':
-            expr_val = self.emit_expression(expr.expression, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
+            expr_val = self.emit_expression(expr.expression, **kwargs)
             if hasattr(expr, 'filename') and expr.filename:
                 table_name = self._resolve_table_name(expr.filename)
                 return f"({expr_val} IN (SELECT * FROM {table_name}))"
             else:
-                values = [self.emit_expression(val, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier) for val in expr.values]
+                values = [self.emit_expression(val, **kwargs) for val in expr.values]
                 return f"({expr_val} IN ({', '.join(values)}))"
 
         elif class_name == 'IsMissingExpression':
-            expr_val = self.emit_expression(expr.expression, in_query=in_query, virtual_fields=virtual_fields, qualifier=qualifier)
+            expr_val = self.emit_expression(expr.expression, **kwargs)
             op = "IS NOT NULL" if expr.inverted else "IS NULL"
             return f"({expr_val} {op})"
 
@@ -496,7 +510,7 @@ class PostgresEmitter:
         # COMPUTE commands
         compute_commands = [c for c in instr.components if c.__class__.__name__ == 'ComputeCommand']
         for cc in compute_commands:
-            sql_expr = self.emit_expression(cc.expression, in_query=True, virtual_fields=file_virtual_fields, qualifier=qualify_field)
+            sql_expr = self.emit_expression(cc.expression, in_query=True, virtual_fields=file_virtual_fields, qualifier=qualify_field, aggregate=is_aggregating, group_by_fields=group_by_fields)
             if cc.name:
                 sql_expr = f"{sql_expr} AS \"{cc.name}\""
             select_fields.append(sql_expr)
@@ -504,7 +518,7 @@ class PostgresEmitter:
         # WHERE and HAVING
         where_clauses = [self.emit_expression(c.condition, in_query=True, virtual_fields=file_virtual_fields, qualifier=qualify_field) for c in instr.components
                          if c.__class__.__name__ == 'WhereClause' and not c.is_total]
-        having_clauses = [self.emit_expression(c.condition, in_query=True, virtual_fields=file_virtual_fields, qualifier=qualify_field) for c in instr.components
+        having_clauses = [self.emit_expression(c.condition, in_query=True, virtual_fields=file_virtual_fields, qualifier=qualify_field, aggregate=is_aggregating, group_by_fields=group_by_fields) for c in instr.components
                           if c.__class__.__name__ == 'WhereClause' and c.is_total]
 
         if not select_fields:

--- a/test/test_e2e_calculated_fields.py
+++ b/test/test_e2e_calculated_fields.py
@@ -1,0 +1,121 @@
+import unittest
+import sys
+import os
+from antlr4 import CommonTokenStream, InputStream
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from ir_builder import IRBuilder
+from ssa_transformer import SSATransformer
+from optimizer import ConstantPropagator, DeadCodeEliminator
+from emitter import PostgresEmitter
+from metadata_registry import MetadataRegistry
+
+class TestE2ECalculatedFields(unittest.TestCase):
+    def _run_e2e(self, fex_code):
+        # 2. Parse
+        input_stream = InputStream(fex_code)
+        lexer = WebFocusReportLexer(input_stream)
+        token_stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(token_stream)
+        tree = parser.start()
+
+        # 3. ASG Construction
+        builder = ReportASGBuilder()
+        asg_nodes = builder.visit(tree)
+
+        # 4. IR/CFG Construction
+        ir_builder = IRBuilder()
+        cfg = ir_builder.build(asg_nodes)
+
+        # 5. SSA Transformation
+        ssa_transformer = SSATransformer()
+        ssa_transformer.transform(cfg)
+
+        # 6. Optimization
+        ConstantPropagator().run(cfg)
+        DeadCodeEliminator().run(cfg)
+
+        # 7. Backend Emission
+        metadata = MetadataRegistry()
+        emitter = PostgresEmitter(metadata_registry=metadata)
+        sql_output = emitter.emit(cfg)
+
+        return sql_output
+
+    def test_define_in_print(self):
+        fex_code = """
+        DEFINE FILE CAR
+        PRICE_EUR = PRICE * 0.85;
+        END
+        TABLE FILE CAR
+        PRINT CAR MODEL PRICE PRICE_EUR
+        END
+        """
+        sql = self._run_e2e(fex_code)
+        self.assertIn("(PRICE * 0.85) AS \"PRICE_EUR\"", sql)
+        self.assertIn("SELECT CAR, MODEL, PRICE, (PRICE * 0.85) AS \"PRICE_EUR\"", sql)
+
+    def test_define_in_sum(self):
+        fex_code = """
+        DEFINE FILE CAR
+        REVENUE = SALES * PRICE;
+        END
+        TABLE FILE CAR
+        SUM REVENUE BY COUNTRY
+        END
+        """
+        sql = self._run_e2e(fex_code)
+        # REVENUE is (SALES * PRICE). SUM(REVENUE) -> SUM(SALES * PRICE)
+        self.assertIn("SUM((SALES * PRICE)) AS \"REVENUE\"", sql)
+        self.assertIn("GROUP BY COUNTRY", sql)
+
+    def test_compute_in_print(self):
+        fex_code = """
+        TABLE FILE CAR
+        PRINT CAR MODEL PRICE
+        COMPUTE PRICE_EUR/D12.2 = PRICE * 0.85;
+        END
+        """
+        sql = self._run_e2e(fex_code)
+        # In PRINT, COMPUTE should behave like a regular expression
+        self.assertIn("(PRICE * 0.85) AS \"PRICE_EUR\"", sql)
+
+    def test_compute_in_sum(self):
+        fex_code = """
+        TABLE FILE CAR
+        SUM SALES
+        COMPUTE AVG_PRICE = SALES / 10;
+        BY COUNTRY
+        END
+        """
+        sql = self._run_e2e(fex_code)
+        # In SUM, fields in COMPUTE should be aggregated.
+        # WebFOCUS: SUM SALES COMPUTE AVG_PRICE = SALES / 10;
+        # means AVG_PRICE = SUM(SALES) / 10
+        self.assertIn("(SUM(SALES) / 10) AS \"AVG_PRICE\"", sql)
+
+    def test_recursive_define_and_compute(self):
+        fex_code = """
+        DEFINE FILE CAR
+        BASE_TAX = PRICE * 0.1;
+        TOTAL_PRICE = PRICE + BASE_TAX;
+        END
+        TABLE FILE CAR
+        SUM TOTAL_PRICE
+        COMPUTE NET_PROFIT = TOTAL_PRICE * 0.5;
+        END
+        """
+        sql = self._run_e2e(fex_code)
+        # TOTAL_PRICE = PRICE + (PRICE * 0.1)
+        # SUM(TOTAL_PRICE) = SUM(PRICE + (PRICE * 0.1))
+        # COMPUTE NET_PROFIT = SUM(TOTAL_PRICE) * 0.5 = SUM(PRICE + (PRICE * 0.1)) * 0.5
+        self.assertIn("SUM((PRICE + (PRICE * 0.1))) AS \"TOTAL_PRICE\"", sql)
+        self.assertIn("(SUM((PRICE + (PRICE * 0.1))) * 0.5) AS \"NET_PROFIT\"", sql)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_emitter.py
+++ b/test/test_emitter.py
@@ -279,7 +279,7 @@ class TestEmitter(unittest.TestCase):
 
         self.assertIn("SELECT REGION, SUM(SALES)", sql)
         self.assertIn("GROUP BY REGION", sql)
-        self.assertIn("HAVING (SALES > 1000)", sql)
+        self.assertIn("HAVING (SUM(SALES) > 1000)", sql)
 
     def test_emit_instruction_report_with_compute(self):
         emitter = PostgresEmitter()
@@ -293,7 +293,7 @@ class TestEmitter(unittest.TestCase):
 
         sql = emitter.emit_instruction(instr)
 
-        self.assertIn("SELECT SUM(SALES), (SALES / 1000) AS \"RATIO\"", sql)
+        self.assertIn("SELECT SUM(SALES), (SUM(SALES) / 1000) AS \"RATIO\"", sql)
 
     def test_emit_instruction_define_and_lift(self):
         emitter = PostgresEmitter()


### PR DESCRIPTION
This PR implements the lifting of calculated fields (DEFINE and COMPUTE) into generated PostgreSQL queries. 

Key changes include:
1. **Aggregation Lifting**: In aggregating reports (e.g., using SUM or COUNT), field references within COMPUTE and HAVING clauses are now automatically wrapped in SUM() if they are not part of the GROUP BY clause. This ensures parity with WebFOCUS semantics where COMPUTE is evaluated after aggregation.
2. **Recursive Expansion**: Both DEFINE and COMPUTE now support recursive field references, which are inlined into the final SQL expression.
3. **End-to-End Verification**: A new test suite `test/test_e2e_calculated_fields.py` validates these behaviors across several reporting scenarios.
4. **MIGRATION_ROADMAP.md**: Marked Phase 5.1.2.3 as completed.

Fixes #199

---
*PR created automatically by Jules for task [5993487097347338857](https://jules.google.com/task/5993487097347338857) started by @chatelao*