### PR TITLE
Implement rule tagging and MasterFile extraction for railroad diagrams

### DIFF
--- a/RAILROAD_ROADMAP.md
+++ b/RAILROAD_ROADMAP.md
@@ -9,10 +9,13 @@ This document outlines the tasks required to implement the automated railroad di
     - [x] 1.1.3 Implement grouping and alternatives mapping.
     - [x] 1.1.4 Implement lexer rule to terminal string conversion.
     - [x] 1.1.5 **Early Testing:** Implement unit tests for each mapping component.
-- [ ] 1.2 Implement rule tagging system in `WebFocusReport.g4` (e.g., `// @internal`).
+- [x] 1.2 Implement rule tagging system in `WebFocusReport.g4` and `MasterFile.g4` (e.g., `// @internal`, `// @inline`).
 - [ ] 1.3 Develop automated rule pruning and inlining logic for technical/internal rules.
-    - [ ] 1.3.1 **Early Testing:** Implement unit tests for inlining logic (handling recursion and name collisions).
-- [ ] 1.4 Support `MasterFile.g4` extraction.
+    - [ ] 1.3.1 Implement `[internal]` rule removal logic.
+    - [ ] 1.3.2 Implement `[inline]` rule substitution logic.
+    - [ ] 1.3.3 Handle recursive rule inlining and prevent infinite loops.
+    - [ ] 1.3.4 **Early Testing:** Implement unit tests for inlining and pruning logic.
+- [x] 1.4 Support `MasterFile.g4` extraction.
 - [ ] 1.5 **Drift Prevention:** Implement a "Grammar Coverage" check to ensure all non-internal rules are present in the EBNF output.
 
 ## Phase 2: Rendering (EBNF to Railroad SVGs)

--- a/scripts/antlr4_to_ebnf.py
+++ b/scripts/antlr4_to_ebnf.py
@@ -5,46 +5,44 @@ def convert_antlr_to_ebnf(antlr_content):
     """
     Converts ANTLR4 grammar content to W3C EBNF.
     """
-    # Remove comments but skip strings
-    antlr_content = remove_comments(antlr_content)
-
-    # Extract parser rules (start with lowercase)
-    parser_rules = re.findall(r'^\s*([a-z]\w*)\s*:\s*(.*?)\s*;', antlr_content, re.DOTALL | re.MULTILINE)
-
-    # Extract lexer rules (start with uppercase)
-    lexer_rules = re.findall(r'^\s*(fragment\s+)?([A-Z]\w*)\s*:\s*(.*?)\s*;', antlr_content, re.DOTALL | re.MULTILINE)
+    # Rule regex that handles strings correctly.
+    # It matches (optional fragment) name : body ;
+    # body can contain strings '...' or "..." or any character except ;
+    # We use a non-greedy match for the body but ensure it consumes full strings.
+    rule_regex = r'(?m)^\s*(fragment\s+)?([a-zA-Z]\w*)\s*:\s*((?:\'(?:\'\'|[^\'])*\'|"(?:\"\"|[^\"])*"|[^;])+)\s*;'
 
     ebnf_rules = []
 
-    for rule_name, body in parser_rules:
-        body = format_body(body)
-        ebnf_rules.append(f"{rule_name} ::= {body}")
+    for match in re.finditer(rule_regex, antlr_content):
+        fragment, name, body = match.groups()
+        start_pos = match.start()
 
-    for fragment, rule_name, body in lexer_rules:
-        body = format_body(body, is_lexer=True)
-        ebnf_rules.append(f"{rule_name} ::= {body}")
+        # Search for tags in the comments before this rule
+        prev_content = antlr_content[:start_pos]
+        last_semi = prev_content.rfind(';')
+        if last_semi == -1:
+            search_window = prev_content
+        else:
+            search_window = prev_content[last_semi:]
+
+        tags = re.findall(r'@\w+', search_window)
+
+        body = format_body(body, is_lexer=name[0].isupper())
+
+        tag_prefix = ""
+        if tags:
+            tag_prefix = "[" + ",".join(t[1:] for t in tags) + "] "
+
+        ebnf_rules.append(f"{tag_prefix}{name} ::= {body}")
 
     return "\n".join(ebnf_rules)
