### PR TITLE
Implement Extended Relational Operators Parity

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -210,6 +210,7 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [x] 5.1.4.3.1 Arithmetic expression folding.
       - [x] 5.1.4.3.2 Character concatenation folding.
       - [x] 5.1.4.3.3 Boolean logic short-circuiting parity.
+    - [x] 5.1.4.4 Extended Relational Operators Parity: CONTAINS, OMITS, EXCEEDS, INCLUDES, EXCLUDES. (Verified via `test/test_e2e_extended_filtering.py`)
 - [x] **5.2 Sample Validation:**
   - [x] 5.2.1 Core Samples: Validate transpiler output against samples in `test/samples/`. (Verified via `test/test_core_samples.py`)
   - [x] 5.2.2 Documentation Examples: Validate against samples in `test/documentation_examples/`. (Verified via `test/test_documentation_examples.py`)

--- a/src/asg_builder.py
+++ b/src/asg_builder.py
@@ -369,9 +369,14 @@ class ReportASGBuilder(WebFocusReportVisitor):
         # Case: INCLUDES / EXCLUDES
         if ctx.INCLUDES() or ctx.EXCLUDES():
             left = self.visit(ctx.dm_concat_expression(0))
-            op = "INCLUDES" if ctx.INCLUDES() else "EXCLUDES"
+            op = "CONTAINS" if ctx.INCLUDES() else "OMITS"
             values = [self.visit(e) for i, e in enumerate(ctx.dm_concat_expression()) if i > 0]
-            return BinaryOperation(left=left, operator=op, right=values)
+
+            node = BinaryOperation(left=left, operator=op, right=values[0])
+            for i in range(1, len(values)):
+                right_expr = BinaryOperation(left=left, operator=op, right=values[i])
+                node = BinaryOperation(left=node, operator="AND", right=right_expr)
+            return node
 
         # Case: Relational op with optional OR
         if ctx.dm_relational_op():

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -294,8 +294,23 @@ class PostgresEmitter:
                 'LE': '<=',
                 'AND': 'AND',
                 'OR': 'OR',
-                'CONCAT': '||'
+                'CONCAT': '||',
+                'EXCEEDS': '>',
+                'IS LESS THAN': '<',
+                'IS MORE THAN': '>',
+                'IS GREATER THAN': '>',
+                'ISLESSTHAN': '<',
+                'ISMORETHAN': '>',
+                'ISGREATERTHAN': '>',
+                'ISNOT': '<>',
+                'IS NOT': '<>'
             }
+
+            if op == 'CONTAINS':
+                return f"({left} LIKE '%' || {right} || '%')"
+            if op == 'OMITS':
+                return f"({left} NOT LIKE '%' || {right} || '%')"
+
             sql_op = op_mapping.get(op, op)
             return f"({left} {sql_op} {right})"
 

--- a/test/test_e2e_extended_filtering.py
+++ b/test/test_e2e_extended_filtering.py
@@ -1,0 +1,109 @@
+import unittest
+import sys
+import os
+from antlr4 import CommonTokenStream, InputStream
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from ir_builder import IRBuilder
+from ssa_transformer import SSATransformer
+from optimizer import ConstantPropagator, DeadCodeEliminator
+from emitter import PostgresEmitter
+from metadata_registry import MetadataRegistry
+
+class TestE2EExtendedFiltering(unittest.TestCase):
+    def _transpile(self, fex_code):
+        input_stream = InputStream(fex_code)
+        lexer = WebFocusReportLexer(input_stream)
+        token_stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(token_stream)
+        tree = parser.start()
+
+        builder = ReportASGBuilder()
+        asg_nodes = builder.visit(tree)
+
+        ir_builder = IRBuilder()
+        cfg = ir_builder.build(asg_nodes)
+
+        ssa_transformer = SSATransformer()
+        ssa_transformer.transform(cfg)
+
+        ConstantPropagator().run(cfg)
+        DeadCodeEliminator().run(cfg)
+
+        metadata = MetadataRegistry()
+        emitter = PostgresEmitter(metadata_registry=metadata)
+        return emitter.emit(cfg)
+
+    def test_contains_filtering(self):
+        fex_code = """
+        TABLE FILE CAR
+        PRINT MODEL
+        WHERE MODEL CONTAINS 'V8'
+        END
+        """
+        sql_output = self._transpile(fex_code)
+        self.assertIn("(MODEL LIKE '%' || 'V8' || '%')", sql_output)
+
+    def test_omits_filtering(self):
+        fex_code = """
+        TABLE FILE CAR
+        PRINT MODEL
+        WHERE MODEL OMITS 'TURBO'
+        END
+        """
+        sql_output = self._transpile(fex_code)
+        self.assertIn("(MODEL NOT LIKE '%' || 'TURBO' || '%')", sql_output)
+
+    def test_exceeds_filtering(self):
+        fex_code = """
+        TABLE FILE CAR
+        PRINT MODEL
+        WHERE SALES EXCEEDS 5000
+        END
+        """
+        sql_output = self._transpile(fex_code)
+        self.assertIn("(SALES > 5000)", sql_output)
+
+    def test_is_less_than_filtering(self):
+        fex_code = """
+        TABLE FILE CAR
+        PRINT MODEL
+        WHERE SALES IS LESS THAN 1000
+        END
+        """
+        sql_output = self._transpile(fex_code)
+        self.assertIn("(SALES < 1000)", sql_output)
+
+    def test_includes_filtering(self):
+        fex_code = """
+        TABLE FILE CAR
+        PRINT MODEL
+        WHERE MODEL INCLUDES 'V8' AND 'TURBO'
+        END
+        """
+        sql_output = self._transpile(fex_code)
+        # Expansion should be: (MODEL LIKE '%' || 'V8' || '%') AND (MODEL LIKE '%' || 'TURBO' || '%')
+        self.assertIn("(MODEL LIKE '%' || 'V8' || '%')", sql_output)
+        self.assertIn("(MODEL LIKE '%' || 'TURBO' || '%')", sql_output)
+        self.assertIn(" AND ", sql_output)
+
+    def test_excludes_filtering(self):
+        fex_code = """
+        TABLE FILE CAR
+        PRINT MODEL
+        WHERE MODEL EXCLUDES 'DIESEL' AND 'OLD'
+        END
+        """
+        sql_output = self._transpile(fex_code)
+        # Expansion should be: (MODEL NOT LIKE '%' || 'DIESEL' || '%') AND (MODEL NOT LIKE '%' || 'OLD' || '%')
+        self.assertIn("(MODEL NOT LIKE '%' || 'DIESEL' || '%')", sql_output)
+        self.assertIn("(MODEL NOT LIKE '%' || 'OLD' || '%')", sql_output)
+        self.assertIn(" AND ", sql_output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented semantic parity for extended relational operators (CONTAINS, OMITS, EXCEEDS, INCLUDES, EXCLUDES) including ASG expansion and SQL emission with wildcards. Verified with new E2E tests.

Fixes #289

---
*PR created automatically by Jules for task [5134639587329652775](https://jules.google.com/task/5134639587329652775) started by @chatelao*