### PR TITLE
Implement MORE phrase support in emitter (Step 5.1.3.13.3)

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -208,7 +208,7 @@ Ensure the new system produces correct results and maintains parity with the leg
     - [ ] 5.1.3.13 Support `MORE` phrase (Universal Concatenation).
       - [x] 5.1.3.13.1 Grammar support for `MORE` phrase in `TABLE` and `MATCH` requests.
       - [x] 5.1.3.13.2 ASG support for `MoreClause` and sub-requests.
-      - [ ] 5.1.3.13.3 Emitter support for `UNION ALL`.
+      - [x] 5.1.3.13.3 Emitter support for `UNION ALL`.
   - [x] 5.1.4 Semantic Parity: Verify that ASG and IR transformations preserve source semantics.
     - [x] 5.1.4.1 Symbol Resolution Validation:
       - [x] 5.1.4.1.1 Global vs. Local scope resolution for AmperVars.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -675,6 +675,7 @@ class PostgresEmitter:
             left_table_alias = alias_map.get(join.left_file, join.left_file)
             alias_part = f" {right_alias}" if right_alias != right_table else ""
             join_clauses.append(f"{join_type} {right_table}{alias_part} ON {left_table_alias}.{join.left_field} = {right_alias}.{join.right_field}")
+
         select_fields = []
         where_clauses = []
         group_by_fields = []
@@ -865,24 +866,125 @@ class PostgresEmitter:
         if not select_fields:
             select_fields = ['*']
 
-        sql = f"/* {instr.filename} */"
-        if report_comments:
-            sql += "\n" + "\n".join(report_comments)
-        sql += f"\nSELECT {', '.join(select_fields)} FROM {table_name}"
-        if join_clauses:
-            sql += "\n" + "\n".join(join_clauses)
+        if instr.more_clause:
+            # Construct a UNION ALL of all data sources first
+            source_queries = []
 
-        if where_clauses:
-            sql += "\nWHERE " + " AND ".join(where_clauses)
+            # 1. Primary file source
+            primary_src_fields = []
+            # We must include all fields needed by the outer query: BY fields and PRINT/SUM fields
+            # Actually, to make UNION ALL work, all branches must have the same columns.
+            # We'll use the raw field names (no aggregations) for the inner sources.
 
-        if is_aggregating and group_by_fields:
-            sql += "\nGROUP BY " + ", ".join(group_by_fields)
+            # Identify all unique raw fields needed
+            needed_raw_fields = []
+            for sc in sort_commands:
+                if sc.field.name not in needed_raw_fields:
+                    needed_raw_fields.append(sc.field.name)
+            for vc in verb_commands:
+                for f in vc.fields:
+                    if f.name != '*' and f.name not in needed_raw_fields:
+                        needed_raw_fields.append(f.name)
 
-        if having_clauses:
-            sql += "\nHAVING " + " AND ".join(having_clauses)
+            def get_source_select(table_alias, fields, q_func):
+                return [f"{q_func(f)} AS \"{f}\"" for f in fields]
 
