### PR TITLE
Implement numeric precision mapping (Phase 5.1.4.2.1)

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -202,7 +202,7 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [x] 5.1.4.1.2 Multi-segment field resolution in joined Master Files.
       - [x] 5.1.4.1.3 Virtual field shadowing rules (DEFINE vs. Master File).
     - [ ] 5.1.4.2 Type Consistency:
-      - [ ] 5.1.4.2.1 Numeric precision mapping (I, F, D, P to PostgreSQL).
+      - [x] 5.1.4.2.1 Numeric precision mapping (I, F, D, P to PostgreSQL).
       - [ ] 5.1.4.2.2 Alpha-numeric string truncation and padding semantics.
       - [ ] 5.1.4.2.3 Date/Time format conversion parity.
     - [x] 5.1.4.3 Constant Folding Parity:

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -1,4 +1,5 @@
 import os
+import re
 import ir
 import asg
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -93,14 +94,47 @@ class PostgresEmitter:
     def _map_type(self, data_type):
         """
         Maps WebFOCUS types to PostgreSQL types.
+        Supports detailed numeric formats (e.g., I8, F8.2, P9.2).
         """
-        mapping = {
-            'I': 'INTEGER',
-            'F': 'NUMERIC',
-            'A': 'TEXT',
-            'LOGICAL': 'BOOLEAN'
-        }
-        return mapping.get(data_type, 'TEXT')
+        if not data_type:
+            return 'TEXT'
+
+        data_type = data_type.upper()
+
+        if data_type == 'LOGICAL':
+            return 'BOOLEAN'
+        if data_type.startswith('A'):
+            return 'TEXT'
+
+        # Integer mapping
+        if data_type.startswith('I'):
+            if '8' in data_type:
+                return 'BIGINT'
+            return 'INTEGER'
+
+        # Float/Decimal mapping
+        if data_type.startswith(('F', 'D', 'P')):
+            # Check for precision and scale: e.g., F8.2 or P9.2
+            match = re.search(r'([FDP])(\d+)(?:\.(\d+))?', data_type)
+            if match:
+                type_char = match.group(1)
+                precision = match.group(2)
+                scale = match.group(3)
+
+                if scale:
+                    return f"NUMERIC({precision}, {scale})"
+
+                if type_char in ('F', 'D'):
+                    return 'DOUBLE PRECISION'
+
+                return f"NUMERIC({precision}, 0)"
+
+            if data_type.startswith(('F', 'D')):
+                return 'DOUBLE PRECISION'
+            if data_type.startswith('P'):
+                return 'NUMERIC'
+
+        return 'TEXT'
 
     def _discover_vars_in_expr(self, node, variables):
         """

--- a/src/type_inferrer.py
+++ b/src/type_inferrer.py
@@ -35,16 +35,15 @@ class TypeInferrer:
         return None
 
     def _get_base_type(self, format_str):
-        """Extracts the base type (A, I, F, LOGICAL) from a WebFOCUS format string."""
+        """Extracts the base type or normalized format string from a WebFOCUS format string."""
         if not format_str:
             return None
         format_str = format_str.upper()
         if format_str.startswith('A'):
             return 'A'
-        if format_str.startswith('I'):
-            return 'I'
-        if format_str.startswith('F') or format_str.startswith('D') or format_str.startswith('P'):
-            return 'F'
+        if format_str.startswith(('I', 'F', 'D', 'P')):
+            # Return the full format for numeric types to allow precision mapping
+            return format_str
         return format_str
 
     def visit_Literal(self, node):
@@ -102,16 +101,29 @@ class TypeInferrer:
         node.data_type = 'A'
         return node.data_type
 
+    def _pick_precise_type(self, type1, type2, category_prefix):
+        """Helper to pick the more specific/precise type between two format strings."""
+        t1 = type1 if type1 and type1.startswith(category_prefix) else None
+        t2 = type2 if type2 and type2.startswith(category_prefix) else None
+
+        if not t1: return t2
+        if not t2: return t1
+
+        # Pick the one with more information (longer string usually means precision/scale)
+        return t1 if len(t1) >= len(t2) else t2
+
     def visit_BinaryOperation(self, node):
         left_type = self.visit(node.left)
         right_type = self.visit(node.right)
 
         op = node.operator.upper()
         if op in ('+', '-', '*', '/'):
-            if left_type == 'F' or right_type == 'F':
-                node.data_type = 'F'
-            elif left_type == 'I' or right_type == 'I':
-                node.data_type = 'I'
+            if any(t and t.startswith(('F', 'D', 'P')) for t in (left_type, right_type)):
+                # If either is float-like, result is float-like.
+                node.data_type = self._pick_precise_type(left_type, right_type, ('F', 'D', 'P')) or 'F'
+            elif any(t and t.startswith('I') for t in (left_type, right_type)):
+                # If both are integer-like, pick the largest
+                node.data_type = self._pick_precise_type(left_type, right_type, 'I') or 'I'
             else:
                 node.data_type = left_type or right_type
         elif op in ('|', '||', 'CONCAT'):
@@ -137,10 +149,10 @@ class TypeInferrer:
         then_type = self.visit(node.then_expr)
         else_type = self.visit(node.else_expr)
 
-        if then_type == 'F' or else_type == 'F':
-            node.data_type = 'F'
-        elif then_type == 'I' or else_type == 'I':
-            node.data_type = 'I'
+        if any(t and t.startswith(('F', 'D', 'P')) for t in (then_type, else_type)):
+            node.data_type = self._pick_precise_type(then_type, else_type, ('F', 'D', 'P')) or 'F'
+        elif any(t and t.startswith('I') for t in (then_type, else_type)):
+            node.data_type = self._pick_precise_type(then_type, else_type, 'I') or 'I'
         else:
             node.data_type = then_type or else_type
 

--- a/test/test_emitter.py
+++ b/test/test_emitter.py
@@ -59,7 +59,7 @@ class TestEmitter(unittest.TestCase):
         variables = emitter.get_variables_from_cfg(cfg)
 
         self.assertEqual(variables['v_VAR1'], 'INTEGER')
-        self.assertEqual(variables['v_VAR2'], 'NUMERIC')
+        self.assertEqual(variables['v_VAR2'], 'DOUBLE PRECISION')
         self.assertEqual(variables['v_VAR3'], 'BOOLEAN')
 
     def test_emit_expression_literals(self):
@@ -191,6 +191,18 @@ class TestEmitter(unittest.TestCase):
         self.assertIn("v_next_block TEXT;", proc)
         self.assertIn("BEGIN", proc)
         self.assertIn("v_VAR := 100;", proc)
+
+    def test_map_type_precision(self):
+        emitter = PostgresEmitter()
+        self.assertEqual(emitter._map_type('I'), 'INTEGER')
+        self.assertEqual(emitter._map_type('I4'), 'INTEGER')
+        self.assertEqual(emitter._map_type('I8'), 'BIGINT')
+        self.assertEqual(emitter._map_type('F8'), 'DOUBLE PRECISION')
+        self.assertEqual(emitter._map_type('D12'), 'DOUBLE PRECISION')
+        self.assertEqual(emitter._map_type('F8.2'), 'NUMERIC(8, 2)')
+        self.assertEqual(emitter._map_type('P9.2'), 'NUMERIC(9, 2)')
+        self.assertEqual(emitter._map_type('P9'), 'NUMERIC(9, 0)')
+        self.assertEqual(emitter._map_type('A10'), 'TEXT')
 
     def test_emit_instruction_report(self):
         emitter = PostgresEmitter()

--- a/test/test_type_inference.py
+++ b/test/test_type_inference.py
@@ -89,5 +89,29 @@ class TestTypeInference(unittest.TestCase):
         self.assertEqual(report.components[1].condition.data_type, 'LOGICAL') # In
         self.assertEqual(report.components[2].condition.data_type, 'LOGICAL') # IsMissing
 
+    def test_precision_inference_from_metadata(self):
+        from symbol_table import Symbol
+
+        # Manually create nodes with symbol and metadata
+        field_node = asg.Identifier(name="LARGE_INT")
+        field_node.symbol = Symbol(name="LARGE_INT", scope=None)
+        field_node.symbol.metadata = {'field': asg.Field(name="LARGE_INT", format="I8")}
+
+        field_node2 = asg.Identifier(name="PREC_NUM")
+        field_node2.symbol = Symbol(name="PREC_NUM", scope=None)
+        field_node2.symbol.metadata = {'field': asg.Field(name="PREC_NUM", format="P9.2")}
+
+        inferrer = TypeInferrer()
+        self.assertEqual(inferrer.visit(field_node), 'I8')
+        self.assertEqual(inferrer.visit(field_node2), 'P9.2')
+
+        # Arithmetic with I8
+        expr = asg.BinaryOperation(field_node, '+', asg.Literal(1))
+        self.assertEqual(inferrer.visit(expr), 'I8')
+
+        # Arithmetic with P9.2
+        expr2 = asg.BinaryOperation(field_node2, '*', asg.Literal(2.0))
+        self.assertEqual(inferrer.visit(expr2), 'P9.2')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change implements Phase 5.1.4.2.1 of the Migration Roadmap. It improves the semantic parity of the transpiler by ensuring that numeric fields with specific precision and scale in WebFOCUS are correctly mapped to their corresponding PostgreSQL types.

Key changes:
1.  **TypeInferrer Enhancement**: `_get_base_type` now returns the full normalized format string for numeric types.
2.  **Robust Type Promotion**: Added `_pick_precise_type` to `TypeInferrer` to handle merging of types in binary operations and conditional expressions, ensuring the most specific format is preserved regardless of operand order.
3.  **Emitter Type Mapping**: `PostgresEmitter._map_type` was overhauled to use regex for parsing format strings and mapping them to `BIGINT`, `DOUBLE PRECISION`, or `NUMERIC(precision, scale)`.
4.  **Testing**: New test cases in `test/test_type_inference.py` and `test/test_emitter.py` verify the end-to-end mapping from metadata to generated SQL variable declarations.
5.  **Roadmap Update**: Marked 5.1.4.2.1 as completed in `MIGRATION_ROADMAP.md`.

Fixes #277

---
*PR created automatically by Jules for task [4008419262856361141](https://jules.google.com/task/4008419262856361141) started by @chatelao*