### PR TITLE
Implement Grammar Coverage Check and Refine Roadmap

### DIFF
--- a/RAILROAD_ROADMAP.md
+++ b/RAILROAD_ROADMAP.md
@@ -10,17 +10,20 @@ This document outlines the tasks required to implement the automated railroad di
     - [x] 1.1.4 Implement lexer rule to terminal string conversion.
     - [x] 1.1.5 **Early Testing:** Implement unit tests for each mapping component.
 - [x] 1.2 Implement rule tagging system in `WebFocusReport.g4` and `MasterFile.g4` (e.g., `// @internal`, `// @inline`).
-- [ ] 1.3 Develop automated rule pruning and inlining logic for technical/internal rules.
-    - [ ] 1.3.1 Implement multi-pass rule collection and `[internal]` rule removal.
-    - [ ] 1.3.2 Implement `[inline]` rule substitution logic (parenthesized replacement).
-    - [ ] 1.3.3 Add recursion protection to prevent infinite inlining loops.
-    - [ ] 1.3.4 Update existing unit tests to verify pruning/inlining behavior.
-    - [ ] 1.3.5 **Verification:** Run the updated script on `WebFocusReport.g4` and verify reduced rule count in EBNF.
+- [x] 1.3 Develop automated rule pruning and inlining logic for technical/internal rules.
+    - [x] 1.3.1 Implement multi-pass rule collection and `[internal]` rule removal.
+    - [x] 1.3.2 Implement `[inline]` rule substitution logic (parenthesized replacement).
+    - [x] 1.3.3 Add recursion protection to prevent infinite inlining loops.
+    - [x] 1.3.4 Update existing unit tests to verify pruning/inlining behavior.
+    - [x] 1.3.5 **Verification:** Run the updated script on `WebFocusReport.g4` and verify reduced rule count in EBNF.
 - [x] 1.4 Support `MasterFile.g4` extraction.
-- [ ] 1.5 **Drift Prevention:** Implement a "Grammar Coverage" check to ensure all non-internal rules are present in the EBNF output.
+- [x] 1.5 **Drift Prevention:** Implement a "Grammar Coverage" check to ensure all non-internal rules are present in the EBNF output.
 
 ## Phase 2: Rendering (EBNF to Railroad SVGs)
 - [ ] 2.1 Integrate Gunther Rademacher's RR tool into the toolchain.
+    - [ ] 2.1.1 Verify Java environment availability (required for RR tool).
+    - [ ] 2.1.2 Download/Provision Gunther Rademacher's RR tool (`rr.war` or executable jar).
+    - [ ] 2.1.3 Implement a basic Python wrapper to execute the RR tool on generated EBNF.
 - [ ] 2.2 Configure visual styles (colors, fonts, shapes) to match Oracle documentation style.
 - [ ] 2.3 Create a template for the documentation HTML container.
 - [ ] 2.4 **Verification:** Automated check that generated SVGs are valid and non-empty.

--- a/scripts/antlr4_to_ebnf.py
+++ b/scripts/antlr4_to_ebnf.py
@@ -95,6 +95,38 @@ def convert_antlr_to_ebnf(antlr_content):
 
     return "\n".join(ebnf_rules)
 
