### PR TITLE
Support for all MATCH FILE merge phrases and multi-file chaining

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -204,10 +204,10 @@ Ensure the new system produces correct results and maintains parity with the leg
     - [ ] 5.1.3.12 Support `MATCH FILE` command.
       - [x] 5.1.3.12.1 Grammar support for `MATCH FILE`, `RUN`, `AFTER MATCH`, and merge phrases (`OLD-OR-NEW`, `OLD-AND-NEW`, `OLD-NOT-NEW`, `NEW-NOT-OLD`, `OLD-NOR-NEW`, `OLD`, `NEW`).
       - [x] 5.1.3.12.2 ASG support for `MatchRequest`, `SubMatch`, and `AfterMatchPhrase`.
-      - [ ] 5.1.3.12.3 Emitter support for `MATCH` logic.
+      - [x] 5.1.3.12.3 Emitter support for `MATCH` logic.
         - [x] 5.1.3.12.3.1 IR support for `MATCH FILE`.
         - [x] 5.1.3.12.3.2 Basic SQL generation for `MATCH` (merging two files).
-        - [ ] 5.1.3.12.3.3 Support for all merge phrases (OLD-OR-NEW, etc.).
+        - [x] 5.1.3.12.3.3 Support for all merge phrases (OLD-OR-NEW, etc.) and multi-file chaining.
     - [x] 5.1.3.13 Support `MORE` phrase (Universal Concatenation).
       - [x] 5.1.3.13.1 Grammar support for `MORE` phrase in `TABLE` and `MATCH` requests.
       - [x] 5.1.3.13.2 ASG support for `MoreClause` and sub-requests.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -1032,7 +1032,7 @@ class PostgresEmitter:
         Translates ir.Match instruction into a SQL SELECT statement using CTEs.
         """
         if not instr.sub_matches:
-             return f"/* MATCH FILE {instr.filename} with no sub-matches */"
+            return f"/* MATCH FILE {instr.filename} with no sub-matches */"
 
         def process_match_request(filename, components):
             table_name = self._resolve_table_name(filename)
@@ -1078,57 +1078,74 @@ class PostgresEmitter:
                 sql += f" GROUP BY {', '.join(group_by_fields)}"
             return sql, [f.strip('"') for f in group_by_fields], value_fields
 
-        # First file
-        sql1, keys1, vals1 = process_match_request(instr.filename, instr.components)
+        # CTE definitions
+        ctes = []
+        sql_first, keys_first, vals_first = process_match_request(instr.filename, instr.components)
+        ctes.append(f"T1 AS (\n{self._indent(sql_first, 4)}\n)")
 
-        # For now, handle exactly one sub_match (merging two files)
-        sub = instr.sub_matches[0]
-        sql2, keys2, vals2 = process_match_request(sub.filename, sub.components)
+        # Sequential merges
+        current_name = "T1"
+        current_keys = keys_first
+        current_vals = vals_first
 
-        merge_type = "OLD-OR-NEW"
-        if sub.after_match:
-            merge_type = sub.after_match.merge_type.upper().replace('_', '-')
+        for idx, sub in enumerate(instr.sub_matches):
+            source_idx = idx + 2
+            sql_sub, keys_sub, vals_sub = process_match_request(sub.filename, sub.components)
+            ctes.append(f"T{source_idx} AS (\n{self._indent(sql_sub, 4)}\n)")
 
-        res = "WITH\n"
-        res += "  T1 AS (\n" + self._indent(sql1, 4) + "\n  ),\n"
-        res += "  T2 AS (\n" + self._indent(sql2, 4) + "\n  )\n"
+            merge_name = f"M{idx + 1}"
+            merge_type = "OLD-OR-NEW"
+            if sub.after_match:
+                merge_type = sub.after_match.merge_type.upper().replace('_', '-')
 
-        # Final SELECT
-        final_sel = []
-        for i in range(min(len(keys1), len(keys2))):
-            k1 = keys1[i]
-            k2 = keys2[i]
-            final_sel.append(f"COALESCE(T1.\"{k1}\", T2.\"{k2}\") AS \"{k1}\"")
+            # Determine JOIN type and WHERE filter
+            join_clause = "FULL OUTER JOIN"
+            where_filter = None
 
-        for v in vals1:
-            final_sel.append(f"T1.\"{v}\"")
-        for v in vals2:
-            final_sel.append(f"T2.\"{v}\"")
+            if merge_type == 'OLD-AND-NEW':
+                join_clause = "INNER JOIN"
+            elif merge_type == 'OLD-NOT-NEW':
+                join_clause = "LEFT JOIN"
+                where_filter = f"T{source_idx}.\"{keys_sub[0]}\" IS NULL"
+            elif merge_type == 'OLD':
+                join_clause = "LEFT JOIN"
+            elif merge_type == 'NEW-NOT-OLD':
+                join_clause = "RIGHT JOIN"
+                where_filter = f"{current_name}.\"{current_keys[0]}\" IS NULL"
+            elif merge_type == 'NEW':
+                join_clause = "RIGHT JOIN"
+            elif merge_type == 'OLD-NOR-NEW':
+                join_clause = "FULL OUTER JOIN"
+                where_filter = f"{current_name}.\"{current_keys[0]}\" IS NULL OR T{source_idx}.\"{keys_sub[0]}\" IS NULL"
 
-        res += "SELECT " + ", ".join(final_sel) + "\nFROM T1\n"
+            # Build the merge CTE
+            merge_sel = []
+            for i in range(min(len(current_keys), len(keys_sub))):
+                k_curr = current_keys[i]
+                k_sub = keys_sub[i]
+                merge_sel.append(f"COALESCE({current_name}.\"{k_curr}\", T{source_idx}.\"{k_sub}\") AS \"{k_curr}\"")
 
-        if merge_type == 'OLD-OR-NEW':
-            res += "FULL OUTER JOIN T2 ON "
-        elif merge_type == 'OLD-AND-NEW':
-            res += "INNER JOIN T2 ON "
-        elif merge_type in ('OLD-NOT-NEW', 'OLD'):
-            res += "LEFT JOIN T2 ON "
-        elif merge_type in ('NEW-NOT-OLD', 'NEW'):
-            res += "RIGHT JOIN T2 ON "
-        else:
-            res += "FULL OUTER JOIN T2 ON "
+            for v in current_vals:
+                merge_sel.append(f"{current_name}.\"{v}\"")
+            for v in vals_sub:
+                merge_sel.append(f"T{source_idx}.\"{v}\"")
 
-        on_conds = []
-        for i in range(min(len(keys1), len(keys2))):
-            on_conds.append(f"T1.\"{keys1[i]}\" = T2.\"{keys2[i]}\"")
-        res += " AND ".join(on_conds)
+            on_conds = []
+            for i in range(min(len(current_keys), len(keys_sub))):
+                on_conds.append(f"{current_name}.\"{current_keys[i]}\" = T{source_idx}.\"{keys_sub[i]}\"")
 
-        if merge_type == 'OLD-NOT-NEW':
-            res += f"\nWHERE T2.\"{keys2[0]}\" IS NULL"
-        elif merge_type == 'NEW-NOT-OLD':
-            res += f"\nWHERE T1.\"{keys1[0]}\" IS NULL"
+            m_sql = f"SELECT {', '.join(merge_sel)}\nFROM {current_name} {join_clause} T{source_idx} ON {' AND '.join(on_conds)}"
+            if where_filter:
+                m_sql += f"\nWHERE {where_filter}"
 
-        res += ";"
+            ctes.append(f"{merge_name} AS (\n{self._indent(m_sql, 4)}\n)")
+
+            current_name = merge_name
+            current_vals = current_vals + vals_sub
+            # Keys remain derived from the first file's naming convention for consistency in the chain
+
+        res = "WITH\n" + ",\n".join(ctes) + "\n"
+        res += f"SELECT * FROM {current_name};"
         return res
 
     def _resolve_table_name(self, filename):

--- a/test/test_e2e_match.py
+++ b/test/test_e2e_match.py
@@ -68,5 +68,204 @@ class TestE2EMatch(unittest.TestCase):
         self.assertIn("SALES", sql)
         self.assertIn("RETURNS", sql)
 
+    def test_match_old_nor_new(self):
+        # Setup metadata
+        registry = MetadataRegistry()
+        f1 = MasterFile(name="FILE1")
+        s1 = Segment(name="S1")
+        s1.fields = [Field(name="PRODUCT"), Field(name="SALES")]
+        f1.segments = [s1]
+        registry.register_master_file(f1)
+
+        f2 = MasterFile(name="FILE2")
+        s2 = Segment(name="S2")
+        s2.fields = [Field(name="PRODUCT"), Field(name="RETURNS")]
+        f2.segments = [s2]
+        registry.register_master_file(f2)
+
+        # Construct ASG
+        match_request = MatchRequest(
+            filename="FILE1",
+            components=[
+                VerbCommand(verb="SUM", fields=[FieldSelection(name="SALES")]),
+                SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+            ],
+            sub_matches=[
+                SubMatch(
+                    filename="FILE2",
+                    components=[
+                        VerbCommand(verb="SUM", fields=[FieldSelection(name="RETURNS")]),
+                        SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+                    ],
+                    after_match=AfterMatchPhrase(merge_type="OLD-NOR-NEW")
+                )
+            ]
+        )
+
+        # Build IR
+        builder = IRBuilder()
+        cfg = builder.build([match_request])
+
+        # Emit SQL
+        emitter = PostgresEmitter(metadata_registry=registry)
+        sql = emitter.emit(cfg)
+
+        print(sql)
+
+        # Assertions for OLD-NOR-NEW (symmetric difference)
+        self.assertIn("FULL OUTER JOIN", sql)
+        # Check for WHERE clause that implements symmetric difference
+        self.assertIn("WHERE T1.\"PRODUCT\" IS NULL OR T2.\"PRODUCT\" IS NULL", sql)
+
+    def test_three_file_match(self):
+        # Setup metadata
+        registry = MetadataRegistry()
+        for i in range(1, 4):
+            f = MasterFile(name=f"FILE{i}")
+            s = Segment(name=f"S{i}")
+            s.fields = [Field(name="PRODUCT"), Field(name=f"VAL{i}")]
+            f.segments = [s]
+            registry.register_master_file(f)
+
+        # Construct ASG: FILE1 + FILE2 + FILE3
+        match_request = MatchRequest(
+            filename="FILE1",
+            components=[
+                VerbCommand(verb="SUM", fields=[FieldSelection(name="VAL1")]),
+                SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+            ],
+            sub_matches=[
+                SubMatch(
+                    filename="FILE2",
+                    components=[
+                        VerbCommand(verb="SUM", fields=[FieldSelection(name="VAL2")]),
+                        SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+                    ],
+                    after_match=AfterMatchPhrase(merge_type="OLD-OR-NEW")
+                ),
+                SubMatch(
+                    filename="FILE3",
+                    components=[
+                        VerbCommand(verb="SUM", fields=[FieldSelection(name="VAL3")]),
+                        SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+                    ],
+                    after_match=AfterMatchPhrase(merge_type="OLD-AND-NEW")
+                )
+            ]
+        )
+
+        # Build IR
+        builder = IRBuilder()
+        cfg = builder.build([match_request])
+
+        # Emit SQL
+        emitter = PostgresEmitter(metadata_registry=registry)
+        sql = emitter.emit(cfg)
+
+        print(sql)
+
+        # Assertions for 3-way match
+        self.assertIn("T1 AS (", sql)
+        self.assertIn("T2 AS (", sql)
+        self.assertIn("T3 AS (", sql)
+        self.assertIn("M1 AS (", sql)
+        self.assertIn("M2 AS (", sql)
+        self.assertIn("FROM M1 INNER JOIN T3", sql)
+        self.assertIn("SELECT * FROM M2", sql)
+
+    def test_match_old(self):
+        # Setup metadata
+        registry = MetadataRegistry()
+        f1 = MasterFile(name="FILE1")
+        s1 = Segment(name="S1")
+        s1.fields = [Field(name="PRODUCT"), Field(name="SALES")]
+        f1.segments = [s1]
+        registry.register_master_file(f1)
+
+        f2 = MasterFile(name="FILE2")
+        s2 = Segment(name="S2")
+        s2.fields = [Field(name="PRODUCT"), Field(name="RETURNS")]
+        f2.segments = [s2]
+        registry.register_master_file(f2)
+
+        # Construct ASG
+        match_request = MatchRequest(
+            filename="FILE1",
+            components=[
+                VerbCommand(verb="SUM", fields=[FieldSelection(name="SALES")]),
+                SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+            ],
+            sub_matches=[
+                SubMatch(
+                    filename="FILE2",
+                    components=[
+                        VerbCommand(verb="SUM", fields=[FieldSelection(name="RETURNS")]),
+                        SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+                    ],
+                    after_match=AfterMatchPhrase(merge_type="OLD")
+                )
+            ]
+        )
+
+        # Build IR
+        builder = IRBuilder()
+        cfg = builder.build([match_request])
+
+        # Emit SQL
+        emitter = PostgresEmitter(metadata_registry=registry)
+        sql = emitter.emit(cfg)
+
+        print(sql)
+
+        self.assertIn("LEFT JOIN", sql)
+        self.assertNotIn("WHERE", sql)
+
+    def test_match_new(self):
+        # Setup metadata
+        registry = MetadataRegistry()
+        f1 = MasterFile(name="FILE1")
+        s1 = Segment(name="S1")
+        s1.fields = [Field(name="PRODUCT"), Field(name="SALES")]
+        f1.segments = [s1]
+        registry.register_master_file(f1)
+
+        f2 = MasterFile(name="FILE2")
+        s2 = Segment(name="S2")
+        s2.fields = [Field(name="PRODUCT"), Field(name="RETURNS")]
+        f2.segments = [s2]
+        registry.register_master_file(f2)
+
+        # Construct ASG
+        match_request = MatchRequest(
+            filename="FILE1",
+            components=[
+                VerbCommand(verb="SUM", fields=[FieldSelection(name="SALES")]),
+                SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+            ],
+            sub_matches=[
+                SubMatch(
+                    filename="FILE2",
+                    components=[
+                        VerbCommand(verb="SUM", fields=[FieldSelection(name="RETURNS")]),
+                        SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+                    ],
+                    after_match=AfterMatchPhrase(merge_type="NEW")
+                )
+            ]
+        )
+
+        # Build IR
+        builder = IRBuilder()
+        cfg = builder.build([match_request])
+
+        # Emit SQL
+        emitter = PostgresEmitter(metadata_registry=registry)
+        sql = emitter.emit(cfg)
+
+        print(sql)
+
+        self.assertIn("RIGHT JOIN", sql)
+        self.assertNotIn("WHERE", sql)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR implements full emitter support for the `MATCH FILE` command. 

It introduces a sequential CTE-based merge strategy in the `PostgresEmitter`, allowing for an arbitrary number of files to be merged. Each subsequent file in a `MATCH` request is joined with the cumulative result of all previous merges, respecting the specific merge phrase (e.g., `OLD-OR-NEW`, `OLD-AND-NEW`, etc.) defined for that step.

Key features:
- **Full Merge Phrase Support**: Implemented logic for all WebFOCUS merge phrases, including symmetric difference (`OLD-NOR-NEW`) and anti-joins (`OLD-NOT-NEW`, `NEW-NOT-OLD`).
- **Multi-file Chaining**: The emitter now supports merging more than two files by iteratively building `M_n` CTEs.
- **Regression Fixes**: Ensured `OLD` and `NEW` phrases correctly map to standard `LEFT JOIN` and `RIGHT JOIN` without unintended filtering.
- **Enhanced Testing**: Added specific E2E tests for `OLD-NOR-NEW`, multi-file matches, and validated standard `OLD`/`NEW` behavior.

`MIGRATION_ROADMAP.md` has been updated to reflect the completion of Phase 5.1.3.12.3.

Fixes #303

---
*PR created automatically by Jules for task [14609634873759220290](https://jules.google.com/task/14609634873759220290) started by @chatelao*