### PR TITLE
Implement Statistical and Distinct Prefix Operators

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -163,9 +163,9 @@ Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
     - [ ] 4.3.1.5 Aggregations: Mapping prefix operators to SQL aggregate functions.
       - [x] 4.3.1.5.1 Basic operators: SUM, AVE, MIN, MAX, CNT, TOT. (Implemented in `src/emitter.py`)
       - [ ] 4.3.1.5.2 Advanced operators: FST, LST (First/Last via window functions).
-      - [ ] 4.3.1.5.3 Statistical operators: MDN, MDE, ASQ (Median, Mode, Average Square).
+      - [x] 4.3.1.5.3 Statistical operators: MDN, MDE, ASQ (Median, Mode, Average Square). (Implemented in `src/emitter.py`)
       - [ ] 4.3.1.5.4 Percentage operators: PCT, RPCT (Percentage, Row Percentage).
-      - [ ] 4.3.1.5.5 Rank and Distinct: RNK, DST.
+      - [ ] 4.3.1.5.5 Rank and Distinct: RNK, DST. (DST implemented in `src/emitter.py`)
     - [x] 4.3.1.6 Post-Aggregation Filtering: Mapping WHERE TOTAL to SQL `HAVING`. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.7 Sorting: Mapping sort options to SQL `ORDER BY`. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.8 Calculated Values: Mapping COMPUTE command to SQL expressions. (Implemented in `src/emitter.py`)

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -804,7 +804,15 @@ class PostgresEmitter:
         for vc in verb_commands:
             if vc.verb in aggregating_verbs:
                 is_aggregating = True
+                break
+            # Check if any field has a prefix operator that implies aggregation
+            for field_sel in vc.fields:
+                if field_sel.prefix_operators:
+                    is_aggregating = True
+                    break
+            if is_aggregating: break
 
+        for vc in verb_commands:
             for field_sel in vc.fields:
                 if field_sel.name == '*':
                     select_fields.append('*')
@@ -826,23 +834,7 @@ class PostgresEmitter:
                             sql_expr = f"CAST({sql_expr} AS {pg_type})"
 
                 # Prefix operators
-                prefix = field_sel.prefix_operators[0] if field_sel.prefix_operators else None
-                if prefix:
-                    prefix_map = {
-                        'AVE': 'AVG',
-                        'MIN': 'MIN',
-                        'MAX': 'MAX',
-                        'SUM': 'SUM',
-                        'CNT': 'COUNT',
-                        'TOT': 'SUM'
-                    }
-                    agg_func = prefix_map.get(prefix)
-                    if agg_func:
-                        sql_expr = f"{agg_func}({sql_expr})"
-                elif vc.verb == 'SUM':
-                    sql_expr = f"SUM({sql_expr})"
-                elif vc.verb == 'COUNT':
-                    sql_expr = f"COUNT({sql_expr})"
+                sql_expr = self._apply_prefixes(sql_expr, field_sel.prefix_operators, vc.verb)
 
                 if field_sel.alias:
                     sql_expr = f"{sql_expr} AS \"{field_sel.alias}\""
@@ -939,13 +931,7 @@ class PostgresEmitter:
                 for f_sel in vc.fields:
                     if f_sel.name == '*': continue
                     sql_f = outer_qualify(f_sel.name)
-                    prefix = f_sel.prefix_operators[0] if f_sel.prefix_operators else None
-                    if prefix:
-                        prefix_map = {'AVE': 'AVG', 'MIN': 'MIN', 'MAX': 'MAX', 'SUM': 'SUM', 'CNT': 'COUNT', 'TOT': 'SUM'}
-                        agg_func = prefix_map.get(prefix)
-                        if agg_func: sql_f = f"{agg_func}({sql_f})"
-                    elif vc.verb == 'SUM': sql_f = f"SUM({sql_f})"
-                    elif vc.verb == 'COUNT': sql_f = f"COUNT({sql_f})"
+                    sql_f = self._apply_prefixes(sql_f, f_sel.prefix_operators, vc.verb)
 
                     if f_sel.alias: sql_f = f"{sql_f} AS \"{f_sel.alias}\""
                     outer_select.append(sql_f)
@@ -1310,6 +1296,59 @@ class PostgresEmitter:
                 self._collect_used_files_in_expr(val, mark_field_used, source_fn)
         elif class_name == 'IsMissingExpression':
             self._collect_used_files_in_expr(expr.expression, mark_field_used, source_fn)
