### PR TITLE
Implement MERGE Emission and Roadmap Breakdown

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -197,9 +197,18 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [x] 5.1.3.10.3 Support `PAGE-BREAK` option for `ON field`.
       - [x] 5.1.3.10.4 Support `DRILLTHROUGH` in `SET STYLE` blocks.
   - [ ] 5.1.4 Semantic Parity: Verify that ASG and IR transformations preserve source semantics.
-    - [ ] 5.1.4.1 Symbol Resolution Validation: Ensure all field and variable references resolve correctly.
-    - [ ] 5.1.4.2 Type Consistency: Verify inferred types match legacy expectations.
-    - [ ] 5.1.4.3 Constant Folding Parity: Ensure constant expressions are evaluated identically.
+    - [ ] 5.1.4.1 Symbol Resolution Validation:
+      - [ ] 5.1.4.1.1 Global vs. Local scope resolution for AmperVars.
+      - [ ] 5.1.4.1.2 Multi-segment field resolution in joined Master Files.
+      - [ ] 5.1.4.1.3 Virtual field shadowing rules (DEFINE vs. Master File).
+    - [ ] 5.1.4.2 Type Consistency:
+      - [ ] 5.1.4.2.1 Numeric precision mapping (I, F, D, P to PostgreSQL).
+      - [ ] 5.1.4.2.2 Alpha-numeric string truncation and padding semantics.
+      - [ ] 5.1.4.2.3 Date/Time format conversion parity.
+    - [ ] 5.1.4.3 Constant Folding Parity:
+      - [ ] 5.1.4.3.1 Arithmetic expression folding.
+      - [ ] 5.1.4.3.2 Character concatenation folding.
+      - [ ] 5.1.4.3.3 Boolean logic short-circuiting parity.
 - [ ] **5.2 Sample Validation:**
   - [x] 5.2.1 Core Samples: Validate transpiler output against samples in `test/samples/`. (Verified via `test/test_core_samples.py`)
   - [ ] 5.2.2 Documentation Examples: Validate against samples in `test/documentation_examples/`. (Verified via `test/test_documentation_examples.py`)
@@ -211,7 +220,7 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [ ] 5.2.2.3.3 End-to-end PL/pgSQL emission for hierarchical report.
     - [ ] 5.2.2.4 Project 4: Data Merge.
       - [x] 5.2.2.4.1 Parse `data_merge.fex`.
