### PR TITLE
Decompose roadmap steps and enhance MATCH FILE support

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -116,7 +116,10 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
     - [x] 3.3.2.1 Reachability Analysis: Remove unreachable blocks from CFG. (Implemented in `src/optimizer.py`)
     - [x] 3.3.2.2 Unused Assignment Elimination: Remove SSA assignments with no consumers. (Implemented in `src/optimizer.py`)
 - [ ] **3.4 Relational Lifting:**
-  - [ ] 3.4.1 Loop Analysis: Identify loops that iterate over data sources.
+  - [ ] 3.4.1 Loop Analysis:
+    - [ ] 3.4.1.1 Identification of constant vs. data-driven loops.
+    - [ ] 3.4.1.2 Lifting constant loops to PL/pgSQL procedural logic.
+    - [ ] 3.4.1.3 Identification of loops over data sources for relational lifting.
   - [ ] 3.4.2 Predicate Pushdown:
     - [x] 3.4.2.1 Filter Lifting: Move WHERE conditions to SQL. (Implemented in `src/emitter.py`)
     - [x] 3.4.2.2 Total Lifting: Move WHERE TOTAL conditions to SQL HAVING. (Implemented in `src/emitter.py`)
@@ -201,13 +204,14 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [x] 5.1.3.11.1 Grammar support for `DECODE` syntax.
       - [x] 5.1.3.11.2 ASG support for `DecodeExpression`.
       - [x] 5.1.3.11.3 Emitter support for translating `DECODE` to SQL `CASE`.
-    - [ ] 5.1.3.12 Support `MATCH FILE` command.
+    - [x] 5.1.3.12 Support `MATCH FILE` command.
       - [x] 5.1.3.12.1 Grammar support for `MATCH FILE`, `RUN`, `AFTER MATCH`, and merge phrases (`OLD-OR-NEW`, `OLD-AND-NEW`, `OLD-NOT-NEW`, `NEW-NOT-OLD`, `OLD-NOR-NEW`, `OLD`, `NEW`).
       - [x] 5.1.3.12.2 ASG support for `MatchRequest`, `SubMatch`, and `AfterMatchPhrase`.
       - [x] 5.1.3.12.3 Emitter support for `MATCH` logic.
         - [x] 5.1.3.12.3.1 IR support for `MATCH FILE`.
         - [x] 5.1.3.12.3.2 Basic SQL generation for `MATCH` (merging two files).
         - [x] 5.1.3.12.3.3 Support for all merge phrases (OLD-OR-NEW, etc.) and multi-file chaining.
+        - [x] 5.1.3.12.3.4 Support COMPUTE and virtual fields in MATCH sub-requests.
     - [x] 5.1.3.13 Support `MORE` phrase (Universal Concatenation).
       - [x] 5.1.3.13.1 Grammar support for `MORE` phrase in `TABLE` and `MATCH` requests.
       - [x] 5.1.3.13.2 ASG support for `MoreClause` and sub-requests.
@@ -217,6 +221,7 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [x] 5.1.4.1.1 Global vs. Local scope resolution for AmperVars.
       - [x] 5.1.4.1.2 Multi-segment field resolution in joined Master Files.
       - [x] 5.1.4.1.3 Virtual field shadowing rules (DEFINE vs. Master File).
+      - [x] 5.1.4.1.4 Symbol resolution within complex expression structures (tuples in lists).
     - [x] 5.1.4.2 Type Consistency:
       - [x] 5.1.4.2.1 Numeric precision mapping (I, F, D, P to PostgreSQL).
       - [x] 5.1.4.2.2 Alpha-numeric string truncation and padding semantics. (Verified via `test/test_alpha_parity.py`)
@@ -243,7 +248,10 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [x] 5.2.2.5.2 Parse `summary_report.fex`.
       - [x] 5.2.2.5.3 Parse `detail_report.fex`.
       - [x] 5.2.2.5.4 End-to-end PL/pgSQL emission for Drill Through.
