### PR TITLE
Implement Automated Rule Pruning and Inlining for Railroad Diagrams

### DIFF
--- a/RAILROAD_ROADMAP.md
+++ b/RAILROAD_ROADMAP.md
@@ -11,10 +11,11 @@ This document outlines the tasks required to implement the automated railroad di
     - [x] 1.1.5 **Early Testing:** Implement unit tests for each mapping component.
 - [x] 1.2 Implement rule tagging system in `WebFocusReport.g4` and `MasterFile.g4` (e.g., `// @internal`, `// @inline`).
 - [ ] 1.3 Develop automated rule pruning and inlining logic for technical/internal rules.
-    - [ ] 1.3.1 Implement `[internal]` rule removal logic.
-    - [ ] 1.3.2 Implement `[inline]` rule substitution logic.
-    - [ ] 1.3.3 Handle recursive rule inlining and prevent infinite loops.
-    - [ ] 1.3.4 **Early Testing:** Implement unit tests for inlining and pruning logic.
+    - [ ] 1.3.1 Implement multi-pass rule collection and `[internal]` rule removal.
+    - [ ] 1.3.2 Implement `[inline]` rule substitution logic (parenthesized replacement).
+    - [ ] 1.3.3 Add recursion protection to prevent infinite inlining loops.
+    - [ ] 1.3.4 Update existing unit tests to verify pruning/inlining behavior.
+    - [ ] 1.3.5 **Verification:** Run the updated script on `WebFocusReport.g4` and verify reduced rule count in EBNF.
 - [x] 1.4 Support `MasterFile.g4` extraction.
 - [ ] 1.5 **Drift Prevention:** Implement a "Grammar Coverage" check to ensure all non-internal rules are present in the EBNF output.
 

--- a/scripts/antlr4_to_ebnf.py
+++ b/scripts/antlr4_to_ebnf.py
@@ -1,18 +1,24 @@
 import re
 import sys
 
+class Rule:
+    def __init__(self, name, body, tags, is_fragment=False, is_lexer=False):
+        self.name = name
+        self.body = body
+        self.tags = tags
+        self.is_fragment = is_fragment
+        self.is_lexer = is_lexer
+
 def convert_antlr_to_ebnf(antlr_content):
     """
-    Converts ANTLR4 grammar content to W3C EBNF.
+    Converts ANTLR4 grammar content to W3C EBNF with pruning and inlining.
     """
     # Rule regex that handles strings correctly.
-    # It matches (optional fragment) name : body ;
-    # body can contain strings '...' or "..." or any character except ;
-    # We use a non-greedy match for the body but ensure it consumes full strings.
     rule_regex = r'(?m)^\s*(fragment\s+)?([a-zA-Z]\w*)\s*:\s*((?:\'(?:\'\'|[^\'])*\'|"(?:\"\"|[^\"])*"|[^;])+)\s*;'
 
-    ebnf_rules = []
+    rules = {}
 
+    # 1. Extraction
     for match in re.finditer(rule_regex, antlr_content):
         fragment, name, body = match.groups()
         start_pos = match.start()
@@ -25,15 +31,67 @@ def convert_antlr_to_ebnf(antlr_content):
         else:
             search_window = prev_content[last_semi:]
 
-        tags = re.findall(r'@\w+', search_window)
+        tags = [t[1:] for t in re.findall(r'@\w+', search_window)]
 
-        body = format_body(body, is_lexer=name[0].isupper())
+        is_lexer = name[0].isupper()
+        body = format_body(body, is_lexer=is_lexer)
 
-        tag_prefix = ""
-        if tags:
-            tag_prefix = "[" + ",".join(t[1:] for t in tags) + "] "
+        rules[name] = Rule(name, body, tags, is_fragment=bool(fragment), is_lexer=is_lexer)
 
