### PR TITLE
Implement ASG support for COMPOUND LAYOUT

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -179,7 +179,7 @@ Ensure the new system produces correct results and maintains parity with the leg
     - [ ] 5.1.3.3 Support `COMPOUND LAYOUT` structure.
       - [x] 5.1.3.3.1 Grammar support for `COMPOUND LAYOUT` and `COMPOUND END`.
       - [x] 5.1.3.3.2 Grammar support for layout components (SECTION, PAGELAYOUT, COMPONENT).
-      - [ ] 5.1.3.3.3 ASG support for multi-component documents.
+      - [x] 5.1.3.3.3 ASG support for multi-component documents.
       - [ ] 5.1.3.3.4 Emitter support for sequential component execution.
     - [x] 5.1.3.4 Support inline format specifications (e.g., `SUM FIELD/I08M`).
     - [x] 5.1.3.5 Support `RECAP` command in report requests.

--- a/src/asg.py
+++ b/src/asg.py
@@ -236,3 +236,23 @@ class Field(DataModelNode):
     """Represents a field within a segment."""
     def __init__(self, name, alias=None, format=None, **kwargs):
         super().__init__(name=name, alias=alias, format=format, **kwargs)
+
+class CompoundLayout(Statement):
+    """Represents a COMPOUND LAYOUT block."""
+    def __init__(self, output_command, statements=None, components=None, **kwargs):
+        super().__init__(output_command=output_command, statements=statements or [], components=components or [], **kwargs)
+
+class LayoutStatement(ASGNode):
+    """Represents a layout statement (e.g., SECTION=..., PAGELAYOUT=..., COMPONENT=...)."""
+    def __init__(self, name, value, properties=None, **kwargs):
+        super().__init__(name=name, value=value, properties=properties or [], **kwargs)
+
+class LayoutProperty(ASGNode):
+    """Represents a layout property within a layout statement."""
+    def __init__(self, name, value, **kwargs):
+        super().__init__(name=name, value=value, **kwargs)
+
+class StyleBlock(Command):
+    """Represents a SET STYLE * ... ENDSTYLE block."""
+    def __init__(self, statements=None, **kwargs):
+        super().__init__(statements=statements or [], **kwargs)

--- a/src/asg_builder.py
+++ b/src/asg_builder.py
@@ -137,6 +137,9 @@ class ReportASGBuilder(WebFocusReportVisitor):
             return self.visit(ctx.recap_command())
         if ctx.set_command():
             return self.visit(ctx.set_command())
+        if ctx.STYLE():
+            statements = [self.visit(s) for s in ctx.layout_statement()]
+            return StyleBlock(statements=statements)
         return None
 
     def visitOn_field_options(self, ctx: WebFocusReportParser.On_field_optionsContext):
@@ -490,3 +493,49 @@ class ReportASGBuilder(WebFocusReportVisitor):
 
     def visitAmper_var(self, ctx: WebFocusReportParser.Amper_varContext):
         return AmperVar(name=ctx.getText())
+
+    def visitCompound_layout_block(self, ctx: WebFocusReportParser.Compound_layout_blockContext):
+        output_command = self.visit(ctx.output_command())
+        statements = [self.visit(s) for s in ctx.layout_statement()]
+
+        components = []
+        # The components are interleaved between the first end_command and COMPOUND END
+        # Children after output_command and layout_statements and the first end_command
+        # compound_layout_block: COMPOUND LAYOUT output_command (layout_statement)* end_command (request | dm_command | join_command | set_command | define_file)* COMPOUND END;
+        # COMPOUND is child 0, LAYOUT is child 1, output_command is child 2
+        start_idx = 3 + len(ctx.layout_statement()) + 1 # +1 for end_command
+        for i in range(start_idx, ctx.getChildCount() - 2):
+            child = ctx.getChild(i)
+            if isinstance(child, TerminalNode):
+                continue
+            node = self.visit(child)
+            if node:
+                if isinstance(node, list):
+                    components.extend(node)
+                else:
+                    components.append(node)
+
+        return CompoundLayout(output_command=output_command, statements=statements, components=components)
+
+    def visitLayout_statement(self, ctx: WebFocusReportParser.Layout_statementContext):
+        name = ctx.getChild(0).getText()
+        value = self.visit(ctx.layout_value())
+        properties = [self.visit(p) for p in ctx.layout_property()]
+        return LayoutStatement(name=name, value=value, properties=properties)
+
+    def visitLayout_property(self, ctx: WebFocusReportParser.Layout_propertyContext):
+        name = ctx.getChild(0).getText()
+        value = self.visit(ctx.layout_value())
+        return LayoutProperty(name=name, value=value)
+
+    def visitLayout_value(self, ctx: WebFocusReportParser.Layout_valueContext):
+        if ctx.getChildCount() > 1 and ctx.getChild(0).getText() == '(':
+            values = []
+            for i in range(1, ctx.getChildCount() - 1):
+                child = ctx.getChild(i)
+                if isinstance(child, WebFocusReportParser.Layout_valueContext):
+                    values.append(self.visit(child))
+            return values
+        if ctx.STRING():
+            return ctx.STRING().getText()[1:-1]
+        return ctx.getText()

