### PR TITLE
Implement Railroad Diagram UX Improvements

### DIFF
--- a/RAILROAD_ROADMAP.md
+++ b/RAILROAD_ROADMAP.md
@@ -52,4 +52,6 @@ This document outlines the tasks required to implement the automated railroad di
 
 ## Phase 6: User Experience & Navigation
 - [x] 6.1 Add generation metadata (date, version) to the documentation index.
-- [ ] 6.2 Integrate links to railroad diagrams into the project README.
+- [x] 6.2 Integrate links to railroad diagrams into the project README.
+- [x] 6.3 Add 'Back to Index' navigation to generated diagrams.
+- [ ] 6.4 Implement rule-filtering capability in grammar documentation.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ The transpiler moves beyond simple syntax parsing to understand the semantic con
 - `DESIGN.md`: Detailed design, transpiler pipeline, and tech stack (ANTLR4, SSA-IR, Jinja2).
 - `ROADMAP.md`: Planned and accomplished steps for the migration engine.
 - `TECHNICAL_DEBTS.md`: Log of technical debts and architectural shifts.
+- `RAILROAD_ROADMAP.md`: Tasks for automated railroad diagram generation.
+
+## Syntax Documentation
+
+Visual railroad diagrams for the supported WebFOCUS grammar are available at:
+[https://chatelao.github.io/web-focus-benf/](https://chatelao.github.io/web-focus-benf/)
+
 - `/src/`: Transpiler source code.
 - `/test/`: Test suite and real-world samples.
 - `/specifications/`: Formal WebFOCUS language manuals (Markdown).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,5 @@
 # ROADMAP
-- [ ] 0.98 Implement a next modest, feasible and reasonable RAILROAD_ROADMAP.md step (#247)
+- [x] 0.98 Implement a next modest, feasible and reasonable RAILROAD_ROADMAP.md step (#247) (completed at 2026-05-01 20:30:15)
 - [x] 0.97 Implement a next modest, feasible and reasonable RAILROAD_ROADMAP.md step (#245) (completed at 2026-05-01 19:59:24)
 - [ ] 0.96 Implement a next modest, feasible and reasonable RAILROAD_ROADMAP.md step
 - [x] 0.95 Implement a next modest, feasible and reasonable RAILROAD_ROADMAP.md step (#243) (completed at 2026-05-01 16:48:21)

--- a/docs/MasterFile.xhtml
+++ b/docs/MasterFile.xhtml
@@ -198,6 +198,23 @@
     rect.nonterminal      { fill: #ffffff !important; stroke: #444444 !important; stroke-width: 1.5 !important; }
     text.terminal         { fill: #002b80 !important; font-weight: bold !important; font-family: 'Verdana', sans-serif !important; }
     text.nonterminal      { fill: #222222 !important; font-family: 'Verdana', sans-serif !important; }
+
+    /* Navigation Bar */
+    .nav-bar {
+        background-color: #002b80;
+        padding: 10px 20px;
+        margin-bottom: 20px;
+        border-radius: 4px;
+        font-family: 'Verdana', sans-serif;
+    }
+    .nav-bar a {
+        color: #ffffff;
+        text-decoration: none;
+        font-weight: bold;
+    }
+    .nav-bar a:hover {
+        text-decoration: underline;
+    }
       </style><svg xmlns="http://www.w3.org/2000/svg">
          <defs>
             <style type="text/css">
@@ -229,6 +246,7 @@
   </style>
          </defs></svg></head>
    <body>
+      <div class="nav-bar"><a href="index.html">&larr; Back to Index</a></div>
       <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="start">start:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="211" height="71">
          <defs>
             <style type="text/css">

--- a/docs/WebFocusReport.xhtml
+++ b/docs/WebFocusReport.xhtml
@@ -198,6 +198,23 @@
     rect.nonterminal      { fill: #ffffff !important; stroke: #444444 !important; stroke-width: 1.5 !important; }
     text.terminal         { fill: #002b80 !important; font-weight: bold !important; font-family: 'Verdana', sans-serif !important; }
     text.nonterminal      { fill: #222222 !important; font-family: 'Verdana', sans-serif !important; }
+
+    /* Navigation Bar */
+    .nav-bar {
+        background-color: #002b80;
+        padding: 10px 20px;
+        margin-bottom: 20px;
+        border-radius: 4px;
+        font-family: 'Verdana', sans-serif;
+    }
+    .nav-bar a {
+        color: #ffffff;
+        text-decoration: none;
+        font-weight: bold;
+    }
+    .nav-bar a:hover {
+        text-decoration: underline;
+    }
       </style><svg xmlns="http://www.w3.org/2000/svg">
          <defs>
             <style type="text/css">
@@ -229,6 +246,7 @@
   </style>
          </defs></svg></head>
    <body>
+      <div class="nav-bar"><a href="index.html">&larr; Back to Index</a></div>
       <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="start">start:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="865" height="3931">
          <defs>
             <style type="text/css">

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@
 <body>
     <h1>WebFocus Syntax Railroad Diagrams</h1>
     <p>Visual representation of the WebFocus grammars.</p>
-    <div class="metadata">Generated on: 2026-05-01 19:08:03</div>
+    <div class="metadata">Generated on: 2026-05-01 20:43:14</div>
     <ul>
         <li><a href="WebFocusReport.xhtml">WebFocusReport.g4</a></li><li><a href="MasterFile.xhtml">MasterFile.g4</a></li>
     </ul>

--- a/scripts/generate_railroad.py
+++ b/scripts/generate_railroad.py
@@ -36,6 +36,23 @@ def post_process_xhtml(filepath):
     rect.nonterminal      { fill: #ffffff !important; stroke: #444444 !important; stroke-width: 1.5 !important; }
     text.terminal         { fill: #002b80 !important; font-weight: bold !important; font-family: 'Verdana', sans-serif !important; }
     text.nonterminal      { fill: #222222 !important; font-family: 'Verdana', sans-serif !important; }
+
+    /* Navigation Bar */
+    .nav-bar {
+        background-color: #002b80;
+        padding: 10px 20px;
+        margin-bottom: 20px;
+        border-radius: 4px;
+        font-family: 'Verdana', sans-serif;
+    }
+    .nav-bar a {
+        color: #ffffff;
+        text-decoration: none;
+        font-weight: bold;
+    }
+    .nav-bar a:hover {
+        text-decoration: underline;
+    }
     """
 
     # The RR tool embeds CSS in every SVG. We'll append our overrides to the main head style block
@@ -43,6 +60,10 @@ def post_process_xhtml(filepath):
     if "</style>" in content:
         # Insert into the first style block in the head
         content = content.replace("</style>", oracle_styles + "  </style>", 1)
+
+    # Inject navigation bar at the beginning of body
+    nav_bar_html = '<div class="nav-bar"><a href="index.html">&larr; Back to Index</a></div>'
+    content = content.replace("<body>", f"<body>\n      {nav_bar_html}", 1)
 
     with open(filepath, "w") as f:
         f.write(content)


### PR DESCRIPTION
Implemented modest and feasible steps from Phase 6 of the RAILROAD_ROADMAP.md. 

Key changes:
1.  **README Integration:** Added a "Syntax Documentation" section to `README.md` with a direct link to the GitHub Pages hosted diagrams.
2.  **Diagram Navigation:** Modified `scripts/generate_railroad.py` to inject a navigation bar into every generated XHTML file. This bar includes a "Back to Index" link, improving usability when browsing multiple grammars.
3.  **Oracle-Style Theming:** Updated the injected CSS in the generation script to style the new navigation bar consistently with the overall Oracle-inspired theme.
4.  **Roadmap Update:** Marked tasks 6.2 and 6.3 as complete in `RAILROAD_ROADMAP.md` and added 6.4 ("Implement rule-filtering capability") as a future goal.
5.  **Documentation Regeneration:** Ran the updated generation script to ensure the `docs/` directory is immediately up-to-date with these improvements.

Verification:
- Full test suite passed (218 tests).
- Visual verification using Playwright confirmed the presence and functionality of the new navigation bar and the correctness of the README link.

Fixes #247

---
*PR created automatically by Jules for task [3159657254244268391](https://jules.google.com/task/3159657254244268391) started by @chatelao*