### PR TITLE
Implement global scoping for Dialogue Manager variables

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -198,7 +198,7 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [x] 5.1.3.10.4 Support `DRILLTHROUGH` in `SET STYLE` blocks.
   - [ ] 5.1.4 Semantic Parity: Verify that ASG and IR transformations preserve source semantics.
     - [ ] 5.1.4.1 Symbol Resolution Validation:
-      - [ ] 5.1.4.1.1 Global vs. Local scope resolution for AmperVars.
+      - [x] 5.1.4.1.1 Global vs. Local scope resolution for AmperVars.
       - [ ] 5.1.4.1.2 Multi-segment field resolution in joined Master Files.
       - [ ] 5.1.4.1.3 Virtual field shadowing rules (DEFINE vs. Master File).
     - [ ] 5.1.4.2 Type Consistency:

--- a/src/symbol_resolver.py
+++ b/src/symbol_resolver.py
@@ -40,13 +40,13 @@ class SymbolResolver:
 
     def visit_SetDM(self, node):
         """Registers a Dialogue Manager variable definition from -SET."""
-        self.symbol_table.define(node.variable, symbol_type='DM_VAR')
+        self.symbol_table.define_global(node.variable, symbol_type='DM_VAR')
         self.visit(node.expression)
 
     def visit_Repeat(self, node):
         """Registers a Dialogue Manager loop variable definition from -REPEAT."""
         if hasattr(node, 'loop_var') and node.loop_var:
-            self.symbol_table.define(node.loop_var, symbol_type='DM_VAR')
+            self.symbol_table.define_global(node.loop_var, symbol_type='DM_VAR')
 
         # Visit all relevant components
         for attr in ['condition', 'times', 'start_val', 'end_val', 'step_val']:

--- a/src/symbol_table.py
+++ b/src/symbol_table.py
@@ -51,6 +51,12 @@ class SymbolTable:
         self.current_scope.define(symbol)
         return symbol
 
+    def define_global(self, name, symbol_type=None, **metadata):
+        """Defines a new symbol in the global scope."""
+        symbol = Symbol(name, symbol_type, **metadata)
+        self.global_scope.define(symbol)
+        return symbol
+
     def lookup(self, name, local_only=False):
         """Resolves a symbol name to its definition."""
         return self.current_scope.lookup(name, local_only)

--- a/test/test_symbol_scoping.py
+++ b/test/test_symbol_scoping.py
@@ -1,0 +1,97 @@
+import unittest
+import sys
+import os
+import tempfile
+import shutil
+from antlr4 import *
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from symbol_resolver import SymbolResolver
+from symbol_table import SymbolTable
+from metadata_registry import MetadataRegistry
+import asg
+
+class TestSymbolScoping(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.registry = MetadataRegistry([self.test_dir])
+
+        # Create a sample Master File
+        mas_content = """
+FILENAME=CAR, SUFFIX=FOC,$
+  SEGNAME=ORIGIN, SEGTYPE=S1,$
+    FIELDNAME=COUNTRY, ALIAS=COUNTRY, FORMAT=A10,$
+"""
+        with open(os.path.join(self.test_dir, "CAR.mas"), 'w') as f:
+            f.write(mas_content)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def build_asg(self, text):
+        input_stream = InputStream(text)
+        lexer = WebFocusReportLexer(input_stream)
+        stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(stream)
+        tree = parser.start()
+        builder = ReportASGBuilder()
+        return builder.visit(tree)
+
+    def test_ampervar_global_scope(self):
+        code = """
+        -SET &OUTER = 1;
+        TABLE FILE CAR
+        -SET &INNER = 2;
+        PRINT CAR
+        END
+        -TYPE &OUTER &INNER
+        """
+        asg_nodes = self.build_asg(code)
+        resolver = SymbolResolver()
+        st = resolver.resolve(asg_nodes)
+
+        # Both should be in the global scope (or at least resolvable at the end)
+        self.assertIsNotNone(st.lookup("&OUTER"))
+        self.assertIsNotNone(st.lookup("&INNER"))
+
+        # The last node is TypeDM
+        type_node = asg_nodes[-1]
+        self.assertIsInstance(type_node, asg.TypeDM)
+
+        outer_usage = type_node.messages[0]
+        self.assertIsNotNone(outer_usage.symbol, "OUTER should be resolved")
+
+        inner_usage = type_node.messages[1]
+        self.assertIsNotNone(inner_usage.symbol, "INNER should be resolved")
+
+    def test_ampervar_scoping_with_metadata(self):
+        code = """
+        TABLE FILE CAR
+        -SET &REPORT_VAR = 10;
+        PRINT COUNTRY
+        END
+        -TYPE &REPORT_VAR
+        """
+        asg_nodes = self.build_asg(code)
+        resolver = SymbolResolver(metadata_registry=self.registry)
+        st = resolver.resolve(asg_nodes)
+
+        # Currently, &REPORT_VAR is defined while visit_ReportRequest has entered a new scope.
+        # When visit_ReportRequest finishes, it exits the scope.
+        # If &REPORT_VAR was defined in that nested scope, it won't be available globally.
+
+        self.assertIsNotNone(st.lookup("&REPORT_VAR"), "&REPORT_VAR should be in global scope")
+
+        type_node = asg_nodes[-1]
+        self.assertIsInstance(type_node, asg.TypeDM)
+
+        var_usage = type_node.messages[0]
+        self.assertIsNotNone(var_usage.symbol, "REPORT_VAR should be resolved in TYPE command after report")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change ensures that Dialogue Manager variables (AmperVars) defined via -SET or -REPEAT commands are registered in the global scope of the SymbolTable, even when they appear within report requests or other nested scopes. This aligns with WebFOCUS semantics where DM variables are globally persistent. 

Key changes:
- Added `define_global` method to `SymbolTable` to allow explicit registration in the root scope.
- Updated `SymbolResolver.visit_SetDM` and `SymbolResolver.visit_Repeat` to use `define_global`.
- Added `test/test_symbol_scoping.py` to verify global persistence of variables defined inside and outside of reports.
- Updated `MIGRATION_ROADMAP.md` to mark Phase 5.1.4.1.1 as completed.

Fixes #269

---
*PR created automatically by Jules for task [10216143388223906972](https://jules.google.com/task/10216143388223906972) started by @chatelao*