### PR TITLE
Implement Constant Folding Parity (Phase 5.1.4.3)

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -205,10 +205,10 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [ ] 5.1.4.2.1 Numeric precision mapping (I, F, D, P to PostgreSQL).
       - [ ] 5.1.4.2.2 Alpha-numeric string truncation and padding semantics.
       - [ ] 5.1.4.2.3 Date/Time format conversion parity.
-    - [ ] 5.1.4.3 Constant Folding Parity:
-      - [ ] 5.1.4.3.1 Arithmetic expression folding.
-      - [ ] 5.1.4.3.2 Character concatenation folding.
-      - [ ] 5.1.4.3.3 Boolean logic short-circuiting parity.
+    - [x] 5.1.4.3 Constant Folding Parity:
+      - [x] 5.1.4.3.1 Arithmetic expression folding.
+      - [x] 5.1.4.3.2 Character concatenation folding.
+      - [x] 5.1.4.3.3 Boolean logic short-circuiting parity.
 - [ ] **5.2 Sample Validation:**
   - [x] 5.2.1 Core Samples: Validate transpiler output against samples in `test/samples/`. (Verified via `test/test_core_samples.py`)
   - [ ] 5.2.2 Documentation Examples: Validate against samples in `test/documentation_examples/`. (Verified via `test/test_documentation_examples.py`)

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -82,21 +82,40 @@ class ConstantPropagator:
             return self.constants.get(expr.name)
 
         if isinstance(expr, asg.BinaryOperation):
+            op = expr.operator.upper()
             left = self._evaluate_constant(expr.left)
+
+            # Short-circuiting for AND/OR
+            if op == 'AND' and left is not None and not left.value:
+                return asg.Literal(value=False)
+            if op == 'OR' and left is not None and left.value:
+                return asg.Literal(value=True)
+
             right = self._evaluate_constant(expr.right)
+
+            # Short-circuiting for AND/OR (right side)
+            if op == 'AND' and right is not None and not right.value:
+                return asg.Literal(value=False)
+            if op == 'OR' and right is not None and right.value:
+                return asg.Literal(value=True)
+
             if left and right:
                 try:
                     res = None
-                    if expr.operator == '+': res = left.value + right.value
-                    elif expr.operator == '-': res = left.value - right.value
-                    elif expr.operator == '*': res = left.value * right.value
-                    elif expr.operator == '/': res = left.value / right.value
-                    elif expr.operator == 'EQ' or expr.operator == '=': res = left.value == right.value
-                    elif expr.operator == 'NE' or expr.operator == '!=': res = left.value != right.value
-                    elif expr.operator == 'LT' or expr.operator == '<': res = left.value < right.value
-                    elif expr.operator == 'GT' or expr.operator == '>': res = left.value > right.value
-                    elif expr.operator == 'LE' or expr.operator == '<=': res = left.value <= right.value
-                    elif expr.operator == 'GE' or expr.operator == '>=': res = left.value >= right.value
+                    if op == '+': res = left.value + right.value
+                    elif op == '-': res = left.value - right.value
+                    elif op == '*': res = left.value * right.value
+                    elif op == '/': res = left.value / right.value
+                    elif op in ('EQ', '='): res = left.value == right.value
+                    elif op in ('NE', '!='): res = left.value != right.value
+                    elif op in ('LT', '<'): res = left.value < right.value
+                    elif op in ('GT', '>'): res = left.value > right.value
+                    elif op in ('LE', '<='): res = left.value <= right.value
+                    elif op in ('GE', '>='): res = left.value >= right.value
+                    elif op in ('||', '|', 'CONCAT'):
+                        res = str(left.value) + str(right.value)
+                    elif op == 'AND': res = left.value and right.value
+                    elif op == 'OR': res = left.value or right.value
 
                     if res is not None:
                         return asg.Literal(value=res)

--- a/test/test_optimizer.py
+++ b/test/test_optimizer.py
@@ -203,5 +203,66 @@ class TestOptimizer(unittest.TestCase):
 
         self.assertEqual(len(entry.instructions), 0)
 
