### PR TITLE
Implement basic SQL generation for MATCH FILE

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -206,7 +206,7 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [x] 5.1.3.12.2 ASG support for `MatchRequest`, `SubMatch`, and `AfterMatchPhrase`.
       - [ ] 5.1.3.12.3 Emitter support for `MATCH` logic.
         - [x] 5.1.3.12.3.1 IR support for `MATCH FILE`.
-        - [ ] 5.1.3.12.3.2 Basic SQL generation for `MATCH` (merging two files).
+        - [x] 5.1.3.12.3.2 Basic SQL generation for `MATCH` (merging two files).
         - [ ] 5.1.3.12.3.3 Support for all merge phrases (OLD-OR-NEW, etc.).
     - [x] 5.1.3.13 Support `MORE` phrase (Universal Concatenation).
       - [x] 5.1.3.13.1 Grammar support for `MORE` phrase in `TABLE` and `MATCH` requests.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -444,7 +444,7 @@ class PostgresEmitter:
             return self._emit_report(instr)
 
         elif class_name == 'Match':
-            return f"/* MATCH FILE {instr.filename} ... (Emission not implemented) */"
+            return self._emit_match(instr)
 
         elif class_name == 'Call':
             args = [self.emit_expression(arg) for arg in instr.arguments]
@@ -1026,6 +1026,110 @@ class PostgresEmitter:
 
         sql += ";"
         return sql
