### PR TITLE
ASG Support for MATCH FILE and MORE Phrase

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -203,11 +203,11 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [x] 5.1.3.11.3 Emitter support for translating `DECODE` to SQL `CASE`.
     - [ ] 5.1.3.12 Support `MATCH FILE` command.
       - [x] 5.1.3.12.1 Grammar support for `MATCH FILE`, `RUN`, `AFTER MATCH`, and merge phrases (`OLD-OR-NEW`, `OLD-AND-NEW`, `OLD-NOT-NEW`, `NEW-NOT-OLD`, `OLD-NOR-NEW`, `OLD`, `NEW`).
-      - [ ] 5.1.3.12.2 ASG support for `MatchRequest`, `SubMatch`, and `MatchAction`.
+      - [x] 5.1.3.12.2 ASG support for `MatchRequest`, `SubMatch`, and `AfterMatchPhrase`.
       - [ ] 5.1.3.12.3 Emitter support for `MATCH` logic.
     - [ ] 5.1.3.13 Support `MORE` phrase (Universal Concatenation).
       - [x] 5.1.3.13.1 Grammar support for `MORE` phrase in `TABLE` and `MATCH` requests.
-      - [ ] 5.1.3.13.2 ASG support for `MoreClause` and sub-requests.
+      - [x] 5.1.3.13.2 ASG support for `MoreClause` and sub-requests.
       - [ ] 5.1.3.13.3 Emitter support for `UNION ALL`.
   - [x] 5.1.4 Semantic Parity: Verify that ASG and IR transformations preserve source semantics.
     - [x] 5.1.4.1 Symbol Resolution Validation:

--- a/src/asg.py
+++ b/src/asg.py
@@ -131,8 +131,8 @@ class ExitDM(Command):
 
 class ReportRequest(Statement):
     """Represents a TABLE FILE report request."""
-    def __init__(self, filename, components=None, **kwargs):
-        super().__init__(filename=filename, components=components or [], **kwargs)
+    def __init__(self, filename, components=None, more_clause=None, **kwargs):
+        super().__init__(filename=filename, components=components or [], more_clause=more_clause, **kwargs)
 
 class VerbCommand(Command):
     """Represents a report verb command (PRINT, SUM, etc.)."""
@@ -310,3 +310,28 @@ class InsertClause(ASGNode):
     """Represents a WHEN NOT MATCHED INSERT clause in a MERGE command."""
     def __init__(self, assignments, **kwargs):
         super().__init__(assignments=assignments or [], **kwargs)
+
+class MatchRequest(Statement):
+    """Represents a MATCH FILE request."""
+    def __init__(self, filename, components=None, more_clause=None, sub_matches=None, **kwargs):
+        super().__init__(filename=filename, components=components or [], more_clause=more_clause, sub_matches=sub_matches or [], **kwargs)
+
+class SubMatch(ASGNode):
+    """Represents a FILE entry within a MATCH request."""
+    def __init__(self, filename, components=None, more_clause=None, after_match=None, **kwargs):
+        super().__init__(filename=filename, components=components or [], more_clause=more_clause, after_match=after_match, **kwargs)
+
+class AfterMatchPhrase(ASGNode):
+    """Represents an AFTER MATCH phrase."""
+    def __init__(self, merge_type, output_command=None, **kwargs):
+        super().__init__(merge_type=merge_type, output_command=output_command, **kwargs)
+
+class MoreClause(ASGNode):
+    """Represents a MORE phrase."""
+    def __init__(self, sub_requests=None, **kwargs):
+        super().__init__(sub_requests=sub_requests or [], **kwargs)
+
+class MoreSubRequest(ASGNode):
+    """Represents a FILE entry within a MORE phrase."""
+    def __init__(self, filename, where_clauses=None, **kwargs):
+        super().__init__(filename=filename, where_clauses=where_clauses or [], **kwargs)

--- a/src/asg_builder.py
+++ b/src/asg_builder.py
@@ -25,10 +25,14 @@ class ReportASGBuilder(WebFocusReportVisitor):
     def visitRequest(self, ctx: WebFocusReportParser.RequestContext):
         filename = self.visit(ctx.table_file())
         components = []