+
+    def _apply_prefixes(self, sql_expr, prefixes, verb=None):
+        """
+        Applies WebFOCUS prefix operators to a SQL expression.
+        """
+        if not prefixes:
+            if verb == 'SUM':
+                return f"SUM({sql_expr})"
+            if verb == 'COUNT':
+                return f"COUNT({sql_expr})"
+            return sql_expr
+
+        # Normalize prefixes
+        prefixes = [p.upper() for p in prefixes]
+        is_distinct = 'DST' in prefixes
+
+        # MDN (Median) and MDE (Mode) have special syntax in PostgreSQL
+        if 'MDN' in prefixes:
+            return f"PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY {sql_expr})"
+        if 'MDE' in prefixes:
+            return f"MODE() WITHIN GROUP (ORDER BY {sql_expr})"
+
+        # ASQ: average sum of squares
+        if 'ASQ' in prefixes:
+            distinct_str = "DISTINCT " if is_distinct else ""
+            return f"AVG({distinct_str}({sql_expr}) * ({sql_expr}))"
+
+        # Mapping for standard aggregates
+        prefix_map = {
+            'AVE': 'AVG',
+            'MIN': 'MIN',
+            'MAX': 'MAX',
+            'SUM': 'SUM',
+            'TOT': 'SUM',
+            'CNT': 'COUNT',
+            'CT': 'COUNT'
+        }
+
+        agg_func = None
+        for p in prefixes:
+            if p in prefix_map:
+                agg_func = prefix_map[p]
+                break
+
+        # Standalone DST implies COUNT(DISTINCT ...)
+        if not agg_func and is_distinct:
+            agg_func = 'COUNT'
+
+        if agg_func:
+            distinct_str = "DISTINCT " if is_distinct else ""
+            return f"{agg_func}({distinct_str}{sql_expr})"
+
+        return sql_expr
 
     def _indent(self, text, spaces):
         """

--- a/test/test_prefix_operators.py
+++ b/test/test_prefix_operators.py
@@ -1,0 +1,100 @@
+import unittest
+import sys
+import os
+from antlr4 import CommonTokenStream, InputStream
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from ir_builder import IRBuilder
+from ssa_transformer import SSATransformer
+from emitter import PostgresEmitter
+
+class TestPrefixOperators(unittest.TestCase):
+    def _compile_to_sql(self, fex_code):
+        input_stream = InputStream(fex_code)
+        lexer = WebFocusReportLexer(input_stream)
+        token_stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(token_stream)
+        tree = parser.start()
+
+        builder = ReportASGBuilder()
+        asg_nodes = builder.visit(tree)
+
+        ir_builder = IRBuilder()
+        cfg = ir_builder.build(asg_nodes)
+
+        ssa_transformer = SSATransformer()
+        ssa_transformer.transform(cfg)
+
+        emitter = PostgresEmitter()
+        return emitter.emit(cfg)
+
+    def test_basic_prefixes(self):
+        fex = """
+        TABLE FILE CAR
+        SUM AVE.PRICE MIN.PRICE MAX.PRICE CNT.PRICE TOT.PRICE CT.PRICE
+        BY COUNTRY
+        END
+        """
+        sql = self._compile_to_sql(fex)
+        self.assertIn("AVG(PRICE)", sql)
+        self.assertIn("MIN(PRICE)", sql)
+        self.assertIn("MAX(PRICE)", sql)
+        self.assertIn("COUNT(PRICE)", sql)
+        self.assertIn("SUM(PRICE)", sql) # TOT.PRICE
+
+    def test_distinct_prefixes(self):
+        fex = """
+        TABLE FILE CAR
+        SUM DST.COUNTRY CNT.DST.COUNTRY SUM.DST.PRICE AVE.DST.PRICE
+        BY COUNTRY
+        END
+        """
+        sql = self._compile_to_sql(fex)
+        self.assertIn("COUNT(DISTINCT COUNTRY)", sql)
+        self.assertIn("SUM(DISTINCT PRICE)", sql)
+        self.assertIn("AVG(DISTINCT PRICE)", sql)
+
+    def test_statistical_prefixes(self):
+        fex = """
+        TABLE FILE CAR
+        SUM ASQ.PRICE MDN.PRICE MDE.PRICE
+        BY COUNTRY
+        END
+        """
+        sql = self._compile_to_sql(fex)
+        self.assertIn("AVG((PRICE) * (PRICE))", sql)
+        self.assertIn("PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY PRICE)", sql)
+        self.assertIn("MODE() WITHIN GROUP (ORDER BY PRICE)", sql)
+
+    def test_print_with_prefixes(self):
+        fex = """
+        TABLE FILE CAR
+        PRINT SUM.PRICE AVE.PRICE
+        BY COUNTRY
+        END
+        """
+        sql = self._compile_to_sql(fex)
+        self.assertIn("SUM(PRICE)", sql)
+        self.assertIn("AVG(PRICE)", sql)
+        self.assertIn("GROUP BY COUNTRY", sql)
+
+    def test_more_with_prefixes(self):
+        fex = """
+        TABLE FILE CAR
+        SUM AVE.PRICE
+        BY COUNTRY
+        MORE
+        FILE CAR_EXTRA
+        END
+        """
+        sql = self._compile_to_sql(fex)
+        self.assertIn("AVG(SRC.\"PRICE\")", sql)
+        self.assertIn("GROUP BY SRC.\"COUNTRY\"", sql)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change implements support for missing WebFOCUS prefix operators in the `PostgresEmitter`, specifically `DST` (Distinct), `ASQ` (Average Square), `MDN` (Median), and `MDE` (Mode), as well as mapping `CT` and `CNT` consistently. It also refactors the emitter to centralize prefix handling and improves aggregation detection for non-aggregating verbs like `PRINT`.

Fixes #311

---
*PR created automatically by Jules for task [138511545340369517](https://jules.google.com/task/138511545340369517) started by @chatelao*