### PR TITLE
Generalize Loop Optimization and Update Roadmap

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -120,12 +120,15 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
     - [x] 3.4.1.1 Identification of constant vs. data-driven loops.
     - [x] 3.4.1.2 Lifting loops to PL/pgSQL procedural state machine. (Implemented in `src/emitter.py`)
     - [ ] 3.4.1.3 Identification of simple loops for native `FOR`/`WHILE` optimization.
-      - [ ] 3.4.1.3.1 Constant-bound `FOR` loops (TIMES/FOR).
+      - [x] 3.4.1.3.1 Constant-bound `FOR` loops (TIMES/FOR).
         - [x] 3.4.1.3.1.1 Pattern matching of REPEAT...TIMES in CFG.
-        - [ ] 3.4.1.3.1.2 Pattern matching of REPEAT...FOR with literal bounds.
+        - [x] 3.4.1.3.1.2 Pattern matching of REPEAT...FOR with literal bounds.
         - [x] 3.4.1.3.1.3 Native `FOR` loop emission in PL/pgSQL.
       - [ ] 3.4.1.3.2 Simple `WHILE` loops with non-mutating condition variables.
     - [ ] 3.4.1.4 Identification of loops over data sources for relational lifting.
+      - [ ] 3.4.1.4.1 Pattern matching for record-at-a-time `-READ` loops.
+      - [ ] 3.4.1.4.2 Detection of procedural aggregations within data loops.
+      - [ ] 3.4.1.4.3 Mapping of data loops to set-based SQL operations.
   - [ ] 3.4.2 Predicate Pushdown:
     - [x] 3.4.2.1 Filter Lifting: Move WHERE conditions to SQL. (Implemented in `src/emitter.py`)
     - [x] 3.4.2.2 Total Lifting: Move WHERE TOTAL conditions to SQL HAVING. (Implemented in `src/emitter.py`)

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -1201,35 +1201,49 @@ class PostgresEmitter:
 
         return "\n".join(lines)
 
-    def _find_simple_times_loop(self, cfg, header_name):
+    def _get_base_name(self, name):
+        if '_' in name:
+            parts = name.split('_')
+            if parts[-1].isdigit():
+                return "_".join(parts[:-1])
+        return name
+
+    def _find_simple_for_loop(self, cfg, header_name):
         """
-        Identifies if a block is the header of a simple REPEAT...TIMES loop.
+        Identifies if a block is the header of a simple REPEAT...TIMES or REPEAT...FOR loop.
         """
         if not header_name.startswith('LOOP_HEADER_'):
             return None
 
         label = header_name[len('LOOP_HEADER_'):]
         header_block = cfg.blocks.get(header_name)
-        if not header_block or len(header_block.instructions) != 1:
+        if not header_block:
             return None
 
-        instr = header_block.instructions[0]
-        if not isinstance(instr, ir.Branch):
+        # In SSA, header might have a Phi node followed by the Branch.
+        branch_instr = None
+        for instr in header_block.instructions:
+            if isinstance(instr, ir.Branch):
+                branch_instr = instr
+                break
+
+        if not branch_instr:
             return None
 
         # condition should be counter <= limit
-        cond = instr.condition
+        cond = branch_instr.condition
         if not (isinstance(cond, asg.BinaryOperation) and cond.operator == 'LE'):
             return None
 
-        if not (isinstance(cond.left, asg.AmperVar) and cond.left.name.startswith('&REPEAT_COUNTER_')):
+        if not isinstance(cond.left, asg.AmperVar):
             return None
 
         counter_var = cond.left.name
+        counter_base = self._get_base_name(counter_var)
         limit = cond.right
 
-        body_start = instr.true_target
-        after_block = instr.false_target
+        body_start = branch_instr.true_target
+        after_block = branch_instr.false_target
 
         # Find the closing label block
         closing_block = cfg.blocks.get(label)
@@ -1246,8 +1260,18 @@ class PostgresEmitter:
         if not (isinstance(last_instr, ir.Jump) and last_instr.target == header_name):
             return None
 
-        if not (isinstance(inc_instr, ir.Assign) and inc_instr.target == counter_var):
+        if not isinstance(inc_instr, ir.Assign):
             return None
+
+        target_name = inc_instr.target if isinstance(inc_instr.target, str) else inc_instr.target.name
+        if self._get_base_name(target_name) != counter_base:
+            return None
+
+        # Extract step from increment: counter = counter + step
+        if not (isinstance(inc_instr.source, asg.BinaryOperation) and inc_instr.source.operator == '+'):
+            return None
+
+        step = inc_instr.source.right
 
         # Verify body is a linear sequence of blocks leading to the closing block
         body_blocks = []