+        more_clause = None
         # Iterate through all children except table_file (first) and end_command (last)
         for i in range(1, ctx.getChildCount() - 1):
             child = ctx.getChild(i)
             if isinstance(child, TerminalNode):
+                continue
+            if isinstance(child, WebFocusReportParser.More_phraseContext):
+                more_clause = self.visit(child)
                 continue
             node = self.visit(child)
             if node:
@@ -36,7 +40,77 @@ class ReportASGBuilder(WebFocusReportVisitor):
                     components.extend(node)
                 else:
                     components.append(node)
-        return ReportRequest(filename=filename, components=components)
+        return ReportRequest(filename=filename, components=components, more_clause=more_clause)
+
+    def visitMatch_request(self, ctx: WebFocusReportParser.Match_requestContext):
+        filename = ctx.qualified_name().getText()
+        components = []
+        more_clause = None
+        sub_matches = []
+
+        # MATCH FILE qualified_name are first three children
+        for i in range(3, ctx.getChildCount() - 1):
+            child = ctx.getChild(i)
+            if isinstance(child, TerminalNode):
+                continue
+            if isinstance(child, WebFocusReportParser.More_phraseContext):
+                more_clause = self.visit(child)
+            elif isinstance(child, WebFocusReportParser.Sub_matchContext):
+                sub_matches.append(self.visit(child))
+            else:
+                node = self.visit(child)
+                if node:
+                    if isinstance(node, list):
+                        components.extend(node)
+                    else:
+                        components.append(node)
+        return MatchRequest(filename=filename, components=components, more_clause=more_clause, sub_matches=sub_matches)
+
+    def visitSub_match(self, ctx: WebFocusReportParser.Sub_matchContext):
+        filename = ctx.qualified_name().getText()
+        components = []
+        more_clause = None
+        after_match = None
+
+        for i in range(2, ctx.getChildCount()):
+            child = ctx.getChild(i)
+            if isinstance(child, TerminalNode):
+                continue
+            if isinstance(child, WebFocusReportParser.More_phraseContext):
+                more_clause = self.visit(child)
+            elif isinstance(child, WebFocusReportParser.After_match_phraseContext):
+                after_match = self.visit(child)
+            else:
+                node = self.visit(child)
+                if node:
+                    if isinstance(node, list):
+                        components.extend(node)
+                    else:
+                        components.append(node)
+        return SubMatch(filename=filename, components=components, more_clause=more_clause, after_match=after_match)
+
+    def visitAfter_match_phrase(self, ctx: WebFocusReportParser.After_match_phraseContext):
+        merge_type = ctx.merge_type().getText().upper()
+        output_command = self.visit(ctx.output_command()) if ctx.output_command() else None
+        return AfterMatchPhrase(merge_type=merge_type, output_command=output_command)
+
+    def visitMore_phrase(self, ctx: WebFocusReportParser.More_phraseContext):
+        sub_requests = []
+        current_sub = None
+        for i in range(1, ctx.getChildCount()):
+            child = ctx.getChild(i)
+            if isinstance(child, TerminalNode):
+                continue
+            if isinstance(child, WebFocusReportParser.Qualified_nameContext):
+                if current_sub:
+                    sub_requests.append(current_sub)
+                current_sub = MoreSubRequest(filename=child.getText(), where_clauses=[])
+            elif isinstance(child, WebFocusReportParser.Where_commandContext):
+                if current_sub:
+                    current_sub.where_clauses.append(self.visit(child))
+        if current_sub:
+            sub_requests.append(current_sub)
+        return MoreClause(sub_requests=sub_requests)
 
     def visitTable_file(self, ctx: WebFocusReportParser.Table_fileContext):
         return ctx.qualified_name().getText()