+def check_coverage(antlr_content, ebnf_content):
+    """
+    Checks if all non-internal/non-inlined rules are present in the EBNF output.
+    Returns a list of missing rules.
+    """
+    rule_regex = r'(?m)^\s*(fragment\s+)?([a-zA-Z]\w*)\s*:'
+
+    # Extract rule names and their tags from ANTLR
+    rules_metadata = {}
+    for match in re.finditer(rule_regex, antlr_content):
+        name = match.group(2)
+        start_pos = match.start()
+
+        prev_content = antlr_content[:start_pos]
+        last_semi = prev_content.rfind(';')
+        search_window = prev_content[last_semi:] if last_semi != -1 else prev_content
+        tags = [t[1:] for t in re.findall(r'@\w+', search_window)]
+
+        rules_metadata[name] = tags
+
+    # Extract rule names from EBNF
+    ebnf_rule_names = set(re.findall(r'^(\w+)\s*::=', ebnf_content, re.MULTILINE))
+
+    missing = []
+    for name, tags in rules_metadata.items():
+        if 'internal' in tags or 'inline' in tags:
+            continue
+        if name not in ebnf_rule_names:
+            missing.append(name)
+
+    return missing
+
 def format_body(body, is_lexer=False):
     """
     Formats the body of a rule for W3C EBNF.
@@ -130,10 +162,27 @@ def convert_char_classes(body):
     return re.sub(r'(\[([a-zA-Z])([a-zA-Z])\])+', replace_sequence, body)
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        content = sys.stdin.read()
-    else:
-        with open(sys.argv[1], 'r') as f:
-            content = f.read()
+    import argparse
+    parser = argparse.ArgumentParser(description='Convert ANTLR4 to W3C EBNF')
+    parser.add_argument('input', nargs='?', help='Input ANTLR4 file')
+    parser.add_argument('--check', action='store_true', help='Check grammar coverage')
 
-    print(convert_antlr_to_ebnf(content))
+    args = parser.parse_args()
+
+    if args.input:
+        with open(args.input, 'r') as f:
+            content = f.read()
+    else:
+        content = sys.stdin.read()
+
+    ebnf = convert_antlr_to_ebnf(content)
+
+    if args.check:
+        missing = check_coverage(content, ebnf)
+        if missing:
+            print(f"Error: Missing rules in EBNF output: {', '.join(missing)}", file=sys.stderr)
+            sys.exit(1)
+        else:
+            print("Coverage check passed.", file=sys.stderr)
+
+    print(ebnf)

--- a/test/test_antlr4_to_ebnf.py
+++ b/test/test_antlr4_to_ebnf.py
@@ -1,5 +1,5 @@
 import pytest
-from scripts.antlr4_to_ebnf import convert_antlr_to_ebnf
+from scripts.antlr4_to_ebnf import convert_antlr_to_ebnf, check_coverage
 
 def test_basic_conversion():
     antlr = """
@@ -140,3 +140,46 @@ def test_semicolon_in_string():
     result = convert_antlr_to_ebnf(antlr)
     assert "SEMI ::= ';'" in result
     assert "OTHER ::= 'abc;def'" in result
+
+def test_coverage_check_all_present():
+    antlr = """
+    rule1: 'A';
+    rule2: 'B';
+    """
+    ebnf = convert_antlr_to_ebnf(antlr)
+    missing = check_coverage(antlr, ebnf)
+    assert missing == []
+
+def test_coverage_check_missing_rule():
+    antlr = """
+    rule1: 'A';
+    rule2: 'B';
+    """
+    # Simulate ebnf missing rule2
+    ebnf = "rule1 ::= 'A'"
+    missing = check_coverage(antlr, ebnf)
+    assert missing == ["rule2"]
+
+def test_coverage_check_ignores_internal_and_inline():
+    antlr = """
+    // @internal
+    rule1: 'A';
+    // @inline
+    rule2: 'B';
+    rule3: 'C';
+    """
+    # ebnf will only contain rule3
+    ebnf = "rule3 ::= 'C'"
+    missing = check_coverage(antlr, ebnf)
+    assert missing == []
+
+def test_coverage_check_recursive_inline_preserved():
+    antlr = """
+    // @inline
+    a: a 'x' | 'y';
+    """
+    ebnf = convert_antlr_to_ebnf(antlr)
+    # Since 'a' is recursive, it is NOT inlined and should remain in EBNF.
+    assert "a ::= a 'x' | 'y'" in ebnf
+    missing = check_coverage(antlr, ebnf)
+    assert missing == []


### PR DESCRIPTION
I have implemented the Grammar Coverage check (Phase 1.5) in the ANTLR4 to EBNF conversion tool. This check ensures that all non-internal/non-inlined rules from the source grammar are preserved in the output, preventing documentation drift. 

Additionally, I have updated the `RAILROAD_ROADMAP.md` to reflect the completion of the automated pruning/inlining logic (Phase 1.3) and this new coverage check. I also broke down Phase 2.1 (RR tool integration) into smaller, more actionable steps to guide future work.

Key changes:
- `scripts/antlr4_to_ebnf.py`: Added `check_coverage` function and updated the CLI to use `argparse` with a `--check` flag.
- `test/test_antlr4_to_ebnf.py`: Added 4 new tests to verify coverage check logic, including handling of recursive rules.
- `RAILROAD_ROADMAP.md`: Updated status of Phase 1 and refined Phase 2.1.

Fixes #227

---
*PR created automatically by Jules for task [6703669444145543269](https://jules.google.com/task/6703669444145543269) started by @chatelao*