### PR TITLE
Implement Date/Time format conversion parity

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -204,7 +204,7 @@ Ensure the new system produces correct results and maintains parity with the leg
     - [ ] 5.1.4.2 Type Consistency:
       - [x] 5.1.4.2.1 Numeric precision mapping (I, F, D, P to PostgreSQL).
       - [ ] 5.1.4.2.2 Alpha-numeric string truncation and padding semantics.
-      - [ ] 5.1.4.2.3 Date/Time format conversion parity.
+      - [x] 5.1.4.2.3 Date/Time format conversion parity.
     - [x] 5.1.4.3 Constant Folding Parity:
       - [x] 5.1.4.3.1 Arithmetic expression folding.
       - [x] 5.1.4.3.2 Character concatenation folding.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -106,6 +106,12 @@ class PostgresEmitter:
         if data_type.startswith('A'):
             return 'TEXT'
 
+        # Date and Date-Time mapping
+        if data_type.startswith('H'):
+            return 'TIMESTAMP'
+        if data_type in ('YYMD', 'MDYY', 'DMYY', 'YMD', 'MDY', 'DMY'):
+            return 'DATE'
+
         # Integer mapping
         if data_type.startswith('I'):
             if '8' in data_type:

--- a/src/type_inferrer.py
+++ b/src/type_inferrer.py
@@ -38,13 +38,7 @@ class TypeInferrer:
         """Extracts the base type or normalized format string from a WebFOCUS format string."""
         if not format_str:
             return None
-        format_str = format_str.upper()
-        if format_str.startswith('A'):
-            return 'A'
-        if format_str.startswith(('I', 'F', 'D', 'P')):
-            # Return the full format for numeric types to allow precision mapping
-            return format_str
-        return format_str
+        return format_str.upper()
 
     def visit_Literal(self, node):
         if isinstance(node.value, int):

--- a/test/test_date_parity.py
+++ b/test/test_date_parity.py
@@ -1,0 +1,34 @@
+import unittest
+from type_inferrer import TypeInferrer
+from emitter import PostgresEmitter
+
+class TestDateParity(unittest.TestCase):
+    def setUp(self):
+        self.inferrer = TypeInferrer()
+        self.emitter = PostgresEmitter()
+
+    def test_type_inferrer_preserves_format(self):
+        self.assertEqual(self.inferrer._get_base_type('A10'), 'A10')
+        self.assertEqual(self.inferrer._get_base_type('YYMD'), 'YYMD')
+        self.assertEqual(self.inferrer._get_base_type('HYYMDI'), 'HYYMDI')
+        self.assertEqual(self.inferrer._get_base_type('I8'), 'I8')
+
+    def test_postgres_emitter_maps_dates(self):
+        self.assertEqual(self.emitter._map_type('YYMD'), 'DATE')
+        self.assertEqual(self.emitter._map_type('MDYY'), 'DATE')
+        self.assertEqual(self.emitter._map_type('DMYY'), 'DATE')
+        self.assertEqual(self.emitter._map_type('YMD'), 'DATE')
+        self.assertEqual(self.emitter._map_type('MDY'), 'DATE')
+        self.assertEqual(self.emitter._map_type('DMY'), 'DATE')
+
+    def test_postgres_emitter_maps_timestamps(self):
+        self.assertEqual(self.emitter._map_type('HYYMDI'), 'TIMESTAMP')
+        self.assertEqual(self.emitter._map_type('HYYMDm'), 'TIMESTAMP')
+        self.assertEqual(self.emitter._map_type('H'), 'TIMESTAMP')
+
+    def test_postgres_emitter_maps_alpha(self):
+        self.assertEqual(self.emitter._map_type('A10'), 'TEXT')
+        self.assertEqual(self.emitter._map_type('A'), 'TEXT')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implement Date/Time format conversion parity (Phase 5.1.4.2.3 in MIGRATION_ROADMAP.md). This includes updating `TypeInferrer` to preserve detailed format strings and `PostgresEmitter` to map WebFOCUS date/time types to PostgreSQL `DATE` and `TIMESTAMP` types. Includes unit tests for the new mapping logic.

Fixes #279

---
*PR created automatically by Jules for task [11433656027693077688](https://jules.google.com/task/11433656027693077688) started by @chatelao*