### PR TITLE
Native PL/pgSQL Loop Optimization for REPEAT...TIMES

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -120,7 +120,10 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
     - [x] 3.4.1.1 Identification of constant vs. data-driven loops.
     - [x] 3.4.1.2 Lifting loops to PL/pgSQL procedural state machine. (Implemented in `src/emitter.py`)
     - [ ] 3.4.1.3 Identification of simple loops for native `FOR`/`WHILE` optimization.
-      - [ ] 3.4.1.3.1 Constant-bound `FOR` loops with literal start/end/step.
+      - [ ] 3.4.1.3.1 Constant-bound `FOR` loops (TIMES/FOR).
+        - [x] 3.4.1.3.1.1 Pattern matching of REPEAT...TIMES in CFG.
+        - [ ] 3.4.1.3.1.2 Pattern matching of REPEAT...FOR with literal bounds.
+        - [x] 3.4.1.3.1.3 Native `FOR` loop emission in PL/pgSQL.
       - [ ] 3.4.1.3.2 Simple `WHILE` loops with non-mutating condition variables.
     - [ ] 3.4.1.4 Identification of loops over data sources for relational lifting.
   - [ ] 3.4.2 Predicate Pushdown:

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -1201,15 +1201,126 @@ class PostgresEmitter:
 
         return "\n".join(lines)
 
+    def _find_simple_times_loop(self, cfg, header_name):
+        """
+        Identifies if a block is the header of a simple REPEAT...TIMES loop.
+        """
+        if not header_name.startswith('LOOP_HEADER_'):
+            return None
+
+        label = header_name[len('LOOP_HEADER_'):]
+        header_block = cfg.blocks.get(header_name)
+        if not header_block or len(header_block.instructions) != 1:
+            return None
+
+        instr = header_block.instructions[0]
+        if not isinstance(instr, ir.Branch):
+            return None
+
+        # condition should be counter <= limit
+        cond = instr.condition
+        if not (isinstance(cond, asg.BinaryOperation) and cond.operator == 'LE'):
+            return None
+
+        if not (isinstance(cond.left, asg.AmperVar) and cond.left.name.startswith('&REPEAT_COUNTER_')):
+            return None
+
+        counter_var = cond.left.name
+        limit = cond.right
+
+        body_start = instr.true_target
+        after_block = instr.false_target
+
+        # Find the closing label block
+        closing_block = cfg.blocks.get(label)
+        if not closing_block:
+            return None
+
+        # Verify closing block ends with increment and jump to header
+        if len(closing_block.instructions) < 2:
+            return None
+
+        last_instr = closing_block.instructions[-1]
+        inc_instr = closing_block.instructions[-2]
+
+        if not (isinstance(last_instr, ir.Jump) and last_instr.target == header_name):
+            return None
+
+        if not (isinstance(inc_instr, ir.Assign) and inc_instr.target == counter_var):
+            return None
+
+        # Verify body is a linear sequence of blocks leading to the closing block
+        body_blocks = []
+        curr = body_start
+        visited = {header_name, after_block}
+        while curr != label:
+            if curr in visited:
+                return None
+            visited.add(curr)
+            body_blocks.append(curr)
+
+            b = cfg.blocks.get(curr)
+            if not b or len(b.successors) != 1:
+                return None
+            curr = b.successors[0].name
+
+        return {
+            'type': 'TIMES',
+            'counter': counter_var,
+            'limit': limit,
+            'body_blocks': body_blocks,
+            'closing_block': label,
+            'after_block': after_block
+        }
+
     def emit_cfg(self, cfg):
         """
         Generates a PL/pgSQL body from a ControlFlowGraph using a block dispatcher.
+        Optimizes simple loops into native PL/pgSQL loops.
         """
         if not cfg.entry_block:
             return ""
 
+        # Identify simple loops
+        loops = {}
+        consumed_blocks = set()
+        for b_name in cfg.blocks:
+            loop = self._find_simple_times_loop(cfg, b_name)
+            if loop:
+                loops[b_name] = loop
+                consumed_blocks.update(loop['body_blocks'])
+                consumed_blocks.add(loop['closing_block'])
+
         blocks_code = []
         for block_name, block in cfg.blocks.items():