-      - [ ] 5.2.2.4.2 End-to-end PL/pgSQL emission for MERGE.
+      - [x] 5.2.2.4.2 End-to-end PL/pgSQL emission for MERGE.
     - [ ] 5.2.2.5 Project 5: Drill Through.
       - [ ] 5.2.2.5.1 Parse `main_controller.fex`.
       - [ ] 5.2.2.5.2 Parse `summary_report.fex`.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -416,6 +416,17 @@ class PostgresEmitter:
         Translates ir.Report instruction into a SQL SELECT statement.
         """
         filename = instr.filename
+
+        # Check for MERGE command
+        merge_cmd = None
+        for comp in instr.components:
+            if comp.__class__.__name__ == 'OnCommand' and comp.target == 'TABLE':
+                for action in comp.actions:
+                    if action.__class__.__name__ == 'MergeCommand':
+                        merge_cmd = action
+                        break
+            if merge_cmd: break
+
         table_name = self._resolve_table_name(filename)
         alias_map = {filename: table_name}
 
@@ -554,6 +565,10 @@ class PostgresEmitter:
                 elif is_virtual:
                     # If it's a virtual field, use its name as alias for the expression
                     sql_expr = f"{sql_expr} AS \"{field_name}\""
+                elif merge_cmd:
+                    # Ensure the column has a predictable name for MERGE
+                    alias_name = field_name.split('.')[-1]
+                    sql_expr = f"{sql_expr} AS \"{alias_name}\""
 
                 select_fields.append(sql_expr)
 
@@ -590,6 +605,41 @@ class PostgresEmitter:
 
         if order_by_phrases:
             sql += "\nORDER BY " + ", ".join(order_by_phrases)
+
+        if merge_cmd:
+            target_table = self._resolve_table_name(merge_cmd.filename)
+
+            # Build ON condition
+            on_conds = []
+            for left, right in merge_cmd.matching_clause.conditions:
+                # Map TRG and SRC to their respective aliases if used
+                # In PostgreSQL MERGE, we can alias target and source.
+                on_conds.append(f"({left} = {right})")
+            on_clause = " AND ".join(on_conds)
+
+            merge_sql = f"MERGE INTO {target_table} AS TRG\nUSING (\n"
+            merge_sql += self._indent(sql, 4) + "\n) AS SRC\n"
+            merge_sql += f"ON {on_clause}\n"
+
+            if merge_cmd.when_matched:
+                updates = []
+                for field, expr in merge_cmd.when_matched.assignments:
+                    sql_expr = self.emit_expression(expr, in_query=True, virtual_fields=file_virtual_fields, qualifier=qualify_field)
+                    updates.append(f"\"{field}\" = {sql_expr}")
+                merge_sql += "WHEN MATCHED THEN\n  UPDATE SET " + ", ".join(updates) + "\n"
+
+            if merge_cmd.when_not_matched:
+                fields = []
+                values = []
+                for field, expr in merge_cmd.when_not_matched.assignments:
+                    sql_expr = self.emit_expression(expr, in_query=True, virtual_fields=file_virtual_fields, qualifier=qualify_field)
+                    fields.append(f"\"{field}\"")
+                    values.append(sql_expr)
+                merge_sql += "WHEN NOT MATCHED THEN\n  INSERT (" + ", ".join(fields) + ") VALUES (" + ", ".join(values) + ");"
+            else:
+                merge_sql += ";"
+
+            return merge_sql
 
         sql += ";"
         return sql

--- a/test/test_e2e_merge.py
+++ b/test/test_e2e_merge.py
@@ -1,0 +1,65 @@
+import unittest
+import sys
+import os
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from wf_parser import WebFocusParser
+from asg_builder import ReportASGBuilder
+from ir_builder import IRBuilder
+from emitter import PostgresEmitter
+from metadata_registry import MetadataRegistry
+
+class TestE2EMerge(unittest.TestCase):
+    def setUp(self):
+        self.parser = WebFocusParser()
+        self.asg_builder = ReportASGBuilder()
+        self.ir_builder = IRBuilder()
+        self.registry = MetadataRegistry()
+        self.emitter = PostgresEmitter(metadata_registry=self.registry)
+
+    def test_basic_merge(self):
+        fex = """
+        TABLE FILE dminv
+        PRINT
+           PROD_NUM
+         COMPUTE QUANTITY =  SUM.QTY_IN_STOCK;
+
+        ON TABLE MERGE INTO FILE dmrpts
+        MATCHING TRG.PROD_NUM EQ SRC.PROD_NUM;
+
+        WHEN MATCHED UPDATE
+          QUANTITY=SRC.QUANTITY;
+
+        WHEN NOT MATCHED INSERT
+          PROD_NUM=SRC.PROD_NUM;
+          QUANTITY=SRC.QUANTITY;
+        END
+        """
+
+        # 1. Parse
+        tree = self.parser.parse(fex)
+
+        # 2. Build ASG
+        asg_nodes = self.asg_builder.visit(tree)
+
+        # 3. Build IR
+        cfg = self.ir_builder.build(asg_nodes)
+
+        # 4. Emit
+        sql = self.emitter.emit(cfg)
+
+        print(sql)
+
+        # 5. Assertions
+        self.assertIn("MERGE INTO DMRPTS", sql.upper())
+        self.assertIn("USING (", sql.upper())
+        self.assertIn("ON (TRG.PROD_NUM = SRC.PROD_NUM)", sql.upper())
+        self.assertIn("WHEN MATCHED THEN", sql.upper())
+        self.assertIn("UPDATE SET", sql.upper())
+        self.assertIn("WHEN NOT MATCHED THEN", sql.upper())
+        self.assertIn('INSERT ("PROD_NUM", "QUANTITY")', sql.upper())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This change advances the migration from Lark to ANTLR4/Jinja2 by implementing a key relational operation: the `ON TABLE MERGE` command. It also provides a granular breakdown of the remaining Semantic Parity tasks in the roadmap to guide future development.

Key changes:
1. **MIGRATION_ROADMAP.md**: Decomposed Phase 5.1.4 into specific tasks covering symbol resolution, type consistency, and constant folding. Marked Data Merge emission as complete.
2. **src/emitter.py**: Updated `_emit_report` to detect `MergeCommand` and wrap the `SELECT` query in a PostgreSQL `MERGE` statement. Implemented `WHEN MATCHED UPDATE` and `WHEN NOT MATCHED INSERT` logic with proper identifier quoting.
3. **test/test_e2e_merge.py**: Introduced a new E2E test suite to validate the generated SQL for MERGE operations.

All tests passed, including existing E2E reporting, filtering, and data integration tests.

Fixes #265

---
*PR created automatically by Jules for task [2248205041119758489](https://jules.google.com/task/2248205041119758489) started by @chatelao*