-        if order_by_phrases:
-            sql += "\nORDER BY " + ", ".join(order_by_phrases)
+            primary_select = get_source_select(table_name, needed_raw_fields, qualify_field)
+            p_sql = f"SELECT {', '.join(primary_select)} FROM {table_name}"
+            if join_clauses:
+                p_sql += "\n" + "\n".join(join_clauses)
+            if where_clauses:
+                p_sql += "\nWHERE " + " AND ".join(where_clauses)
+            source_queries.append(p_sql)
+
+            # 2. MORE FILE sources
+            for sub in instr.more_clause.sub_requests:
+                sub_t = self._resolve_table_name(sub.filename)
+                sub_q_func = lambda f: f"{sub_t}.{f}"
+                sub_select = get_source_select(sub_t, needed_raw_fields, sub_q_func)
+                s_sql = f"SELECT {', '.join(sub_select)} FROM {sub_t}"
+                sub_where = [self.emit_expression(c.condition, in_query=True, virtual_fields=file_virtual_fields, qualifier=sub_q_func)
+                             for c in sub.where_clauses]
+                if sub_where:
+                    s_sql += "\nWHERE " + " AND ".join(sub_where)
+                source_queries.append(s_sql)
+
+            union_sql = "\nUNION ALL\n".join(source_queries)
+
+            # Now build the outer query
+            # Qualify everything to the "SRC" alias
+            outer_qualify = lambda f: f"SRC.\"{f}\""
+
+            outer_select = []
+            for sc in sort_commands:
+                if not sc.noprint:
+                    outer_select.append(f"{outer_qualify(sc.field.name)}" + (f" AS \"{sc.field.alias}\"" if sc.field.alias else ""))
+
+            for vc in verb_commands:
+                for f_sel in vc.fields:
+                    if f_sel.name == '*': continue
+                    sql_f = outer_qualify(f_sel.name)
+                    prefix = f_sel.prefix_operators[0] if f_sel.prefix_operators else None
+                    if prefix:
+                        prefix_map = {'AVE': 'AVG', 'MIN': 'MIN', 'MAX': 'MAX', 'SUM': 'SUM', 'CNT': 'COUNT', 'TOT': 'SUM'}
+                        agg_func = prefix_map.get(prefix)
+                        if agg_func: sql_f = f"{agg_func}({sql_f})"
+                    elif vc.verb == 'SUM': sql_f = f"SUM({sql_f})"
+                    elif vc.verb == 'COUNT': sql_f = f"COUNT({sql_f})"
+
+                    if f_sel.alias: sql_f = f"{sql_f} AS \"{f_sel.alias}\""
+                    outer_select.append(sql_f)
+
+            for cc in compute_commands:
+                sql_e = self.emit_expression(cc.expression, in_query=True, virtual_fields=file_virtual_fields, qualifier=outer_qualify, aggregate=is_aggregating, group_by_fields=[])
+                alias = getattr(cc, 'alias', None) or cc.name
+                outer_select.append(f"{sql_e} AS \"{alias}\"")
+
+            sql = f"/* {instr.filename} with MORE */"
+            if report_comments:
+                sql += "\n" + "\n".join(report_comments)
+
+            sql += f"\nSELECT {', '.join(outer_select)} FROM (\n"
+            sql += self._indent(union_sql, 4)
+            sql += "\n) AS SRC"
+
+            if is_aggregating and group_by_fields:
+                outer_group_by = [outer_qualify(sc.field.name) for sc in sort_commands]
+                sql += "\nGROUP BY " + ", ".join(outer_group_by)
+
+            if having_clauses:
+                 # Re-emit having clauses qualified to SRC
+                 outer_having = [self.emit_expression(c.condition, in_query=True, virtual_fields=file_virtual_fields, qualifier=outer_qualify, aggregate=is_aggregating, group_by_fields=[]) for c in instr.components
+                          if c.__class__.__name__ == 'WhereClause' and c.is_total]
+                 sql += "\nHAVING " + " AND ".join(outer_having)
+
+            if order_by_phrases:
+                outer_order_by = []
+                for sc in sort_commands:
+                     direction = "DESC" if sc.options.get("order") == "HIGHEST" else "ASC"
+                     outer_order_by.append(f"{outer_qualify(sc.field.name)} {direction}")
+                sql += "\nORDER BY " + ", ".join(outer_order_by)
+
+        else:
+            # Standard report logic (no MORE)
+            sql = f"/* {instr.filename} */"
+            if report_comments:
+                sql += "\n" + "\n".join(report_comments)
+            sql += f"\nSELECT {', '.join(select_fields)} FROM {table_name}"
+            if join_clauses:
+                sql += "\n" + "\n".join(join_clauses)
+
+            if where_clauses:
+                sql += "\nWHERE " + " AND ".join(where_clauses)
+
+            if is_aggregating and group_by_fields:
+                sql += "\nGROUP BY " + ", ".join(group_by_fields)
+
+            if having_clauses:
+                sql += "\nHAVING " + " AND ".join(having_clauses)
+
+            if order_by_phrases:
+                sql += "\nORDER BY " + ", ".join(order_by_phrases)
 
         if merge_cmd:
             target_table = self._resolve_table_name(merge_cmd.filename)

--- a/src/ir.py
+++ b/src/ir.py
@@ -78,8 +78,8 @@ class Define(Instruction):
 
 class Report(Instruction):
     """Represents a report request (TABLE FILE)."""
-    def __init__(self, filename, components, joins=None, **kwargs):
-        super().__init__(filename=filename, components=components, joins=joins or [], **kwargs)
+    def __init__(self, filename, components, joins=None, more_clause=None, **kwargs):
+        super().__init__(filename=filename, components=components, joins=joins or [], more_clause=more_clause, **kwargs)
 
 class CompoundLayout(Instruction):
     """Represents the start of a COMPOUND LAYOUT block."""

--- a/src/ir_builder.py
+++ b/src/ir_builder.py
@@ -204,7 +204,8 @@ class IRBuilder:
                 self.current_block.add_instruction(ir.Report(
                     filename=node.filename,
                     components=node.components,
-                    joins=list(self.active_joins)
+                    joins=list(self.active_joins),
+                    more_clause=node.more_clause
                 ))
             elif class_name == 'JoinClear':
                 self.current_block.add_instruction(ir.JoinClear())