+            if block_name in consumed_blocks:
+                continue
+
+            if block_name in loops:
+                loop = loops[block_name]
+                # Emit native FOR loop
+                counter = self._sanitize_name(loop['counter'])
+                limit = self.emit_expression(loop['limit'])
+
+                loop_body_lines = []
+                for b_in_loop in loop['body_blocks']:
+                    b = cfg.blocks[b_in_loop]
+                    # Emit only instructions, ignoring the terminal jump
+                    for instr in b.instructions:
+                        loop_body_lines.append(self.emit_instruction(instr, b, cfg))
+
+                # Also include instructions from closing block BEFORE the increment/jump
+                cb = cfg.blocks[loop['closing_block']]
+                for instr in cb.instructions[:-2]:
+                    loop_body_lines.append(self.emit_instruction(instr, cb, cfg))
+
+                indented_body = self._indent("\n".join(loop_body_lines), 4)
+                loop_code = f"FOR {counter} IN 1..{limit} LOOP\n{indented_body}\nEND LOOP;\n"
+                loop_code += f"v_next_block := '{loop['after_block']}';"
+
+                blocks_code.append(f"        WHEN '{block_name}' THEN\n{self._indent(loop_code, 8)}")
+                continue
+
             block_code = self.emit_block(block, cfg)
             indented_block = self._indent(block_code, 8)
             blocks_code.append(f"        WHEN '{block_name}' THEN\n{indented_block}")

--- a/test/test_e2e_control_flow.py
+++ b/test/test_e2e_control_flow.py
@@ -101,12 +101,9 @@ class TestE2EControlFlow(unittest.TestCase):
         -END_REPEAT
         """
         sql = self._run_e2e(fex_code, optimize=False)
-        # Check counter initialization
-        self.assertIn("v_REPEAT_COUNTER_END_REPEAT := 1;", sql)
-        # Check counter increment
-        self.assertIn("v_REPEAT_COUNTER_END_REPEAT_0 := (v_REPEAT_COUNTER_END_REPEAT_0 + 1);", sql)
-        # Check header condition
-        self.assertIn("(v_REPEAT_COUNTER_END_REPEAT_0 <= 5)", sql)
+        # With the new emitter, simple loops are optimized even without global optimize=True
+        # because the optimization happens during emission based on CFG structure.
+        self.assertIn("FOR v_REPEAT_COUNTER_END_REPEAT_0 IN 1..5 LOOP", sql)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_loop_optimization.py
+++ b/test/test_loop_optimization.py
@@ -1,0 +1,60 @@
+import unittest
+import sys
+import os
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from asg_builder import ReportASGBuilder
+from wf_parser import ReportParser
+from ir_builder import IRBuilder
+from emitter import PostgresEmitter
+
+class TestLoopOptimization(unittest.TestCase):
+    def setUp(self):
+        self.parser = ReportParser()
+        self.asg_builder = ReportASGBuilder()
+        self.ir_builder = IRBuilder()
+        self.emitter = PostgresEmitter()
+
+    def test_simple_times_loop_optimization(self):
+        fex = """
+        -REPEAT MYLABEL 5 TIMES
+        -TYPE 'Hello' &REPEAT_COUNTER_MYLABEL
+        -MYLABEL
+        """
+        tree = self.parser.parse(fex)
+        asg_nodes = self.asg_builder.visit(tree)
+        cfg = self.ir_builder.build(asg_nodes)
+
+        # We need to make sure the counter variable is declared
+        # Actually emitter handles it via get_variables_from_cfg
+
+        sql = self.emitter.emit(cfg)
+
+        # Verify that native FOR loop is present
+        self.assertIn("FOR v_REPEAT_COUNTER_MYLABEL IN 1..5 LOOP", sql)
+        # Verify that it doesn't just use the state machine for the loop body
+        # (Though the state machine is still the outer wrapper)
+        self.assertIn("RAISE NOTICE '%', 'Hello' || v_REPEAT_COUNTER_MYLABEL;", sql)
+
+    def test_complex_loop_remains_state_machine(self):
+        # A loop with a -GOTO out of it might be too complex for the simple optimizer
+        fex = """
+        -REPEAT MYLABEL 5 TIMES
+        -IF &X EQ 1 THEN GOTO EXIT_LOOP;
+        -TYPE Hello
+        -MYLABEL
+        -EXIT_LOOP
+        """
+        tree = self.parser.parse(fex)
+        asg_nodes = self.asg_builder.visit(tree)
+        cfg = self.ir_builder.build(asg_nodes)
+
+        sql = self.emitter.emit(cfg)
+
+        # Should NOT contain native FOR loop because of the conditional branch to outside
+        self.assertNotIn("FOR v_REPEAT_COUNTER_MYLABEL IN 1..5 LOOP", sql)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change implements Phase 3.4.1.3.1 from the migration roadmap. It enhances the `PostgresEmitter` to recognize simple `REPEAT...TIMES` loops in the Control Flow Graph and translate them into native PL/pgSQL `FOR` loops instead of generic state-machine blocks. This improves the readability and potentially the performance of the generated procedural logic. The implementation is conservative and falls back to the robust state-machine dispatcher if the loop contains non-linear control flow (e.g., internal branches or jumps to outside the loop).

Fixes #315

---
*PR created automatically by Jules for task [1845444475402204231](https://jules.google.com/task/1845444475402204231) started by @chatelao*