### PR TITLE
Implement Multi-segment Field Resolution in Joined Master Files

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -199,7 +199,7 @@ Ensure the new system produces correct results and maintains parity with the leg
   - [ ] 5.1.4 Semantic Parity: Verify that ASG and IR transformations preserve source semantics.
     - [ ] 5.1.4.1 Symbol Resolution Validation:
       - [x] 5.1.4.1.1 Global vs. Local scope resolution for AmperVars.
-      - [ ] 5.1.4.1.2 Multi-segment field resolution in joined Master Files.
+      - [x] 5.1.4.1.2 Multi-segment field resolution in joined Master Files.
       - [ ] 5.1.4.1.3 Virtual field shadowing rules (DEFINE vs. Master File).
     - [ ] 5.1.4.2 Type Consistency:
       - [ ] 5.1.4.2.1 Numeric precision mapping (I, F, D, P to PostgreSQL).

--- a/src/symbol_resolver.py
+++ b/src/symbol_resolver.py
@@ -9,6 +9,7 @@ class SymbolResolver:
     def __init__(self, symbol_table=None, metadata_registry=None):
         self.symbol_table = symbol_table or SymbolTable()
         self.metadata_registry = metadata_registry
+        self.active_joins = []
 
     def resolve(self, nodes):
         """Main entry point for resolving symbols in a list of ASG nodes or a single node."""
@@ -53,6 +54,14 @@ class SymbolResolver:
             if hasattr(node, attr):
                 self.visit(getattr(node, attr))
 
+    def visit_Join(self, node):
+        """Tracks an active JOIN."""
+        self.active_joins.append(node)
+
+    def visit_JoinClear(self, node):
+        """Clears all active JOINs."""
+        self.active_joins = []
+
     def visit_AmperVar(self, node):
         """Resolves a Dialogue Manager variable usage."""
         symbol = self.symbol_table.lookup(node.name)
@@ -66,19 +75,56 @@ class SymbolResolver:
 
             if master_file:
                 self.symbol_table.enter_scope()
-                # Register fields from the Master File
-                for segment in master_file.segments:
-                    for field in segment.fields:
-                        # Register both short name and qualified name
-                        self.symbol_table.define(field.name, symbol_type='FIELD', metadata={'field': field, 'segment': segment})
-                        self.symbol_table.define(f"{segment.name}.{field.name}", symbol_type='FIELD', metadata={'field': field, 'segment': segment})
 
-                    for vf in segment.virtual_fields:
-                        self.symbol_table.define(vf.name, symbol_type='VIRTUAL_FIELD', metadata={'define': vf, 'segment': segment})
-                        self.symbol_table.define(f"{segment.name}.{vf.name}", symbol_type='VIRTUAL_FIELD', metadata={'define': vf, 'segment': segment})
+                # We use a set to keep track of files whose fields are already registered
+                # to handle potential join loops or redundant registrations.
+                registered_files = set()
 
-                for vf in master_file.virtual_fields:
-                    self.symbol_table.define(vf.name, symbol_type='VIRTUAL_FIELD', metadata={'define': vf})
+                def register_master_fields(mf, alias=None):
+                    if mf.name.upper() in registered_files and alias is None:
+                        return
+                    if alias is None:
+                        registered_files.add(mf.name.upper())
+
+                    for segment in mf.segments:
+                        for field in segment.fields:
+                            # Register both short name and qualified name
+                            self.symbol_table.define(field.name, symbol_type='FIELD', metadata={'field': field, 'segment': segment})
+                            self.symbol_table.define(f"{segment.name}.{field.name}", symbol_type='FIELD', metadata={'field': field, 'segment': segment})
+                            if alias:
+                                self.symbol_table.define(f"{alias}.{field.name}", symbol_type='FIELD', metadata={'field': field, 'segment': segment})
+
+                        for vf in segment.virtual_fields:
+                            self.symbol_table.define(vf.name, symbol_type='VIRTUAL_FIELD', metadata={'define': vf, 'segment': segment})
+                            self.symbol_table.define(f"{segment.name}.{vf.name}", symbol_type='VIRTUAL_FIELD', metadata={'define': vf, 'segment': segment})
+                            if alias:
+                                self.symbol_table.define(f"{alias}.{vf.name}", symbol_type='VIRTUAL_FIELD', metadata={'define': vf, 'segment': segment})
+
+                    for vf in mf.virtual_fields:
+                        self.symbol_table.define(vf.name, symbol_type='VIRTUAL_FIELD', metadata={'define': vf})
+                        if alias:
+                            self.symbol_table.define(f"{alias}.{vf.name}", symbol_type='VIRTUAL_FIELD', metadata={'define': vf})
+
+                # Register fields from the primary Master File
+                register_master_fields(master_file)
+
+                # Register fields from joined Master Files
+                # In WebFOCUS, JOINs can be chained. We'll do a simple iterative resolution.
+                files_to_check = [node.filename.upper()]
+                processed_files = set()
+
+                while files_to_check:
+                    current_file = files_to_check.pop(0)
+                    if current_file in processed_files:
+                        continue
+                    processed_files.add(current_file)
+
+                    for join in self.active_joins:
+                        if join.left_file.upper() == current_file:
+                            joined_mf = self.metadata_registry.get_master_file(join.right_file)
+                            if joined_mf:
+                                register_master_fields(joined_mf, alias=join.join_as)
+                                files_to_check.append(join.right_file.upper())
 
                 # Visit components (verbs, WHERE, COMPUTE, etc.)
                 for component in node.components:

--- a/test/test_joined_symbol_resolution.py
+++ b/test/test_joined_symbol_resolution.py
@@ -1,0 +1,80 @@
+import unittest
+import os
+import tempfile
+import shutil
+import sys
+from antlr4 import *
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from symbol_resolver import SymbolResolver
+from metadata_registry import MetadataRegistry
+import asg
+
+class TestJoinedSymbolResolution(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.registry = MetadataRegistry([self.test_dir])
+
+        # Create CAR Master File
+        car_mas = """
+FILENAME=CAR, SUFFIX=FOC,$
+  SEGNAME=ORIGIN, SEGTYPE=S1,$
+    FIELDNAME=COUNTRY, ALIAS=COUNTRY, FORMAT=A10,$
+"""
+        with open(os.path.join(self.test_dir, "CAR.mas"), 'w') as f:
+            f.write(car_mas)
+
+        # Create SALES Master File
+        sales_mas = """
+FILENAME=SALES, SUFFIX=FOC,$
+  SEGNAME=SALES, SEGTYPE=S1,$
+    FIELDNAME=CAR, ALIAS=CAR, FORMAT=A16,$
+    FIELDNAME=RETAIL_PRICE, ALIAS=RP, FORMAT=D12.2,$
+"""
+        with open(os.path.join(self.test_dir, "SALES.mas"), 'w') as f:
+            f.write(sales_mas)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def build_asg(self, text):
+        input_stream = InputStream(text)
+        lexer = WebFocusReportLexer(input_stream)
+        stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(stream)
+        tree = parser.start()
+        builder = ReportASGBuilder()
+        return builder.visit(tree)
+
+    def test_joined_field_resolution(self):
+        code = """
+        JOIN CAR IN CAR TO CAR IN SALES AS J1
+        TABLE FILE CAR
+        PRINT COUNTRY AND J1.RETAIL_PRICE
+        END
+        """
+        asg_nodes = self.build_asg(code)
+        resolver = SymbolResolver(metadata_registry=self.registry)
+        resolver.resolve(asg_nodes)
+
+        # asg_nodes[0] is Join
+        # asg_nodes[1] is ReportRequest
+        report = asg_nodes[1]
+        verb = report.components[0]
+
+        country_field = verb.fields[0]
+        self.assertEqual(country_field.name, "COUNTRY")
+        self.assertIsNotNone(country_field.symbol, "COUNTRY field should be resolved")
+
+        rp_field = verb.fields[1]
+        self.assertEqual(rp_field.name, "J1.RETAIL_PRICE")
+        self.assertIsNotNone(rp_field.symbol, "J1.RETAIL_PRICE field should be resolved")
+        self.assertEqual(rp_field.symbol.symbol_type, "FIELD")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change implements Phase 5.1.4.1.2 of the MIGRATION_ROADMAP.md, enabling the SymbolResolver to correctly identify and resolve fields originating from joined Master Files. It handles chained joins and supports both segment qualification and join aliases.

Fixes #273

---
*PR created automatically by Jules for task [5741513929000834296](https://jules.google.com/task/5741513929000834296) started by @chatelao*