### PR TITLE
Implement Oracle-style visual configuration for railroad diagrams

### DIFF
--- a/RAILROAD_ROADMAP.md
+++ b/RAILROAD_ROADMAP.md
@@ -25,6 +25,9 @@ This document outlines the tasks required to implement the automated railroad di
     - [x] 2.1.2 Download/Provision Gunther Rademacher's RR tool (`rr.war` or executable jar).
     - [x] 2.1.3 Implement a basic Python wrapper to execute the RR tool on generated EBNF.
 - [ ] 2.2 Configure visual styles (colors, fonts, shapes) to match Oracle documentation style.
+    - [ ] 2.2.1 Research and define Oracle-style color palette and fonts (CSS properties).
+    - [ ] 2.2.2 Update `RRTool` wrapper to support additional styling flags (`-suppressebnf`, `-offset`).
+    - [ ] 2.2.3 Update `generate_railroad.py` to expose styling flags and implement CSS post-processing for XHTML to match Oracle style.
 - [x] 2.3 Create a template for the documentation HTML container.
 - [x] 2.4 **Verification:** Automated check that generated SVGs are valid and non-empty.
 

--- a/docs/MasterFile.xhtml
+++ b/docs/MasterFile.xhtml
@@ -189,7 +189,16 @@
       -o-user-select: none;
       -ms-user-select: none;
     }
