### PR TITLE
Implement native PL/pgSQL WHILE loop optimization

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -124,7 +124,7 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
         - [x] 3.4.1.3.1.1 Pattern matching of REPEAT...TIMES in CFG.
         - [x] 3.4.1.3.1.2 Pattern matching of REPEAT...FOR with literal bounds.
         - [x] 3.4.1.3.1.3 Native `FOR` loop emission in PL/pgSQL.
-      - [ ] 3.4.1.3.2 Simple `WHILE` loops with non-mutating condition variables.
+      - [x] 3.4.1.3.2 Simple `WHILE` loops with non-mutating condition variables.
     - [ ] 3.4.1.4 Identification of loops over data sources for relational lifting.
       - [ ] 3.4.1.4.1 Pattern matching for record-at-a-time `-READ` loops.
       - [ ] 3.4.1.4.2 Detection of procedural aggregations within data loops.

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -1315,6 +1315,67 @@ class PostgresEmitter:
             'after_block': after_block
         }
 
+    def _find_simple_while_loop(self, cfg, header_name):
+        """
+        Identifies if a block is the header of a simple REPEAT...WHILE or REPEAT...UNTIL loop.
+        """
+        if not header_name.startswith('LOOP_HEADER_'):
+            return None
+
+        label = header_name[len('LOOP_HEADER_'):]
+        header_block = cfg.blocks.get(header_name)
+        if not header_block:
+            return None
+
+        branch_instr = None
+        for instr in header_block.instructions:
+            if isinstance(instr, ir.Branch):
+                branch_instr = instr
+                break
+
+        if not branch_instr:
+            return None
+
+        cond = branch_instr.condition
+        body_start = branch_instr.true_target
+        after_block = branch_instr.false_target
+
+        # Find the closing label block
+        closing_block = cfg.blocks.get(label)
+        if not closing_block:
+            return None
+
+        # Verify closing block ends with jump to header
+        if not closing_block.instructions:
+            return None
+
+        last_instr = closing_block.instructions[-1]
+        if not (isinstance(last_instr, ir.Jump) and last_instr.target == header_name):
+            return None
+
+        # Verify body is a linear sequence of blocks leading to the closing block
+        body_blocks = []
+        curr = body_start
+        visited = {header_name, after_block}
+        while curr != label:
+            if curr in visited:
+                return None
+            visited.add(curr)
+            body_blocks.append(curr)
+
+            b = cfg.blocks.get(curr)
+            if not b or len(b.successors) != 1:
+                return None
+            curr = b.successors[0].name
+
+        return {
+            'type': 'WHILE',
+            'condition': cond,
+            'body_blocks': body_blocks,
+            'closing_block': label,
+            'after_block': after_block
+        }
+
     def emit_cfg(self, cfg):
         """
         Generates a PL/pgSQL body from a ControlFlowGraph using a block dispatcher.
@@ -1328,6 +1389,9 @@ class PostgresEmitter:
         consumed_blocks = set()
         for b_name in cfg.blocks:
             loop = self._find_simple_for_loop(cfg, b_name)
+            if not loop:
+                loop = self._find_simple_while_loop(cfg, b_name)
+
             if loop:
                 loops[b_name] = loop
                 consumed_blocks.update(loop['body_blocks'])
@@ -1340,33 +1404,55 @@ class PostgresEmitter:
 
             if block_name in loops:
                 loop = loops[block_name]
-                # Emit native FOR loop
-                counter = self._sanitize_name(loop['counter'])
-                start = self.emit_expression(loop['start'])
-                limit = self.emit_expression(loop['limit'])
-                step_val = loop['step']
+                loop_code = ""
 
-                step_clause = ""
-                if isinstance(step_val, asg.Literal) and step_val.value != 1:
-                    step_clause = f" BY {step_val.value}"
-                elif not isinstance(step_val, asg.Literal):
-                    step_clause = f" BY {self.emit_expression(step_val)}"
+                if loop['type'] == 'FOR':
+                    # Emit native FOR loop
+                    counter = self._sanitize_name(loop['counter'])
+                    start = self.emit_expression(loop['start'])
+                    limit = self.emit_expression(loop['limit'])
+                    step_val = loop['step']
 
-                loop_body_lines = []
-                for b_in_loop in loop['body_blocks']:
-                    b = cfg.blocks[b_in_loop]
-                    # Emit only instructions, ignoring the terminal jump
-                    for instr in b.instructions:
-                        loop_body_lines.append(self.emit_instruction(instr, b, cfg))
+                    step_clause = ""
+                    if isinstance(step_val, asg.Literal) and step_val.value != 1:
+                        step_clause = f" BY {step_val.value}"
+                    elif not isinstance(step_val, asg.Literal):
+                        step_clause = f" BY {self.emit_expression(step_val)}"
 
-                # Also include instructions from closing block BEFORE the increment/jump
-                cb = cfg.blocks[loop['closing_block']]
-                for instr in cb.instructions[:-2]:
-                    loop_body_lines.append(self.emit_instruction(instr, cb, cfg))
+                    loop_body_lines = []
+                    for b_in_loop in loop['body_blocks']:
+                        b = cfg.blocks[b_in_loop]
+                        # Emit only instructions, ignoring the terminal jump
+                        for instr in b.instructions:
+                            loop_body_lines.append(self.emit_instruction(instr, b, cfg))
 
-                indented_body = self._indent("\n".join(loop_body_lines), 4)
-                loop_code = f"FOR {counter} IN {start}..{limit}{step_clause} LOOP\n{indented_body}\nEND LOOP;\n"
-                loop_code += f"v_next_block := '{loop['after_block']}';"
+                    # Also include instructions from closing block BEFORE the increment/jump
+                    cb = cfg.blocks[loop['closing_block']]
+                    for instr in cb.instructions[:-2]:
+                        loop_body_lines.append(self.emit_instruction(instr, cb, cfg))
+
+                    indented_body = self._indent("\n".join(loop_body_lines), 4)
+                    loop_code = f"FOR {counter} IN {start}..{limit}{step_clause} LOOP\n{indented_body}\nEND LOOP;\n"
+                    loop_code += f"v_next_block := '{loop['after_block']}';"
+
+                elif loop['type'] == 'WHILE':
+                    cond = self.emit_expression(loop['condition'])
+
+                    loop_body_lines = []
+                    for b_in_loop in loop['body_blocks']:
+                        b = cfg.blocks[b_in_loop]
+                        # Emit only instructions, ignoring the terminal jump
+                        for instr in b.instructions:
+                            loop_body_lines.append(self.emit_instruction(instr, b, cfg))
+
+                    # Also include instructions from closing block BEFORE the jump
+                    cb = cfg.blocks[loop['closing_block']]
+                    for instr in cb.instructions[:-1]:
+                        loop_body_lines.append(self.emit_instruction(instr, cb, cfg))
+
+                    indented_body = self._indent("\n".join(loop_body_lines), 4)
+                    loop_code = f"WHILE {cond} LOOP\n{indented_body}\nEND LOOP;\n"
+                    loop_code += f"v_next_block := '{loop['after_block']}';"
 
                 blocks_code.append(f"        WHEN '{block_name}' THEN\n{self._indent(loop_code, 8)}")
                 continue

--- a/test/test_while_optimization.py
+++ b/test/test_while_optimization.py
@@ -1,0 +1,87 @@
+import unittest
+import sys
+import os
+from antlr4 import CommonTokenStream, InputStream
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from ir_builder import IRBuilder
+from ssa_transformer import SSATransformer
+from optimizer import ConstantPropagator, DeadCodeEliminator
+from emitter import PostgresEmitter
+from metadata_registry import MetadataRegistry
+
+class TestWhileOptimization(unittest.TestCase):
+    def _run_e2e(self, fex_code):
+        # 2. Parse
+        input_stream = InputStream(fex_code)
+        lexer = WebFocusReportLexer(input_stream)
+        token_stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(token_stream)
+        tree = parser.start()
+
+        # 3. ASG Construction
+        builder = ReportASGBuilder()
+        asg_nodes = builder.visit(tree)
+
+        # 4. IR/CFG Construction
+        ir_builder = IRBuilder()
+        cfg = ir_builder.build(asg_nodes)
+
+        # 5. SSA Transformation
+        ssa_transformer = SSATransformer()
+        ssa_transformer.transform(cfg)
+
+        # 6. Optimization
+        ConstantPropagator().run(cfg)
+        DeadCodeEliminator().run(cfg)
+
+        # 7. Backend Emission
+        metadata = MetadataRegistry()
+        emitter = PostgresEmitter(metadata_registry=metadata)
+        sql_output = emitter.emit(cfg)
+
+        return sql_output
+
+    def test_repeat_while_optimization(self):
+        fex_code = """
+        -SET &I = 1;
+        -REPEAT LOOP_END WHILE &I LE 5;
+        -TYPE &I
+        -SET &I = &I + 1;
+        -LOOP_END
+        """
+        sql = self._run_e2e(fex_code)
+
+        # Verify it uses native WHILE loop
+        self.assertIn("WHILE (v_I_0 <= 5) LOOP", sql)
+        self.assertIn("RAISE NOTICE '%', v_I_0;", sql)
+        self.assertIn("v_I_0 := (v_I_0 + 1);", sql)
+        self.assertIn("END LOOP;", sql)
+
+        # Verify it doesn't have the body as separate CASE WHEN blocks
+        # (It's consumed by the optimization)
+        # Note: LOOP_HEADER remains as the container for the optimized loop
+        self.assertNotIn("WHEN 'LOOP_BODY_LOOP_END' THEN", sql)
+
+    def test_repeat_until_optimization(self):
+        fex_code = """
+        -SET &I = 1;
+        -REPEAT LOOP_END UNTIL &I GT 5;
+        -TYPE &I
+        -SET &I = &I + 1;
+        -LOOP_END
+        """
+        sql = self._run_e2e(fex_code)
+
+        # UNTIL &I GT 5 is translated to WHILE NOT (&I GT 5)
+        # Emitter might add space after NOT
+        self.assertIn("WHILE NOT ((v_I_0 > 5)) LOOP", sql)
+        self.assertIn("END LOOP;", sql)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change implements the optimization of simple Dialogue Manager `-REPEAT` loops using `WHILE` or `UNTIL` conditions into native PL/pgSQL `WHILE ... LOOP` constructs. 

Key changes:
- Added `_find_simple_while_loop` to `PostgresEmitter` to identify loop patterns in the CFG.
- Enhanced `emit_cfg` to support native `WHILE` loop emission alongside existing `FOR` loop optimization.
- Added comprehensive end-to-end tests in `test/test_while_optimization.py` covering both `WHILE` and `UNTIL` conditions.
- Updated `MIGRATION_ROADMAP.md` to reflect the completion of Phase 3.4.1.3.2.

Fixes #319

---
*PR created automatically by Jules for task [12831794307678794052](https://jules.google.com/task/12831794307678794052) started by @chatelao*