--- a/src/metadata_registry.py
+++ b/src/metadata_registry.py
@@ -18,6 +18,10 @@ class MetadataRegistry:
         if path not in self.search_paths:
             self.search_paths.append(path)
 
+    def register_master_file(self, master_file):
+        """Manually registers a MasterFile ASG node."""
+        self.cache[master_file.name.upper()] = master_file
+
     def get_master_file(self, name):
         """
         Retrieves a MasterFile ASG node by name.

--- a/test/test_e2e_more_phrase.py
+++ b/test/test_e2e_more_phrase.py
@@ -1,0 +1,72 @@
+import unittest
+from antlr4 import InputStream, CommonTokenStream
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from ir_builder import IRBuilder
+from emitter import PostgresEmitter
+from metadata_registry import MetadataRegistry
+from asg import MasterFile, Segment, Field
+
+class TestE2EMorePhrase(unittest.TestCase):
+    def test_more_phrase_union_all(self):
+        fex = """
+        TABLE FILE EMP1
+        SUM SALARY BY EMP_ID
+        WHERE DEPT EQ 'A'
+        MORE
+        FILE EMP2
+        WHERE DEPT EQ 'B'
+        END
+        """
+
+        # Setup metadata
+        registry = MetadataRegistry()
+        emp1 = MasterFile(name="EMP1")
+        seg1 = Segment(name="S1")
+        seg1.fields = [Field(name="SALARY", format="I8"), Field(name="EMP_ID", format="A10"), Field(name="DEPT", format="A10")]
+        emp1.segments = [seg1]
+        registry.register_master_file(emp1)
+
+        emp2 = MasterFile(name="EMP2")
+        seg2 = Segment(name="S2")
+        seg2.fields = [Field(name="SALARY", format="I8"), Field(name="EMP_ID", format="A10"), Field(name="DEPT", format="A10")]
+        emp2.segments = [seg2]
+        registry.register_master_file(emp2)
+
+        # Parse
+        input_stream = InputStream(fex)
+        lexer = WebFocusReportLexer(input_stream)
+        token_stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(token_stream)
+        tree = parser.start()
+
+        asg_builder = ReportASGBuilder()
+        asg_nodes = asg_builder.visit(tree)
+
+        # Build IR
+        ir_builder = IRBuilder()
+        cfg = ir_builder.build(asg_nodes)
+
+        # Emit
+        emitter = PostgresEmitter(metadata_registry=registry)
+        sql = emitter.emit(cfg)
+
+        print(sql)
+
+        # Verify
+        self.assertIn("UNION ALL", sql)
+        # Wrapping subquery
+        self.assertIn('SELECT SRC."EMP_ID", SUM(SRC."SALARY") FROM (', sql)
+        # Main source query
+        self.assertIn('SELECT EMP_ID AS "EMP_ID", SALARY AS "SALARY" FROM EMP1', sql)
+        self.assertIn("WHERE (DEPT = 'A')", sql)
+        # Sub source query
+        self.assertIn('SELECT EMP2.EMP_ID AS "EMP_ID", EMP2.SALARY AS "SALARY" FROM EMP2', sql)
+        self.assertIn("WHERE (EMP2.DEPT = 'B')", sql)
+        # Final aggregation
+        self.assertIn('GROUP BY SRC."EMP_ID"', sql)
+        self.assertIn('ORDER BY SRC."EMP_ID" ASC', sql)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I have implemented support for the `MORE` phrase (Universal Concatenation) in the PostgreSQL emitter, fulfilling step 5.1.3.13.3 of the `MIGRATION_ROADMAP.md`. 

The implementation ensures semantic correctness by wrapping the individual data sources (primary file and `MORE FILE` entries) in a `UNION ALL` subquery. This allows the outer query to perform global aggregations (like `SUM` and `COUNT`), post-aggregation filtering (`HAVING`), and global sorting (`ORDER BY`) on the combined dataset, matching WebFOCUS semantics.

I've also:
- Updated the Intermediate Representation (IR) to carry the `more_clause` metadata.
- Modified the `IRBuilder` to extract this metadata from the ASG.
- Enhanced the `MetadataRegistry` with a helper for manual Master File registration to simplify unit testing.
- Added a comprehensive end-to-end test `test/test_e2e_more_phrase.py`.
- Verified the fix against the full test suite (290 tests passing).
- Updated the roadmap to reflect this progress.

Fixes #297

---
*PR created automatically by Jules for task [2053672711262561957](https://jules.google.com/task/2053672711262561957) started by @chatelao*