### PR TITLE
Refine and Decompose Migration Roadmap Steps

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -116,10 +116,11 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
     - [x] 3.3.2.1 Reachability Analysis: Remove unreachable blocks from CFG. (Implemented in `src/optimizer.py`)
     - [x] 3.3.2.2 Unused Assignment Elimination: Remove SSA assignments with no consumers. (Implemented in `src/optimizer.py`)
 - [ ] **3.4 Relational Lifting:**
-  - [ ] 3.4.1 Loop Analysis:
-    - [ ] 3.4.1.1 Identification of constant vs. data-driven loops.
-    - [ ] 3.4.1.2 Lifting constant loops to PL/pgSQL procedural logic.
-    - [ ] 3.4.1.3 Identification of loops over data sources for relational lifting.
+  - [ ] 3.4.1 Loop Analysis: (Basic loop lifting to PL/pgSQL state machine implemented)
+    - [x] 3.4.1.1 Identification of constant vs. data-driven loops.
+    - [x] 3.4.1.2 Lifting loops to PL/pgSQL procedural state machine. (Implemented in `src/emitter.py`)
+    - [ ] 3.4.1.3 Identification of simple loops for native `FOR`/`WHILE` optimization.
+    - [ ] 3.4.1.4 Identification of loops over data sources for relational lifting.
   - [ ] 3.4.2 Predicate Pushdown:
     - [x] 3.4.2.1 Filter Lifting: Move WHERE conditions to SQL. (Implemented in `src/emitter.py`)
     - [x] 3.4.2.2 Total Lifting: Move WHERE TOTAL conditions to SQL HAVING. (Implemented in `src/emitter.py`)
@@ -159,7 +160,12 @@ Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
     - [x] 4.3.1.2 Data Sources: Mapping filenames to SQL tables (using `MetadataRegistry`). (Implemented in `src/emitter.py`)
     - [x] 4.3.1.3 Filtering: Mapping WHERE clauses to SQL `WHERE`. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.4 Grouping: Mapping BY/ACROSS phrases to SQL `GROUP BY`. (Implemented in `src/emitter.py`)
-    - [x] 4.3.1.5 Aggregations: Mapping prefix operators (SUM., AVG., etc.) to SQL aggregate functions. (Implemented in `src/emitter.py`)
+    - [ ] 4.3.1.5 Aggregations: Mapping prefix operators to SQL aggregate functions.
+      - [x] 4.3.1.5.1 Basic operators: SUM, AVE, MIN, MAX, CNT, TOT. (Implemented in `src/emitter.py`)
+      - [ ] 4.3.1.5.2 Advanced operators: FST, LST (First/Last via window functions).
+      - [ ] 4.3.1.5.3 Statistical operators: MDN, MDE, ASQ (Median, Mode, Average Square).
+      - [ ] 4.3.1.5.4 Percentage operators: PCT, RPCT (Percentage, Row Percentage).
+      - [ ] 4.3.1.5.5 Rank and Distinct: RNK, DST.
     - [x] 4.3.1.6 Post-Aggregation Filtering: Mapping WHERE TOTAL to SQL `HAVING`. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.7 Sorting: Mapping sort options to SQL `ORDER BY`. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.8 Calculated Values: Mapping COMPUTE command to SQL expressions. (Implemented in `src/emitter.py`)
@@ -253,9 +259,10 @@ Ensure the new system produces correct results and maintains parity with the leg
       - [x] 5.2.2.5.3 Parse `detail_report.fex`.
       - [x] 5.2.2.5.4 End-to-end PL/pgSQL emission for Drill Through.
   - [ ] 5.2.3 Real-world Samples:
-    - [ ] 5.2.3.1 Complex Sales Reporting samples.
-    - [ ] 5.2.3.2 Financial Statement samples with complex RECAPs.
-    - [ ] 5.2.3.3 Multi-step MATCH FILE integration samples.
+    - [ ] 5.2.3.1 Sales and Revenue Dashboard: Complex aggregations, multi-table joins, and temporal filtering.
+    - [ ] 5.2.3.2 Inventory Management: Multi-step `MATCH FILE` chaining and `MORE` phrase for historical vs. current reconciliation.
+    - [ ] 5.2.3.3 HR Organizational Hierarchy: Leveraging `BY...HIERARCHY`, `WHEN`, and `SHOW` for recursive reporting.
+    - [ ] 5.2.3.4 Financial Reconciliation: Complex `RECAP` logic, `COMPUTE` with conditional branching, and Dialogue Manager orchestration.
 - [ ] **5.3 Performance Benchmarking:**
   - [ ] 5.3.1 Query Execution: Compare generated SQL performance vs original WebFOCUS execution.
   - [x] 5.3.2 Compilation Overhead: Measure transpilation time for large projects. (Implemented in `scripts/benchmark_compilation.py`)


### PR DESCRIPTION
This change refines the `MIGRATION_ROADMAP.md` by breaking down broad phases into modest, actionable steps. Specifically, it acknowledges the completion of basic loop lifting while adding optimization goals, expands the scope of aggregation support to include advanced prefix operators, and defines concrete business scenarios for real-world validation.

Fixes #309

---
*PR created automatically by Jules for task [10116696595949436821](https://jules.google.com/task/10116696595949436821) started by @chatelao*