### PR TITLE
Implement IR and Emitter support for COMPOUND LAYOUT

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -180,7 +180,7 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [x] 5.1.3.3.1 Grammar support for `COMPOUND LAYOUT` and `COMPOUND END`.
       - [x] 5.1.3.3.2 Grammar support for layout components (SECTION, PAGELAYOUT, COMPONENT).
       - [x] 5.1.3.3.3 ASG support for multi-component documents.
-      - [ ] 5.1.3.3.4 Emitter support for sequential component execution.
+      - [x] 5.1.3.3.4 Emitter support for sequential component execution.
     - [x] 5.1.3.4 Support inline format specifications (e.g., `SUM FIELD/I08M`).
     - [x] 5.1.3.5 Support `RECAP` command in report requests.
     - [x] 5.1.3.6 Support `ACROSS-TOTAL` for cross-tabulation summaries.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -126,6 +126,14 @@ class PostgresEmitter:
         if hasattr(node, 'assignments'):
             for a in node.assignments:
                 self._discover_vars_in_expr(a, variables)
+        if hasattr(node, 'statements'):
+            for s in node.statements:
+                self._discover_vars_in_expr(s, variables)
+        if hasattr(node, 'properties'):
+            for p in node.properties:
+                self._discover_vars_in_expr(p, variables)
+        if hasattr(node, 'value'):
+            self._discover_vars_in_expr(node.value, variables)
         if hasattr(node, 'expression'):
             self._discover_vars_in_expr(node.expression, variables)
         if hasattr(node, 'sources') and not isinstance(node, (asg.BinaryOperation, asg.UnaryOperation)):
@@ -368,7 +376,34 @@ class PostgresEmitter:
                 self.virtual_fields[instr.filename][assignment.name] = assignment.expression
             return f"/* DEFINE FILE {instr.filename} ... */"
 
+        elif class_name == 'CompoundLayout':
+            return self._emit_compound_layout(instr)
+
+        elif class_name == 'CompoundEnd':
+            return "/* COMPOUND END */"
+
         return f"/* Unsupported instruction: {class_name} */"