-  - [ ] 5.2.3 Real-world Samples: Validate against complex samples in `test/realworld_samples/`.
+  - [ ] 5.2.3 Real-world Samples:
+    - [ ] 5.2.3.1 Complex Sales Reporting samples.
+    - [ ] 5.2.3.2 Financial Statement samples with complex RECAPs.
+    - [ ] 5.2.3.3 Multi-step MATCH FILE integration samples.
 - [ ] **5.3 Performance Benchmarking:**
   - [ ] 5.3.1 Query Execution: Compare generated SQL performance vs original WebFOCUS execution.
   - [x] 5.3.2 Compilation Overhead: Measure transpilation time for large projects. (Implemented in `scripts/benchmark_compilation.py`)

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -1065,11 +1065,29 @@ class PostgresEmitter:
                             select_fields.append(f"\"{f_name}\" AS \"{alias}\"")
                         value_fields.append(alias)
 
+            # COMPUTE fields
+            for comp in components:
+                if comp.__class__.__name__ == 'ComputeCommand':
+                    sql_expr = self.emit_expression(
+                        comp.expression,
+                        in_query=True,
+                        virtual_fields=self.virtual_fields.get(filename, {}),
+                        qualifier=lambda f: f"\"{f}\"" if '.' not in f else f
+                    )
+                    alias = getattr(comp, 'alias', None) or comp.name
+                    select_fields.append(f"{sql_expr} AS \"{alias}\"")
+                    value_fields.append(alias)
+
             # Where clauses
             where_clauses = []
             for comp in components:
                 if comp.__class__.__name__ == 'WhereClause':
-                    where_clauses.append(self.emit_expression(comp.condition, in_query=True, qualifier=lambda f: f"\"{f}\"" if '.' not in f else f))
+                    where_clauses.append(self.emit_expression(
+                        comp.condition,
+                        in_query=True,
+                        virtual_fields=self.virtual_fields.get(filename, {}),
+                        qualifier=lambda f: f"\"{f}\"" if '.' not in f else f
+                    ))
 
             sql = f"SELECT {', '.join(select_fields)} FROM {table_name}"
             if where_clauses:

--- a/src/symbol_resolver.py
+++ b/src/symbol_resolver.py
@@ -40,6 +40,10 @@ class SymbolResolver:
                 for item in attr_value:
                     if isinstance(item, ASGNode):
                         self.visit(item)
+                    elif isinstance(item, tuple):
+                        for sub_item in item:
+                            if isinstance(sub_item, ASGNode):
+                                self.visit(sub_item)
 
     def visit_SetDM(self, node):
         """Registers a Dialogue Manager variable definition from -SET."""

--- a/src/type_inferrer.py
+++ b/src/type_inferrer.py
@@ -32,6 +32,10 @@ class TypeInferrer:
                 for item in attr_value:
                     if isinstance(item, ASGNode):
                         self.visit(item)
+                    elif isinstance(item, tuple):
+                        for sub_item in item:
+                            if isinstance(sub_item, ASGNode):
+                                self.visit(sub_item)
         return None
 
     def _get_base_type(self, format_str):
@@ -192,3 +196,34 @@ class TypeInferrer:
         self.visit(node.expression)
         node.data_type = 'LOGICAL'
         return node.data_type
+
+    def visit_DecodeExpression(self, node):
+        self.visit(node.expression)
+        types = []
+        for val, res in node.pairs:
+            self.visit(val)
+            types.append(self.visit(res))
+
+        if node.default_value:
+            types.append(self.visit(node.default_value))
+
+        if any(t and t.startswith(('F', 'D', 'P')) for t in types):
+            node.data_type = self._pick_precise_type_list(types, ('F', 'D', 'P')) or 'F'
+        elif any(t and t.startswith('I') for t in types):
+            node.data_type = self._pick_precise_type_list(types, 'I') or 'I'
+        elif types:
+            # Filter out None and pick the first available
+            valid_types = [t for t in types if t]
+            node.data_type = valid_types[0] if valid_types else 'A'
+        else:
+            node.data_type = 'A'
+
+        return node.data_type
+
+    def _pick_precise_type_list(self, type_list, category_prefix):
+        """Helper to pick the most specific/precise type from a list of format strings."""
+        result = None
+        for t in type_list:
+            if t:
+                result = self._pick_precise_type(result, t, category_prefix)
+        return result

