### PR TITLE
Refine ANTLR4 to EBNF conversion and complete Phase 1.1 of Railroad Roadmap

### DIFF
--- a/RAILROAD_ROADMAP.md
+++ b/RAILROAD_ROADMAP.md
@@ -3,12 +3,12 @@
 This document outlines the tasks required to implement the automated railroad diagram generation as defined in `RAILROAD_CONCEPT.md`.
 
 ## Phase 1: Extraction & Transformation (ANTLR4 to EBNF)
-- [ ] 1.1 Develop ANTLR4 to W3C EBNF conversion script.
+- [x] 1.1 Develop ANTLR4 to W3C EBNF conversion script.
     - [x] 1.1.1 Implement parser rule extraction and basic EBNF mapping (terminals/non-terminals).
-    - [ ] 1.1.2 Implement cardinality mapping (optional, repeat, one-or-more).
-    - [ ] 1.1.3 Implement grouping and alternatives mapping.
-    - [ ] 1.1.4 Implement lexer rule to terminal string conversion.
-    - [ ] 1.1.5 **Early Testing:** Implement unit tests for each mapping component.
+    - [x] 1.1.2 Implement cardinality mapping (optional, repeat, one-or-more).
+    - [x] 1.1.3 Implement grouping and alternatives mapping.
+    - [x] 1.1.4 Implement lexer rule to terminal string conversion.
+    - [x] 1.1.5 **Early Testing:** Implement unit tests for each mapping component.
 - [ ] 1.2 Implement rule tagging system in `WebFocusReport.g4` (e.g., `// @internal`).
 - [ ] 1.3 Develop automated rule pruning and inlining logic for technical/internal rules.
     - [ ] 1.3.1 **Early Testing:** Implement unit tests for inlining logic (handling recursion and name collisions).

--- a/scripts/antlr4_to_ebnf.py
+++ b/scripts/antlr4_to_ebnf.py
@@ -4,17 +4,15 @@ import sys
 def convert_antlr_to_ebnf(antlr_content):
     """
     Converts ANTLR4 grammar content to W3C EBNF.
-    This is an initial implementation focusing on basic rule mapping.
     """
     # Remove comments but skip strings
     antlr_content = remove_comments(antlr_content)
 
     # Extract parser rules (start with lowercase)
-    # Using a more robust regex that handles multiline rules and leading whitespace
     parser_rules = re.findall(r'^\s*([a-z]\w*)\s*:\s*(.*?)\s*;', antlr_content, re.DOTALL | re.MULTILINE)
 
     # Extract lexer rules (start with uppercase)
-    lexer_rules = re.findall(r'^\s*([A-Z]\w*)\s*:\s*(.*?)\s*;', antlr_content, re.DOTALL | re.MULTILINE)
+    lexer_rules = re.findall(r'^\s*(fragment\s+)?([A-Z]\w*)\s*:\s*(.*?)\s*;', antlr_content, re.DOTALL | re.MULTILINE)
 
     ebnf_rules = []
 
@@ -22,8 +20,8 @@ def convert_antlr_to_ebnf(antlr_content):
         body = format_body(body)
         ebnf_rules.append(f"{rule_name} ::= {body}")
 
-    for rule_name, body in lexer_rules:
-        body = format_body(body)
+    for fragment, rule_name, body in lexer_rules:
+        body = format_body(body, is_lexer=True)
         ebnf_rules.append(f"{rule_name} ::= {body}")
 
     return "\n".join(ebnf_rules)
@@ -32,32 +30,49 @@ def remove_comments(content):
     """
     Removes ANTLR4 comments while preserving strings.
     """
-    # Regex to match single-quoted strings, double-quoted strings,
-    # block comments, or line comments.
-    # Fixed: non-greedy match for //.* to avoid swallowing the whole line if multiple comments exist
-    # and to not swallow \n which might be needed for ^ anchors in rules.
     pattern = r"'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\"|/\*.*?\*/|//[^\n]*"
 
     def replace(match):
         m = match.group(0)
         if m.startswith('/') :