--- a/test/test_asg_match_more.py
+++ b/test/test_asg_match_more.py
@@ -1,0 +1,92 @@
+import unittest
+from antlr4 import InputStream, CommonTokenStream
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from asg import *
+
+class TestAsgMatchMore(unittest.TestCase):
+    def get_asg(self, text):
+        input_stream = InputStream(text)
+        lexer = WebFocusReportLexer(input_stream)
+        token_stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(token_stream)
+        tree = parser.start()
+        builder = ReportASGBuilder()
+        return builder.visit(tree)
+
+    def test_match_file_asg(self):
+        text = """
+        MATCH FILE EDUCFILE
+        SUM COURSE_CODE
+        BY EMP_ID
+        RUN
+        FILE EMPLOYEE
+        SUM LAST_NAME AND FIRST_NAME
+        BY EMP_ID BY CURR_SAL
+        AFTER MATCH HOLD AS MYRESULT OLD-OR-NEW
+        END
+        """
+        asg = self.get_asg(text)
+        self.assertEqual(len(asg), 1)
+        match_req = asg[0]
+        self.assertIsInstance(match_req, MatchRequest)
+        self.assertEqual(match_req.filename, "EDUCFILE")
+        self.assertEqual(len(match_req.components), 2) # SUM and BY
+        self.assertEqual(len(match_req.sub_matches), 1)
+
+        sub = match_req.sub_matches[0]
+        self.assertIsInstance(sub, SubMatch)
+        self.assertEqual(sub.filename, "EMPLOYEE")
+        self.assertEqual(len(sub.components), 3) # SUM, BY, BY
+        self.assertIsInstance(sub.after_match, AfterMatchPhrase)
+        self.assertEqual(sub.after_match.merge_type, "OLD-OR-NEW")
+        self.assertIsInstance(sub.after_match.output_command, OutputCommand)
+        self.assertEqual(sub.after_match.output_command.filename, "MYRESULT")
+
+    def test_table_more_phrase_asg(self):
+        text = """
+        TABLE FILE EMPLOYEE
+        PRINT CURR_SAL
+        BY EMP_ID
+        MORE
+        FILE EXPERSON
+        WHERE SALARY GT 50000;
+        FILE OTHERS
+        END
+        """
+        asg = self.get_asg(text)
+        self.assertEqual(len(asg), 1)
+        req = asg[0]
+        self.assertIsInstance(req, ReportRequest)
+        self.assertIsInstance(req.more_clause, MoreClause)
+        self.assertEqual(len(req.more_clause.sub_requests), 2)
+
+        sub1 = req.more_clause.sub_requests[0]
+        self.assertEqual(sub1.filename, "EXPERSON")
+        self.assertEqual(len(sub1.where_clauses), 1)
+
+        sub2 = req.more_clause.sub_requests[1]
+        self.assertEqual(sub2.filename, "OTHERS")
+        self.assertEqual(len(sub2.where_clauses), 0)
+
+    def test_match_multi_file_asg(self):
+        text = """
+        MATCH FILE file1
+        RUN
+        FILE file2
+        AFTER MATCH OLD-OR-NEW
+        RUN
+        FILE file3
+        AFTER MATCH OLD-AND-NEW
+        END
+        """
+        asg = self.get_asg(text)
+        self.assertEqual(len(asg), 1)
+        match_req = asg[0]
+        self.assertEqual(len(match_req.sub_matches), 2)
+        self.assertEqual(match_req.sub_matches[0].after_match.merge_type, "OLD-OR-NEW")
+        self.assertEqual(match_req.sub_matches[1].after_match.merge_type, "OLD-AND-NEW")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implemented Abstract Semantic Graph (ASG) support for WebFOCUS `MATCH FILE` requests and `MORE` phrases. This includes defining new ASG nodes and implementing the corresponding visitor logic in `ReportASGBuilder`.

Key changes:
- `src/asg.py`: Defined `MatchRequest`, `SubMatch`, `AfterMatchPhrase`, `MoreClause`, and `MoreSubRequest`.
- `src/asg_builder.py`: Implemented `visitMatch_request`, `visitSub_match`, `visitAfter_match_phrase`, and `visitMore_phrase`. Updated `visitRequest` to handle `more_phrase`.
- `test/test_asg_match_more.py`: New tests verifying the correct construction of the ASG for these constructs.
- `MIGRATION_ROADMAP.md`: Marked 5.1.3.12.2 and 5.1.3.13.2 as complete.

Fixes #295

---
*PR created automatically by Jules for task [6263736780852387289](https://jules.google.com/task/6263736780852387289) started by @chatelao*