-  </style><svg xmlns="http://www.w3.org/2000/svg">
+
+    /* Oracle Style Overrides */
+    .line                 { stroke: #333333 !important; }
+    .bold-line            { stroke: #111111 !important; }
+    .filled               { fill: #333333 !important; }
+    rect.terminal         { fill: #f2f2f2 !important; stroke: #333333 !important; }
+    rect.nonterminal      { fill: #ffffff !important; stroke: #333333 !important; }
+    text.terminal         { fill: #000000 !important; }
+    text.nonterminal      { fill: #000000 !important; }
+      </style><svg xmlns="http://www.w3.org/2000/svg">
          <defs>
             <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";

--- a/docs/WebFocusReport.xhtml
+++ b/docs/WebFocusReport.xhtml
@@ -189,7 +189,16 @@
       -o-user-select: none;
       -ms-user-select: none;
     }
-  </style><svg xmlns="http://www.w3.org/2000/svg">
+
+    /* Oracle Style Overrides */
+    .line                 { stroke: #333333 !important; }
+    .bold-line            { stroke: #111111 !important; }
+    .filled               { fill: #333333 !important; }
+    rect.terminal         { fill: #f2f2f2 !important; stroke: #333333 !important; }
+    rect.nonterminal      { fill: #ffffff !important; stroke: #333333 !important; }
+    text.terminal         { fill: #000000 !important; }
+    text.nonterminal      { fill: #000000 !important; }
+      </style><svg xmlns="http://www.w3.org/2000/svg">
          <defs>
             <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";

--- a/scripts/generate_railroad.py
+++ b/scripts/generate_railroad.py
@@ -2,6 +2,7 @@ import os
 import sys
 import subprocess
 import argparse
+import re
 
 # Add src to sys.path to find rr_wrapper
 sys.path.append(os.path.join(os.getcwd(), "src"))
@@ -18,7 +19,35 @@ def is_up_to_date(source_path, target_path):
         return False
     return os.path.getmtime(target_path) > os.path.getmtime(source_path)
 
-def generate_docs(grammars=None, output_dir="docs", ebnf_dir="build/ebnf", color="#4D88FF", width=None, force=False):
+def post_process_xhtml(filepath):
+    """Injects custom CSS into the generated XHTML to match Oracle style."""
+    print(f"Post-processing {filepath} for Oracle styling...")
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    # Define Oracle-inspired style overrides
+    oracle_styles = """
+    /* Oracle Style Overrides */
+    .line                 { stroke: #333333 !important; }
+    .bold-line            { stroke: #111111 !important; }
+    .filled               { fill: #333333 !important; }
+    rect.terminal         { fill: #f2f2f2 !important; stroke: #333333 !important; }
+    rect.nonterminal      { fill: #ffffff !important; stroke: #333333 !important; }
+    text.terminal         { fill: #000000 !important; }
+    text.nonterminal      { fill: #000000 !important; }
+    """
+
+    # The RR tool embeds CSS in every SVG. We'll append our overrides to the main head style block
+    # and also use !important to ensure they take precedence.
+    if "</style>" in content:
+        # Insert into the first style block in the head
+        content = content.replace("</style>", oracle_styles + "  </style>", 1)
+
+    with open(filepath, "w") as f:
+        f.write(content)
+
+def generate_docs(grammars=None, output_dir="docs", ebnf_dir="build/ebnf", color="#4D88FF", width=None,
+                  suppress_ebnf=False, offset=None, force=False):
     src_dir = "src"
 
     if not grammars:
@@ -54,8 +83,10 @@ def generate_docs(grammars=None, output_dir="docs", ebnf_dir="build/ebnf", color
             subprocess.run(["python3", "scripts/antlr4_to_ebnf.py", grammar_path, "--check"], stdout=f, check=True)
 
         print(f"Generating Railroad Diagram for {grammar_name}...")
-        rr.generate(ebnf_path, out_path=xhtml_path, color=color, width=width)
+        rr.generate(ebnf_path, out_path=xhtml_path, color=color, width=width,
+                    suppress_ebnf=suppress_ebnf, offset=offset)
 
+        post_process_xhtml(xhtml_path)
         validate_output(xhtml_path)
         generated_files.append((grammar_name, xhtml_name))
 
@@ -116,6 +147,8 @@ if __name__ == "__main__":
     parser.add_argument('--ebnf-dir', default='build/ebnf', help='Directory for intermediate EBNF files (default: build/ebnf)')
     parser.add_argument('--color', default='#4D88FF', help='Base color for diagrams (default: #4D88FF)')
     parser.add_argument('--width', type=int, help='Try to break graphics into multiple lines if width exceeds this value')
+    parser.add_argument('--suppress-ebnf', action='store_true', help='Do not show EBNF next to generated diagrams')
+    parser.add_argument('--offset', type=int, help='Hue offset to secondary color in degrees')
     parser.add_argument('--force', '-f', action='store_true', help='Force regeneration of all diagrams')
 
     args = parser.parse_args()
@@ -126,5 +159,7 @@ if __name__ == "__main__":
         ebnf_dir=args.ebnf_dir,
         color=args.color,
         width=args.width,
+        suppress_ebnf=args.suppress_ebnf,
+        offset=args.offset,
         force=args.force
     )

--- a/src/rr_wrapper.py
+++ b/src/rr_wrapper.py
@@ -16,7 +16,7 @@ class RRTool:
         if not os.path.exists(war_path):
             raise FileNotFoundError(f"RR tool not found at {war_path}. Run scripts/provision_rr.py first.")
 
-    def generate(self, ebnf_path, out_path=None, color=None, width=None, options=None):
+    def generate(self, ebnf_path, out_path=None, color=None, width=None, suppress_ebnf=False, offset=None, options=None):
         """
         Executes the RR tool on the given EBNF file.
         """
@@ -28,6 +28,10 @@ class RRTool:
             cmd.append(f"-color:{color}")
         if width:
             cmd.append(f"-width:{width}")
+        if suppress_ebnf:
+            cmd.append("-suppressebnf")
+        if offset is not None:
+            cmd.append(f"-offset:{offset}")
 
         if options:
             for opt in options:


### PR DESCRIPTION
Implemented visual customization for railroad diagrams to match Oracle's documentation style. This involved:
- Decomposing the roadmap task for visual styling into actionable sub-tasks.
- Enhancing the `RRTool` wrapper in `src/rr_wrapper.py` to support `-suppressebnf` and `-offset` flags.
- Updating `scripts/generate_railroad.py` to expose these flags and implement a `post_process_xhtml` function.
- The `post_process_xhtml` function injects a custom `<style>` block into the generated XHTML files, using `!important` to override the RR tool's default styles for terminals, non-terminals, and lines with Oracle-inspired colors (light grey/white backgrounds and dark grey strokes).
- Verified the end-to-end pipeline and the visual output via integration tests and Playwright-based visual verification.

Fixes #239

---
*PR created automatically by Jules for task [6927079498204709991](https://jules.google.com/task/6927079498204709991) started by @chatelao*