--- a/test/test_e2e_match.py
+++ b/test/test_e2e_match.py
@@ -7,7 +7,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../s
 
 from asg import (
     MatchRequest, SubMatch, VerbCommand, FieldSelection,
-    SortCommand, AfterMatchPhrase, MasterFile, Segment, Field
+    SortCommand, AfterMatchPhrase, MasterFile, Segment, Field,
+    ComputeCommand, BinaryOperation, Literal, Identifier,
+    DefineFile, DefineAssignment
 )
 from ir_builder import IRBuilder
 from emitter import PostgresEmitter
@@ -266,6 +268,66 @@ class TestE2EMatch(unittest.TestCase):
 
         self.assertIn("RIGHT JOIN", sql)
         self.assertNotIn("WHERE", sql)
+
+    def test_match_with_compute_and_virtual_fields(self):
+        registry = MetadataRegistry()
+        f1 = MasterFile(name="FILE1")
+        s1 = Segment(name="S1")
+        s1.fields = [Field(name="PRODUCT"), Field(name="SALES")]
+        f1.segments = [s1]
+        registry.register_master_file(f1)
+
+        f2 = MasterFile(name="FILE2")
+        s2 = Segment(name="S2")
+        s2.fields = [Field(name="PRODUCT"), Field(name="RETURNS")]
+        f2.segments = [s2]
+        registry.register_master_file(f2)
+
+        # Virtual field for FILE1
+        define = DefineFile(
+            filename="FILE1",
+            assignments=[
+                DefineAssignment(
+                    name="NET_SALES",
+                    expression=BinaryOperation(Identifier(name="SALES"), "-", Literal(10))
+                )
+            ]
+        )
+
+        match_request = MatchRequest(
+            filename="FILE1",
+            components=[
+                VerbCommand(verb="SUM", fields=[FieldSelection(name="SALES")]),
+                ComputeCommand(
+                    name="CALC_VAL",
+                    expression=BinaryOperation(Identifier(name="NET_SALES"), "*", Literal(2))
+                ),
+                SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+            ],
+            sub_matches=[
+                SubMatch(
+                    filename="FILE2",
+                    components=[
+                        VerbCommand(verb="SUM", fields=[FieldSelection(name="RETURNS")]),
+                        SortCommand(sort_type="BY", field=FieldSelection(name="PRODUCT"))
+                    ],
+                    after_match=AfterMatchPhrase(merge_type="OLD-OR-NEW")
+                )
+            ]
+        )
+
+        builder = IRBuilder()
+        cfg = builder.build([define, match_request])
+
+        emitter = PostgresEmitter(metadata_registry=registry)
+        sql = emitter.emit(cfg)
+
+        print(sql)
+
+        # Assertions
+        # CALC_VAL should be (("SALES" - 10) * 2)
+        self.assertIn("((\"SALES\" - 10) * 2) AS \"CALC_VAL\"", sql)
+        self.assertIn("FULL OUTER JOIN", sql)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR improves the MIGRATION_ROADMAP.md by breaking down complex future tasks into manageable steps. It also implements a modest functional improvement by enhancing the `MATCH FILE` emitter logic to support `COMPUTE` statements and virtual field expansion from `DEFINE`. Additionally, it fixes a traversal gap in the semantic analysis phase (SymbolResolver and TypeInferrer) that prevented correct processing of expressions like `DECODE` where children are stored in tuples.

Fixes #305

---
*PR created automatically by Jules for task [11825183915045514531](https://jules.google.com/task/11825183915045514531) started by @chatelao*