-            return ' ' # It's a comment, replace with space
-        return m # It's a string, keep it
+            return ' '
+        return m
 
     return re.sub(pattern, replace, content, flags=re.DOTALL)
 
-def format_body(body):
+def format_body(body, is_lexer=False):
     """
     Formats the body of a rule for W3C EBNF.
     """
     # Remove ANTLR actions if any
     body = re.sub(r'\{.*?\}', '', body, flags=re.DOTALL)
 
+    # Remove lexer commands
+    body = re.sub(r'->\s*\w+(\(.*?\))?', '', body)
+
+    # Handle case-insensitive character classes in lexer rules
+    if is_lexer:
+        body = convert_char_classes(body)
+
+    # Remove non-greedy markers
+    body = body.replace('*?', '*').replace('+?', '+').replace('??', '?')
+
     # Clean up whitespace
     body = body.replace('\n', ' ').strip()
     body = re.sub(r'\s+', ' ', body)
 
     return body
+
+def convert_char_classes(body):
+    """
+    Converts sequences like [tT][aA][bB] to 'TAB'.
+    """
+    def replace_sequence(match):
+        chars = re.findall(r'\[([a-zA-Z])([a-zA-Z])\]', match.group(0))
+        res = "".join(c1.upper() for c1, c2 in chars if c1.lower() == c2.lower())
+        return f"'{res}'"
+
+    return re.sub(r'(\[([a-zA-Z])([a-zA-Z])\])+', replace_sequence, body)
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:

--- a/test/test_antlr4_to_ebnf.py
+++ b/test/test_antlr4_to_ebnf.py
@@ -47,3 +47,46 @@ def test_string_with_comment_markers():
     """
     result = convert_antlr_to_ebnf(antlr)
     assert "rule ::= 'http://' | \"/* not a comment */\"" in result
+
+def test_cardinality_and_grouping():
+    antlr = """
+    rule: (part1 | part2)* part3+ part4?;
+    """
+    result = convert_antlr_to_ebnf(antlr)
+    assert "rule ::= (part1 | part2)* part3+ part4?" in result
+
+def test_non_greedy_markers():
+    antlr = """
+    rule: part1*? part2+? part3??;
+    """
+    result = convert_antlr_to_ebnf(antlr)
+    assert "rule ::= part1* part2+ part3?" in result
+
+def test_lexer_commands():
+    antlr = r"""
+    WS: [ \t\r\n]+ -> skip;
+    COMMENT: '/*' .*? '*/' -> channel(HIDDEN);
+    """
+    result = convert_antlr_to_ebnf(antlr)
+    assert r"WS ::= [ \t\r\n]+" in result
+    assert "COMMENT ::= '/*' .* '*/'" in result
+
+def test_char_class_conversion():
+    antlr = """
+    TABLE: [tT][aA][bB][lL][eE];
+    FILE: [fF][iI][lL][eE];
+    MIXED: 'PREFIX' [sS][uU][fF][fF][iI][xX];
+    """
+    result = convert_antlr_to_ebnf(antlr)
+    assert "TABLE ::= 'TABLE'" in result
+    assert "FILE ::= 'FILE'" in result
+    assert "MIXED ::= 'PREFIX' 'SUFFIX'" in result
+
+def test_fragment_rules():
+    antlr = """
+    fragment DIGIT: [0-9];
+    NUMBER: DIGIT+;
+    """
+    result = convert_antlr_to_ebnf(antlr)
+    assert "DIGIT ::= [0-9]" in result
+    assert "NUMBER ::= DIGIT+" in result


### PR DESCRIPTION
This PR refines the ANTLR4 to W3C EBNF conversion script to support more advanced constructs required for high-quality railroad diagram generation. Specifically, it now handles cardinality markers, simplifies non-greedy markers, converts case-insensitive lexer rules into readable terminal strings, and filters out internal lexer commands. These changes complete Phase 1.1 of the RAILROAD_ROADMAP.md.

Fixes #221

---
*PR created automatically by Jules for task [6064546623736181443](https://jules.google.com/task/6064546623736181443) started by @chatelao*