-
-def remove_comments(content):
-    """
-    Removes ANTLR4 comments while preserving strings.
-    """
-    pattern = r"'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\"|/\*.*?\*/|//[^\n]*"
-
-    def replace(match):
-        m = match.group(0)
-        if m.startswith('/') :
-            return ' '
-        return m
-
-    return re.sub(pattern, replace, content, flags=re.DOTALL)
 
 def format_body(body, is_lexer=False):
     """
     Formats the body of a rule for W3C EBNF.
     """
     # Remove ANTLR actions if any
+    # Using a simple non-nested approach for now as it's common in these grammars
     body = re.sub(r'\{.*?\}', '', body, flags=re.DOTALL)
 
     # Remove lexer commands

--- a/src/MasterFile.g4
+++ b/src/MasterFile.g4
@@ -30,14 +30,20 @@ compute_decl: COMPUTE_KW name_format EQUALS expression SEMICOLON (COMMA attr_val
 
 other_decl: ATTR EQUALS value (COMMA attr_val)* COMMA? TERMINATOR?;
 
+// @inline
 attr_val: assignment | value;
+// @inline
 assignment: ATTR EQUALS value;
 
+// @inline
 name_format: value (SLASH value)?;
 
+// @inline
 value: STRING | ATTR | UNQUOTED_VALUE;
 
+// @internal
 expression: expression_part+;
+// @internal
 expression_part: ATTR | UNQUOTED_VALUE | STRING | COMMA | EQUALS | SLASH | FILENAME_KW | SEGNAME_KW | FIELDNAME_KW | VARIABLE_KW | DEFINE_KW | COMPUTE_KW ;
 
 FILENAME_KW: [fF][iI][lL][eE][nN][aA][mM][eE] | [fF][iI][lL][eE];
@@ -49,6 +55,7 @@ VARIABLE_KW: [vV][aA][rR][iI][aA][bB][lL][eE];
 DEFINE_KW: [dD][eE][fF][iI][nN][eE];
 COMPUTE_KW: [cC][oO][mM][pP][uU][tT][eE];
 
+// @internal
 TERMINATOR: '$' ~[\r\n]* (WS* '$' ~[\r\n]*)*;
 
 COMMA: ',';

--- a/src/WebFocusReport.g4
+++ b/src/WebFocusReport.g4
@@ -2,14 +2,18 @@ grammar WebFocusReport;
 
 start: (request | dm_command | join_command | set_command | define_file | compound_layout_block)* EOF;
 
+// @inline
 request: table_file (verb_command | by_command | across_command | where_command | when_command | show_command | heading_command | footing_command | on_command | compute_command | recap_command | dm_command | STRING)* end_command;
 
 compound_layout_block: COMPOUND LAYOUT output_command (layout_statement)* end_command (request | dm_command | join_command | set_command | define_file)* COMPOUND END;
 
+// @inline
 layout_statement: (identifier | TYPE) EQ layout_value (COMMA layout_property)* (COMMA? DOLLAR)?;
 
+// @inline
 layout_property: (identifier | TYPE) EQ layout_value;
 
+// @inline
 layout_value: qualified_name
             | NUMBER
             | dm_float
@@ -106,22 +110,33 @@ dm_relational_op: EQ | NE | LE | GE | LT | GT | CONTAINS | OMITS | LIKE | EXCEED
                 | NOT LIKE | NOT SUB_OP LIKE
                 ;
 
+// @internal
 is_not_op: IS_NOT | IS NOT | IS SUB_OP NOT;
+// @internal
 is_from_op: IS_FROM | IS FROM | IS SUB_OP FROM;
+// @internal
 not_from_op: NOT_FROM | NOT FROM | NOT SUB_OP FROM;
+// @internal
 is_less_op: IS_LESS_THAN | IS LESS THAN | IS SUB_OP LESS THAN;
+// @internal
 is_more_op: IS_MORE_THAN | IS MORE_KW THAN | IS SUB_OP MORE_KW THAN;
+// @internal
 is_greater_op: IS_GREATER_THAN | IS GREATER THAN | IS SUB_OP GREATER THAN;
 
+// @inline
 dm_concat_expression: dm_additive_expression (CONCAT dm_additive_expression)*;
 
+// @inline
 dm_additive_expression: dm_multiplicative_expression ((ADD_OP | SUB_OP) dm_multiplicative_expression)*;
 
+// @inline
 dm_multiplicative_expression: dm_unary_expression ((MUL | SLASH) dm_unary_expression)*;
 
+// @inline
 dm_unary_expression: (ADD_OP | SUB_OP) dm_unary_expression
                    | dm_primary;
 
+// @inline
 dm_primary: NUMBER
           | dm_float
           | qualified_name '(' (dm_expression (COMMA dm_expression)*)? ')'
@@ -130,10 +145,13 @@ dm_primary: NUMBER
           | STRING
           | '(' dm_expression ')';
 
+// @inline
 dm_float: NUMBER DOT NUMBER;
 
+// @inline
 amper_var: AMPER_VAR;
 
+// @inline
 table_file: TABLE FILE qualified_name;
 
 verb_command: verb (field_list | asterisk);
@@ -194,8 +212,10 @@ output_command: (HOLD | PCHOLD | SAVE | SAVB) (AS qualified_name)? (FORMAT (NAME
 
 end_command: END;
 
+// @inline
 qualified_name: identifier (DOT identifier)*;
 
+// @internal
 identifier: NAME
           | prefix_operator
           | IS | CONTAINS | OMITS | LIKE | TOTAL | MISSING | INCLUDES | EXCLUDES | EXCEEDS | ALL
@@ -209,6 +229,7 @@ identifier: NAME
           | HIERARCHY | WHEN | SHOW | UP | DOWN
           ;
 
+// @internal
 prefix_operator: AVE | MIN | MAX | CNT | FST | LST | ASQ | MDN | MDE | PCT | RPCT | RNK | DST | TOT | SUM | CT;
 
 // Keywords

--- a/test/test_antlr4_to_ebnf.py
+++ b/test/test_antlr4_to_ebnf.py
@@ -90,3 +90,28 @@ def test_fragment_rules():
     result = convert_antlr_to_ebnf(antlr)
     assert "DIGIT ::= [0-9]" in result
     assert "NUMBER ::= DIGIT+" in result
+
+def test_tagging():
+    antlr = """
+    // @internal
+    rule1: 'body';
+
+    /* @inline */
+    rule2: 'other';
+
+    // @internal @inline
+    rule3: 'both';
+    """
+    result = convert_antlr_to_ebnf(antlr)
+    assert "[internal] rule1 ::= 'body'" in result
+    assert "[inline] rule2 ::= 'other'" in result
+    assert "[internal,inline] rule3 ::= 'both'" in result
+
+def test_semicolon_in_string():
+    antlr = """
+    SEMI: ';';
+    OTHER: 'abc;def';
+    """
+    result = convert_antlr_to_ebnf(antlr)
+    assert "SEMI ::= ';'" in result
+    assert "OTHER ::= 'abc;def'" in result


### PR DESCRIPTION
This change implements Phases 1.2 and 1.4 of the RAILROAD_ROADMAP.md. It enhances the ANTLR4 to EBNF conversion script to support rule tagging via comments and improves its robustness when encountering semicolons in lexer rules. It also applies these tags to the existing grammars and updates the roadmap with a more detailed breakdown of the next steps.

Fixes #223

---
*PR created automatically by Jules for task [6864761318572781177](https://jules.google.com/task/6864761318572781177) started by @chatelao*