+
+    def _emit_compound_layout(self, instr):
+        """
+        Translates ir.CompoundLayout instruction into SQL comments.
+        """
+        output = instr.output_command
+        output_str = f"{output.output_type}"
+        if output.filename:
+            output_str += f" {output.filename}"
+        if output.format:
+            output_str += f" FORMAT {output.format}"
+
+        lines = [f"/* COMPOUND LAYOUT {output_str} */"]
+        for stmt in instr.statements:
+            line = f"/*   {stmt.name}={stmt.value}"
+            if stmt.properties:
+                props = [f"{p.name}={p.value}" for p in stmt.properties]
+                line += f", {', '.join(props)}"
+            line += " */"
+            lines.append(line)
+        return "\n".join(lines)
 
     def _emit_report(self, instr):
         """

--- a/src/ir.py
+++ b/src/ir.py
@@ -76,6 +76,15 @@ class Report(Instruction):
     def __init__(self, filename, components, joins=None, **kwargs):
         super().__init__(filename=filename, components=components, joins=joins or [], **kwargs)
 
+class CompoundLayout(Instruction):
+    """Represents the start of a COMPOUND LAYOUT block."""
+    def __init__(self, output_command, statements=None, **kwargs):
+        super().__init__(output_command=output_command, statements=statements or [], **kwargs)
+
+class CompoundEnd(Instruction):
+    """Represents the end of a COMPOUND LAYOUT block."""
+    pass
+
 class BasicBlock(IRNode):
     """Represents a basic block: a linear sequence of instructions."""
     def __init__(self, name, **kwargs):

--- a/src/ir_builder.py
+++ b/src/ir_builder.py
@@ -21,19 +21,27 @@ class IRBuilder:
         self.cfg.add_block(block)
         return block
 
-    def build(self, asg_nodes):
-        # Pass 1: Identify all labels
-        for node in asg_nodes:
+    def _discover_labels(self, nodes):
+        for node in nodes:
             class_name = node.__class__.__name__
             if class_name == 'Label':
                 if node.name not in self.labels:
                     block = self._new_block(node.name)
                     self.labels[node.name] = block.name
+            elif class_name == 'CompoundLayout':
+                self._discover_labels(node.components)
+
+    def build(self, asg_nodes):
+        # Pass 1: Identify all labels
+        self._discover_labels(asg_nodes)
 
         # Pass 2: Build instructions and edges
         self.current_block = self._new_block("ENTRY")
+        self._process_nodes(asg_nodes)
+        return self.cfg
 
-        for node in asg_nodes:
+    def _process_nodes(self, nodes):
+        for node in nodes:
             class_name = node.__class__.__name__
             if class_name == 'Label':
                 target_block_name = self.labels[node.name]
@@ -199,11 +207,16 @@ class IRBuilder:
             elif class_name == 'JoinClear':
                 self.current_block.add_instruction(ir.JoinClear())
                 self.active_joins = []
+            elif class_name == 'CompoundLayout':
+                self.current_block.add_instruction(ir.CompoundLayout(
+                    output_command=node.output_command,
+                    statements=node.statements
+                ))
+                self._process_nodes(node.components)
+                self.current_block.add_instruction(ir.CompoundEnd())
             elif class_name == 'RunDM':
                 self.current_block.add_instruction(ir.Call(target='-RUN'))
             elif class_name == 'ExitDM':
                 self.current_block.add_instruction(ir.Jump(target='EXIT'))
                 # No edge to 'EXIT' yet unless we define an EXIT block.
                 self.current_block = self._new_block()
-
-        return self.cfg

--- a/test/test_compound_layout.py
+++ b/test/test_compound_layout.py
@@ -1,0 +1,75 @@
+import unittest
+import sys
+import os
+from antlr4 import CommonTokenStream, InputStream
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from ir_builder import IRBuilder
+from ssa_transformer import SSATransformer
+from emitter import PostgresEmitter
+from metadata_registry import MetadataRegistry
+
+class TestCompoundLayout(unittest.TestCase):
+    def test_compound_layout_compilation(self):
+        fex_code = """
+        SET PAGE-NUM=OFF
+        COMPOUND LAYOUT PCHOLD FORMAT PDF
+        SECTION=S1, LAYOUT=ON, MERGE=ON, ORIENTATION=LANDSCAPE, $
+        PAGELAYOUT=1, $
+        COMPONENT=Sales, TYPE=REPORT, POSITION=(1 1), DIMENSION=(4 4), $
+        COMPONENT=Units, TYPE=REPORT, POSITION=(6.25 1), DIMENSION=(4 4), $
+        END
+        SET COMPONENT=Sales
+        TABLE FILE GGSALES
+        SUM DOLLARS
+        BY REGION
+        ON TABLE HOLD FORMAT PDF
+        END
+        SET COMPONENT=Units
+        TABLE FILE GGSALES
+        SUM UNITS
+        BY PRODUCT
+        ON TABLE HOLD FORMAT PDF
+        END
+        COMPOUND END
+        """
+
+        # 1. Parse
+        input_stream = InputStream(fex_code)
+        lexer = WebFocusReportLexer(input_stream)
+        token_stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(token_stream)
+        tree = parser.start()
+
+        # 2. ASG Construction
+        builder = ReportASGBuilder()
+        asg_nodes = builder.visit(tree)
+
+        # Verify ASG has CompoundLayout
+        self.assertTrue(any(node.__class__.__name__ == 'CompoundLayout' for node in asg_nodes))
+
+        # 3. IR/CFG Construction
+        ir_builder = IRBuilder()
+        cfg = ir_builder.build(asg_nodes)
+
+        # 4. SSA Transformation
+        ssa_transformer = SSATransformer()
+        ssa_transformer.transform(cfg)
+
+        # 5. Backend Emission
+        emitter = PostgresEmitter()
+        sql_output = emitter.emit(cfg)
+
+        # 6. Verifications
+        self.assertIn("COMPOUND LAYOUT", sql_output)
+        self.assertIn("GGSALES", sql_output)
+        self.assertIn("SUM(DOLLARS)", sql_output)
+        self.assertIn("SUM(UNITS)", sql_output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented Phase 5.1.3.3.4 of the migration roadmap: support for `COMPOUND LAYOUT` in the IR and Emitter. This involved refactoring the `IRBuilder` to handle nested ASG structures and updating the `PostgresEmitter` to emit descriptive comments for layout blocks while ensuring interleaved reports are still processed as SQL.

Fixes #207

---
*PR created automatically by Jules for task [9190901689684332398](https://jules.google.com/task/9190901689684332398) started by @chatelao*