+    def test_constant_folding_concatenation(self):
+        cfg = ir.ControlFlowGraph()
+        entry = ir.BasicBlock("ENTRY")
+        cfg.add_block(entry)
+        cfg.entry_block = entry
+
+        entry.add_instruction(ir.Assign(target="S1", source=asg.Literal("Hello")))
+        entry.add_instruction(ir.Assign(target="S2", source=asg.Literal("World")))
+        entry.add_instruction(ir.Assign(target="S3", source=asg.BinaryOperation(asg.AmperVar("S1"), "||", asg.AmperVar("S2"))))
+        entry.add_instruction(ir.Assign(target="S4", source=asg.BinaryOperation(asg.AmperVar("S1"), "|", asg.Literal(" "))))
+        entry.add_instruction(ir.Assign(target="S5", source=asg.BinaryOperation(asg.AmperVar("S4"), "CONCAT", asg.AmperVar("S2"))))
+
+        propagator = ConstantPropagator()
+        propagator.run(cfg)
+
+        self.assertEqual(propagator.constants["S3"].value, "HelloWorld")
+        self.assertEqual(propagator.constants["S4"].value, "Hello ")
+        self.assertEqual(propagator.constants["S5"].value, "Hello World")
+
+    def test_constant_folding_boolean_short_circuit(self):
+        cfg = ir.ControlFlowGraph()
+        entry = ir.BasicBlock("ENTRY")
+        cfg.add_block(entry)
+        cfg.entry_block = entry
+
+        # False AND X -> False
+        entry.add_instruction(ir.Assign(target="B1", source=asg.BinaryOperation(asg.Literal(False), "AND", asg.AmperVar("X"))))
+        # True OR X -> True
+        entry.add_instruction(ir.Assign(target="B2", source=asg.BinaryOperation(asg.Literal(True), "OR", asg.AmperVar("X"))))
+        # X AND False -> False
+        entry.add_instruction(ir.Assign(target="B3", source=asg.BinaryOperation(asg.AmperVar("X"), "AND", asg.Literal(False))))
+        # X OR True -> True
+        entry.add_instruction(ir.Assign(target="B4", source=asg.BinaryOperation(asg.AmperVar("X"), "OR", asg.Literal(True))))
+
+        propagator = ConstantPropagator()
+        propagator.run(cfg)
+
+        self.assertEqual(propagator.constants["B1"].value, False)
+        self.assertEqual(propagator.constants["B2"].value, True)
+        self.assertEqual(propagator.constants["B3"].value, False)
+        self.assertEqual(propagator.constants["B4"].value, True)
+
+    def test_constant_folding_boolean_full(self):
+        cfg = ir.ControlFlowGraph()
+        entry = ir.BasicBlock("ENTRY")
+        cfg.add_block(entry)
+        cfg.entry_block = entry
+
+        entry.add_instruction(ir.Assign(target="B1", source=asg.BinaryOperation(asg.Literal(True), "AND", asg.Literal(True))))
+        entry.add_instruction(ir.Assign(target="B2", source=asg.BinaryOperation(asg.Literal(True), "AND", asg.Literal(False))))
+        entry.add_instruction(ir.Assign(target="B3", source=asg.BinaryOperation(asg.Literal(False), "OR", asg.Literal(True))))
+        entry.add_instruction(ir.Assign(target="B4", source=asg.BinaryOperation(asg.Literal(False), "OR", asg.Literal(False))))
+
+        propagator = ConstantPropagator()
+        propagator.run(cfg)
+
+        self.assertEqual(propagator.constants["B1"].value, True)
+        self.assertEqual(propagator.constants["B2"].value, False)
+        self.assertEqual(propagator.constants["B3"].value, True)
+        self.assertEqual(propagator.constants["B4"].value, False)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implemented Phase 5.1.4.3 of the MIGRATION_ROADMAP.md, which covers Constant Folding Parity. 

Key changes:
- **src/optimizer.py**: Updated `ConstantPropagator._evaluate_constant` to handle string concatenation (`||`, `|`, `CONCAT`) and boolean short-circuiting (`AND`, `OR`).
- **test/test_optimizer.py**: Added new test cases to verify these optimizations, ensuring that constant expressions are correctly folded and that non-constant operands are properly handled via short-circuiting.
- **MIGRATION_ROADMAP.md**: Marked Phase 5.1.4.3 and its sub-tasks as complete.

Fixes #271

---
*PR created automatically by Jules for task [12360462519020751420](https://jules.google.com/task/12360462519020751420) started by @chatelao*