+
+    def _emit_match(self, instr):
+        """
+        Translates ir.Match instruction into a SQL SELECT statement using CTEs.
+        """
+        if not instr.sub_matches:
+             return f"/* MATCH FILE {instr.filename} with no sub-matches */"
+
+        def process_match_request(filename, components):
+            table_name = self._resolve_table_name(filename)
+
+            select_fields = []
+            group_by_fields = []
+            value_fields = []
+
+            # BY fields
+            for comp in components:
+                if comp.__class__.__name__ == 'SortCommand' and comp.sort_type == 'BY':
+                    f_name = comp.field.name
+                    select_fields.append(f"\"{f_name}\"")
+                    group_by_fields.append(f"\"{f_name}\"")
+
+            # Verb fields
+            for comp in components:
+                if comp.__class__.__name__ == 'VerbCommand':
+                    for f_sel in comp.fields:
+                        if f_sel.name == '*': continue
+                        f_name = f_sel.name
+                        if f"\"{f_name}\"" in group_by_fields: continue
+
+                        alias = f_sel.alias or f_name
+                        if comp.verb == 'SUM':
+                            select_fields.append(f"SUM(\"{f_name}\") AS \"{alias}\"")
+                        elif comp.verb == 'COUNT':
+                            select_fields.append(f"COUNT(\"{f_name}\") AS \"{alias}\"")
+                        else:
+                            select_fields.append(f"\"{f_name}\" AS \"{alias}\"")
+                        value_fields.append(alias)
+
+            # Where clauses
+            where_clauses = []
+            for comp in components:
+                if comp.__class__.__name__ == 'WhereClause':
+                    where_clauses.append(self.emit_expression(comp.condition, in_query=True, qualifier=lambda f: f"\"{f}\"" if '.' not in f else f))
+
+            sql = f"SELECT {', '.join(select_fields)} FROM {table_name}"
+            if where_clauses:
+                sql += f" WHERE {' AND '.join(where_clauses)}"
+            if group_by_fields:
+                sql += f" GROUP BY {', '.join(group_by_fields)}"
+            return sql, [f.strip('"') for f in group_by_fields], value_fields
+
+        # First file
+        sql1, keys1, vals1 = process_match_request(instr.filename, instr.components)
+
+        # For now, handle exactly one sub_match (merging two files)
+        sub = instr.sub_matches[0]
+        sql2, keys2, vals2 = process_match_request(sub.filename, sub.components)
+
+        merge_type = "OLD-OR-NEW"
+        if sub.after_match:
+            merge_type = sub.after_match.merge_type.upper().replace('_', '-')
+
+        res = "WITH\n"
+        res += "  T1 AS (\n" + self._indent(sql1, 4) + "\n  ),\n"
+        res += "  T2 AS (\n" + self._indent(sql2, 4) + "\n  )\n"
+
+        # Final SELECT
+        final_sel = []
+        for i in range(min(len(keys1), len(keys2))):
+            k1 = keys1[i]
+            k2 = keys2[i]
+            final_sel.append(f"COALESCE(T1.\"{k1}\", T2.\"{k2}\") AS \"{k1}\"")
+
+        for v in vals1:
+            final_sel.append(f"T1.\"{v}\"")
+        for v in vals2:
+            final_sel.append(f"T2.\"{v}\"")
+
+        res += "SELECT " + ", ".join(final_sel) + "\nFROM T1\n"
+
+        if merge_type == 'OLD-OR-NEW':
+            res += "FULL OUTER JOIN T2 ON "
+        elif merge_type == 'OLD-AND-NEW':
+            res += "INNER JOIN T2 ON "
+        elif merge_type in ('OLD-NOT-NEW', 'OLD'):
+            res += "LEFT JOIN T2 ON "
+        elif merge_type in ('NEW-NOT-OLD', 'NEW'):
+            res += "RIGHT JOIN T2 ON "
+        else:
+            res += "FULL OUTER JOIN T2 ON "
+
+        on_conds = []
+        for i in range(min(len(keys1), len(keys2))):
+            on_conds.append(f"T1.\"{keys1[i]}\" = T2.\"{keys2[i]}\"")
+        res += " AND ".join(on_conds)
+
+        if merge_type == 'OLD-NOT-NEW':
+            res += f"\nWHERE T2.\"{keys2[0]}\" IS NULL"
+        elif merge_type == 'NEW-NOT-OLD':
+            res += f"\nWHERE T1.\"{keys1[0]}\" IS NULL"
+
+        res += ";"
+        return res
 
     def _resolve_table_name(self, filename):
         """

--- a/test/test_e2e_match.py
+++ b/test/test_e2e_match.py
@@ -1,0 +1,72 @@
+import unittest
+import sys
+import os
+
+# Add src to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from asg import (
+    MatchRequest, SubMatch, VerbCommand, FieldSelection,
+    SortCommand, AfterMatchPhrase, MasterFile, Segment, Field
+)
+from ir_builder import IRBuilder
+from emitter import PostgresEmitter
+from metadata_registry import MetadataRegistry
+
+class TestE2EMatch(unittest.TestCase):
+    def test_basic_match_old_or_new(self):
+        # Setup metadata
+        registry = MetadataRegistry()
+
+        f1 = MasterFile(name="FILE1")
+        s1 = Segment(name="S1")
+        s1.fields = [Field(name="PRODUCT"), Field(name="SALES")]
+        f1.segments = [s1]
+        registry.register_master_file(f1)
+
+        f2 = MasterFile(name="FILE2")
+        s2 = Segment(name="S2")
+        s2.fields = [Field(name="PRODUCT"), Field(name="RETURNS")]
+        f2.segments = [s2]
+        registry.register_master_file(f2)
+
+        # Construct ASG
+        match_request = MatchRequest(
+            filename="FILE1",
+            components=[
+                VerbCommand(verb="SUM", fields=[FieldSelection(name="SALES")]),
+                SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+            ],
+            sub_matches=[
+                SubMatch(
+                    filename="FILE2",
+                    components=[
+                        VerbCommand(verb="SUM", fields=[FieldSelection(name="RETURNS")]),
+                        SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+                    ],
+                    after_match=AfterMatchPhrase(merge_type="OLD-OR-NEW")
+                )
+            ]
+        )
+
+        # Build IR
+        builder = IRBuilder()
+        cfg = builder.build([match_request])
+
+        # Emit SQL
+        emitter = PostgresEmitter(metadata_registry=registry)
+        sql = emitter.emit(cfg)
+
+        print(sql)
+
+        # Basic assertions
+        self.assertIn("FULL OUTER JOIN", sql)
+        self.assertIn("COALESCE", sql)
+        self.assertIn("FILE1", sql)
+        self.assertIn("FILE2", sql)
+        self.assertIn("PRODUCT", sql)
+        self.assertIn("SALES", sql)
+        self.assertIn("RETURNS", sql)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented basic SQL generation for the `MATCH FILE` command in `src/emitter.py`. The implementation uses Common Table Expressions (CTEs) for each file in the match request and joins them using PostgreSQL JOIN types corresponding to WebFOCUS merge phrases (e.g., `FULL OUTER JOIN` for `OLD-OR-NEW`). It also handles join key `COALESCE` logic and basic field selection with aggregations. Verified with a new end-to-end test and the existing test suite.

Fixes #301

---
*PR created automatically by Jules for task [15403054171818652222](https://jules.google.com/task/15403054171818652222) started by @chatelao*