-        ebnf_rules.append(f"{tag_prefix}{name} ::= {body}")
+    # 2. Inlining
+    to_inline = [name for name, rule in rules.items() if 'inline' in rule.tags or 'internal' in rule.tags]
+    actually_inlined = set()
+
+    # Pre-wrap bodies of rules that will be inlined if they are complex
+    for name in to_inline:
+        rule = rules[name]
+        body = rule.body.strip()
+        # Direct recursion check for pre-wrapping
+        if re.search(rf'\b{name}\b', body):
+            continue
+
+        if ' ' in body or '|' in body:
+            if not (body.startswith('(') and body.endswith(')')):
+                rule.body = f"( {body} )"
+
+    # Multiple passes to handle nested inlining
+    max_passes = 10
+    for _ in range(max_passes):
+        any_changed = False
+        for name_to_inline in to_inline:
+            rule_to_inline = rules[name_to_inline]
+            inline_body = rule_to_inline.body
+
+            # If name_to_inline appears in its own body, we have direct recursion.
+            # Inlining it would be infinite.
+            if re.search(rf'\b{name_to_inline}\b', inline_body):
+                continue
+
+            pattern = re.compile(rf'\b{name_to_inline}\b')
+            for name, rule in rules.items():
+                if name == name_to_inline:
+                    continue
+
+                # Using a lambda for replacement to avoid backslash escaping issues in re.sub
+                new_body = pattern.sub(lambda m: inline_body, rule.body)
+                if new_body != rule.body:
+                    rule.body = new_body
+                    any_changed = True
+                    actually_inlined.add(name_to_inline)
+        if not any_changed:
+            break
+
+    # 3. Final Formatting
+    ebnf_rules = []
+    for name, rule in rules.items():
+        # A rule is removed if it was successfully inlined into something else,
+        # OR if it was tagged for inlining/pruning and is NOT recursive (safe to remove).
+        if name in actually_inlined:
+            continue
+        if (name in to_inline) and not re.search(rf'\b{name}\b', rule.body):
+            continue
+
+        ebnf_rules.append(f"{name} ::= {rule.body}")
 
     return "\n".join(ebnf_rules)
 
@@ -42,7 +100,6 @@ def format_body(body, is_lexer=False):
     Formats the body of a rule for W3C EBNF.
     """
     # Remove ANTLR actions if any
-    # Using a simple non-nested approach for now as it's common in these grammars
     body = re.sub(r'\{.*?\}', '', body, flags=re.DOTALL)
 
     # Remove lexer commands

--- a/test/test_antlr4_to_ebnf.py
+++ b/test/test_antlr4_to_ebnf.py
@@ -91,21 +91,46 @@ def test_fragment_rules():
     assert "DIGIT ::= [0-9]" in result
     assert "NUMBER ::= DIGIT+" in result
 
-def test_tagging():
+def test_pruning_and_inlining():
     antlr = """
     // @internal
-    rule1: 'body';
+    rule1: 'internal_body';
+
+    // @inline
+    rule2: 'inline_body';
+
+    // @inline
+    rule3: 'with' 'spaces';
 
     /* @inline */
-    rule2: 'other';
+    rule4: rule2 | 'other';
 
-    // @internal @inline
-    rule3: 'both';
+    start: rule1 rule2 rule3 rule4;
     """
     result = convert_antlr_to_ebnf(antlr)
-    assert "[internal] rule1 ::= 'body'" in result
-    assert "[inline] rule2 ::= 'other'" in result
-    assert "[internal,inline] rule3 ::= 'both'" in result
+
+    # rule1, rule2, rule3, rule4 should not be in the output as top-level rules
+    assert "rule1 ::=" not in result
+    assert "rule2 ::=" not in result
+    assert "rule3 ::=" not in result
+    assert "rule4 ::=" not in result
+
+    # Check inlining in start
+    # rule1 was internal, so it is inlined (currently we inline both)
+    assert "start ::= 'internal_body' 'inline_body' ( 'with' 'spaces' ) ( 'inline_body' | 'other' )" in result
+
+def test_recursion_protection():
+    antlr = """
+    // @inline
+    a: a 'x' | 'y';
+
+    start: a;
+    """
+    result = convert_antlr_to_ebnf(antlr)
+    # a should NOT be inlined into itself or start if it causes recursion
+    # our current logic says: if name_to_inline in inline_body, don't inline.
+    assert "a ::= a 'x' | 'y'" in result
+    assert "start ::= a" in result
 
 def test_semicolon_in_string():
     antlr = """


### PR DESCRIPTION
Implemented automated rule pruning and inlining in the ANTLR4 to EBNF conversion script. This allows for cleaner railroad diagrams by substituting technical or internal rules directly into their parent rules, while preventing infinite recursion for recursive rules. The roadmap was also updated to reflect the granular steps completed.

Fixes #225

---
*PR created automatically by Jules for task [9988492649113538214](https://jules.google.com/task/9988492649113538214) started by @chatelao*