### PR TITLE
Implement initial ANTLR4 to W3C EBNF conversion logic

### DIFF
--- a/RAILROAD_ROADMAP.md
+++ b/RAILROAD_ROADMAP.md
@@ -4,7 +4,11 @@ This document outlines the tasks required to implement the automated railroad di
 
 ## Phase 1: Extraction & Transformation (ANTLR4 to EBNF)
 - [ ] 1.1 Develop ANTLR4 to W3C EBNF conversion script.
-    - [ ] 1.1.1 **Early Testing:** Implement unit tests for core conversion logic (terminals, non-terminals, cardinality).
+    - [x] 1.1.1 Implement parser rule extraction and basic EBNF mapping (terminals/non-terminals).
+    - [ ] 1.1.2 Implement cardinality mapping (optional, repeat, one-or-more).
+    - [ ] 1.1.3 Implement grouping and alternatives mapping.
+    - [ ] 1.1.4 Implement lexer rule to terminal string conversion.
+    - [ ] 1.1.5 **Early Testing:** Implement unit tests for each mapping component.
 - [ ] 1.2 Implement rule tagging system in `WebFocusReport.g4` (e.g., `// @internal`).
 - [ ] 1.3 Develop automated rule pruning and inlining logic for technical/internal rules.
     - [ ] 1.3.1 **Early Testing:** Implement unit tests for inlining logic (handling recursion and name collisions).

--- a/scripts/antlr4_to_ebnf.py
+++ b/scripts/antlr4_to_ebnf.py
@@ -1,0 +1,69 @@
+import re
+import sys
+
+def convert_antlr_to_ebnf(antlr_content):
+    """
+    Converts ANTLR4 grammar content to W3C EBNF.
+    This is an initial implementation focusing on basic rule mapping.
+    """
+    # Remove comments but skip strings
+    antlr_content = remove_comments(antlr_content)
+
+    # Extract parser rules (start with lowercase)
+    # Using a more robust regex that handles multiline rules and leading whitespace
+    parser_rules = re.findall(r'^\s*([a-z]\w*)\s*:\s*(.*?)\s*;', antlr_content, re.DOTALL | re.MULTILINE)
+
+    # Extract lexer rules (start with uppercase)
+    lexer_rules = re.findall(r'^\s*([A-Z]\w*)\s*:\s*(.*?)\s*;', antlr_content, re.DOTALL | re.MULTILINE)
+
+    ebnf_rules = []
+
+    for rule_name, body in parser_rules:
+        body = format_body(body)
+        ebnf_rules.append(f"{rule_name} ::= {body}")
+
+    for rule_name, body in lexer_rules:
+        body = format_body(body)
+        ebnf_rules.append(f"{rule_name} ::= {body}")
+
+    return "\n".join(ebnf_rules)
+
+def remove_comments(content):
+    """
+    Removes ANTLR4 comments while preserving strings.
+    """
+    # Regex to match single-quoted strings, double-quoted strings,
+    # block comments, or line comments.
+    # Fixed: non-greedy match for //.* to avoid swallowing the whole line if multiple comments exist
+    # and to not swallow \n which might be needed for ^ anchors in rules.
+    pattern = r"'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\"|/\*.*?\*/|//[^\n]*"
+
+    def replace(match):
+        m = match.group(0)
+        if m.startswith('/') :
+            return ' ' # It's a comment, replace with space
+        return m # It's a string, keep it
+
+    return re.sub(pattern, replace, content, flags=re.DOTALL)
+
+def format_body(body):
+    """
+    Formats the body of a rule for W3C EBNF.
+    """
+    # Remove ANTLR actions if any
+    body = re.sub(r'\{.*?\}', '', body, flags=re.DOTALL)
+
+    # Clean up whitespace
+    body = body.replace('\n', ' ').strip()
+    body = re.sub(r'\s+', ' ', body)
+
+    return body
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        content = sys.stdin.read()
+    else:
+        with open(sys.argv[1], 'r') as f:
+            content = f.read()
+
+    print(convert_antlr_to_ebnf(content))

--- a/test/test_antlr4_to_ebnf.py
+++ b/test/test_antlr4_to_ebnf.py
@@ -1,0 +1,49 @@
+import pytest
+from scripts.antlr4_to_ebnf import convert_antlr_to_ebnf
+
+def test_basic_conversion():
+    antlr = """
+    grammar Test;
+    rule1: 'TERM' rule2;
+    rule2: 'ANOTHER' | rule3;
+    rule3: 'FINAL';
+
+    TOKEN1: 'literal';
+    """
+    expected = [
+        "rule1 ::= 'TERM' rule2",
+        "rule2 ::= 'ANOTHER' | rule3",
+        "rule3 ::= 'FINAL'",
+        "TOKEN1 ::= 'literal'"
+    ]
+    result = convert_antlr_to_ebnf(antlr)
+    for rule in expected:
+        assert rule in result
+
+def test_multiline_rule():
+    antlr = """
+    rule:
+        PART1
+        | PART2
+        ;
+    """
+    result = convert_antlr_to_ebnf(antlr)
+    assert "rule ::= PART1 | PART2" in result
+
+def test_comment_removal():
+    antlr = """
+    // This is a comment
+    rule: 'TERM'; /* Multiline
+    comment */
+    """
+    result = convert_antlr_to_ebnf(antlr)
+    assert "//" not in result
+    assert "/*" not in result
+    assert "rule ::= 'TERM'" in result
+
+def test_string_with_comment_markers():
+    antlr = """
+    rule: 'http://' | "/* not a comment */";
+    """
+    result = convert_antlr_to_ebnf(antlr)
+    assert "rule ::= 'http://' | \"/* not a comment */\"" in result


### PR DESCRIPTION
Progressed the railroad diagram implementation by refining the roadmap and implementing the first granular step: basic ANTLR4 to W3C EBNF conversion logic. The implementation includes a string-aware comment removal tool to ensure grammar literals are preserved, and is supported by a new suite of unit tests.

Fixes #219

---
*PR created automatically by Jules for task [16399525735688005983](https://jules.google.com/task/16399525735688005983) started by @chatelao*