--- a/test/test_asg_compound_layout.py
+++ b/test/test_asg_compound_layout.py
@@ -1,0 +1,87 @@
+import pytest
+from antlr4 import CommonTokenStream, InputStream
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from asg import *
+
+def test_compound_layout_asg():
+    fex = """
+COMPOUND LAYOUT PCHOLD FORMAT PDF
+SECTION=section1, LAYOUT=ON, METADATA='metadata', $
+PAGELAYOUT=1, NAME='Page Layout 1', SCREEN=ON, $
+COMPONENT=Table_1, TYPE=REPORT, POSITION=(1.0 1.0), DIMENSION=(5.0 5.0), $
+END
+TABLE FILE CAR
+PRINT COUNTRY CAR MODEL
+END
+COMPOUND END
+"""
+    input_stream = InputStream(fex)
+    lexer = WebFocusReportLexer(input_stream)
+    token_stream = CommonTokenStream(lexer)
+    parser = WebFocusReportParser(token_stream)
+    tree = parser.start()
+
+    builder = ReportASGBuilder()
+    asg_nodes = builder.visit(tree)
+
+    assert len(asg_nodes) == 1
+    compound = asg_nodes[0]
+    assert isinstance(compound, CompoundLayout)
+    assert compound.output_command.output_type == "PCHOLD"
+    assert compound.output_command.format == "PDF"
+
+    assert len(compound.statements) == 3
+    assert compound.statements[0].name == "SECTION"
+    assert compound.statements[0].value == "section1"
+    assert len(compound.statements[0].properties) == 2
+    assert compound.statements[0].properties[0].name == "LAYOUT"
+    assert compound.statements[0].properties[0].value == "ON"
+
+    assert compound.statements[1].name == "PAGELAYOUT"
+    assert compound.statements[1].value == "1"
+    assert len(compound.statements[1].properties) == 2
+    assert compound.statements[1].properties[0].name == "NAME"
+    assert compound.statements[1].properties[0].value == "Page Layout 1"
+
+    assert compound.statements[2].name == "COMPONENT"
+    assert compound.statements[2].value == "Table_1"
+    assert len(compound.statements[2].properties) == 3
+    assert compound.statements[2].properties[1].name == "POSITION"
+    assert compound.statements[2].properties[1].value == ["1.0", "1.0"]
+
+    assert len(compound.components) == 1
+    assert isinstance(compound.components[0], ReportRequest)
+    assert compound.components[0].filename == "CAR"
+
+def test_on_table_set_style_asg():
+    fex = """
+TABLE FILE CAR
+PRINT COUNTRY
+ON TABLE SET STYLE *
+TYPE=REPORT, GRID=OFF, $
+ENDSTYLE
+END
+"""
+    input_stream = InputStream(fex)
+    lexer = WebFocusReportLexer(input_stream)
+    token_stream = CommonTokenStream(lexer)
+    parser = WebFocusReportParser(token_stream)
+    tree = parser.start()
+
+    builder = ReportASGBuilder()
+    asg_nodes = builder.visit(tree)
+
+    assert len(asg_nodes) == 1
+    report = asg_nodes[0]
+    assert isinstance(report, ReportRequest)
+
+    on_table = next(c for c in report.components if isinstance(c, OnCommand) and c.target == "TABLE")
+    style_block = next(a for a in on_table.actions if isinstance(a, StyleBlock))
+
+    assert len(style_block.statements) == 1
+    assert style_block.statements[0].name == "TYPE"
+    assert style_block.statements[0].value == "REPORT"
+    assert style_block.statements[0].properties[0].name == "GRID"
+    assert style_block.statements[0].properties[0].value == "OFF"


### PR DESCRIPTION
I have implemented support for the `COMPOUND LAYOUT` structure in the Abstract Semantic Graph (ASG). This involved creating new ASG nodes and implementing the necessary visitor logic in the `ReportASGBuilder`. I also added support for `SET STYLE` blocks, which are often used within compound layouts. These changes progress the project's migration roadmap (Phase 5.1.3.3.3) and have been verified with a new set of unit tests and by ensuring no regressions in the existing test suite.

Fixes #205

---
*PR created automatically by Jules for task [784431539385101024](https://jules.google.com/task/784431539385101024) started by @chatelao*