@@ -1264,10 +1288,28 @@ class PostgresEmitter:
                 return None
             curr = b.successors[0].name
 
+        # Find start value
+        start_val = asg.Literal(1) # Default for TIMES
+        if not counter_base.startswith('&REPEAT_COUNTER_'):
+            # Find the predecessor block that is not the back-edge
+            preds = [p for p in header_block.predecessors if p.name != label]
+            if len(preds) == 1:
+                pred = preds[0]
+                # Look for assignment in the last few instructions
+                for i in reversed(range(len(pred.instructions))):
+                    item = pred.instructions[i]
+                    if isinstance(item, ir.Assign):
+                        target = item.target if isinstance(item.target, str) else item.target.name
+                        if self._get_base_name(target) == counter_base:
+                            start_val = item.source
+                            break
+
         return {
-            'type': 'TIMES',
+            'type': 'FOR',
             'counter': counter_var,
+            'start': start_val,
             'limit': limit,
+            'step': step,
             'body_blocks': body_blocks,
             'closing_block': label,
             'after_block': after_block
@@ -1285,7 +1327,7 @@ class PostgresEmitter:
         loops = {}
         consumed_blocks = set()
         for b_name in cfg.blocks:
-            loop = self._find_simple_times_loop(cfg, b_name)
+            loop = self._find_simple_for_loop(cfg, b_name)
             if loop:
                 loops[b_name] = loop
                 consumed_blocks.update(loop['body_blocks'])
@@ -1300,7 +1342,15 @@ class PostgresEmitter:
                 loop = loops[block_name]
                 # Emit native FOR loop
                 counter = self._sanitize_name(loop['counter'])
+                start = self.emit_expression(loop['start'])
                 limit = self.emit_expression(loop['limit'])
+                step_val = loop['step']
+
+                step_clause = ""
+                if isinstance(step_val, asg.Literal) and step_val.value != 1:
+                    step_clause = f" BY {step_val.value}"
+                elif not isinstance(step_val, asg.Literal):
+                    step_clause = f" BY {self.emit_expression(step_val)}"
 
                 loop_body_lines = []
                 for b_in_loop in loop['body_blocks']:
@@ -1315,7 +1365,7 @@ class PostgresEmitter:
                     loop_body_lines.append(self.emit_instruction(instr, cb, cfg))
 
                 indented_body = self._indent("\n".join(loop_body_lines), 4)
-                loop_code = f"FOR {counter} IN 1..{limit} LOOP\n{indented_body}\nEND LOOP;\n"
+                loop_code = f"FOR {counter} IN {start}..{limit}{step_clause} LOOP\n{indented_body}\nEND LOOP;\n"
                 loop_code += f"v_next_block := '{loop['after_block']}';"
 
                 blocks_code.append(f"        WHEN '{block_name}' THEN\n{self._indent(loop_code, 8)}")

--- a/test/test_e2e_control_flow.py
+++ b/test/test_e2e_control_flow.py
@@ -105,5 +105,15 @@ class TestE2EControlFlow(unittest.TestCase):
         # because the optimization happens during emission based on CFG structure.
         self.assertIn("FOR v_REPEAT_COUNTER_END_REPEAT_0 IN 1..5 LOOP", sql)
 
+    def test_repeat_for_loop_optimization(self):
+        fex_code = """
+        -REPEAT END_REPEAT FOR &I FROM 1 TO 10 STEP 2
+        -TYPE &I
+        -END_REPEAT
+        """
+        sql = self._run_e2e(fex_code, optimize=False)
+        self.assertIn("FOR v_I_0 IN 1..10 BY 2 LOOP", sql)
+        self.assertIn("RAISE NOTICE '%', v_I_0;", sql)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implemented a modest next step in the migration roadmap by generalizing the loop optimization logic in the `PostgresEmitter`. The emitter now recognizes and optimizes both `REPEAT...TIMES` and `REPEAT...FOR` loops into native PL/pgSQL `FOR` loops, even when SSA transformations have versioned the variables. Also updated the `MIGRATION_ROADMAP.md` to reflect these changes and provide a more granular breakdown for future relational lifting tasks. All tests passed.

Fixes #317

---
*PR created automatically by Jules for task [9975896496744316057](https://jules.google.com/task/9975896496744316057) started by @chatelao*