### PR TITLE
Integrate DDLGenerator and FixtureLoader into RuntimeRunner

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -149,7 +149,7 @@ Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
 
 - [x] **4.1 PL/pgSQL Emission Infrastructure:**
   - [x] 4.1.1 Template Environment: Setup Jinja2 and base layout templates.
-- [ ] **4.1.2 Variable Mapping: Implement mapping between SSA versions and PL/pgSQL variables.
+- [x] **4.1.2 Variable Mapping: Implement mapping between SSA versions and PL/pgSQL variables.
     - [x] 4.1.2.1 Variable Discovery: Identify all unique SSA variables in the CFG. (Implemented in `src/emitter.py`)
     - [x] 4.1.2.2 Name Sanitization: Map WebFOCUS/SSA names to SQL-safe identifiers. (Implemented in `src/emitter.py`)
     - [x] 4.1.2.3 Type Mapping: Map WebFOCUS types (I, F, A) to PostgreSQL types. (Implemented in `src/type_mapper.py`)
@@ -296,12 +296,12 @@ Ensure the generated PL/pgSQL code is not only syntactically correct but also ex
 - [x] **7.1 Live Database Environment:**
   - [x] 7.1.1 Configure a PostgreSQL service container in the CI/CD pipeline (GitHub Actions). (Implemented in `.github/workflows/cicd.yml`)
   - [x] 7.1.2 Implement a robust database connection utility for use in the test suite. (Implemented in `src/db_utils.py`)
-- [ ] **7.2 Data & Schema Fixtures:**
+- [x] **7.2 Data & Schema Fixtures:**
   - [x] 7.2.1 Implement an automated DDL generator that transforms Master File metadata into PostgreSQL `CREATE TABLE` statements. (Implemented in `src/ddl_generator.py`)
   - [x] 7.2.2 Develop a fixture loading mechanism to populate the live database with test data (from JSON/CSV) for each sample. (Implemented in `src/fixture_loader.py`)
 - [ ] **7.3 Integration & Runtime Testing:**
-  - [ ] 7.3.1 Implement a runtime test runner.
+  - [x] 7.3.1 Implement a runtime test runner.
     - [x] 7.3.1.1 Implement procedure execution and notice capturing in `RuntimeRunner`. (Implemented in `src/runtime_runner.py`)
-    - [ ] 7.3.1.2 Integrate `DDLGenerator` and `FixtureLoader` into `RuntimeRunner` for automated environment setup.
+    - [x] 7.3.1.2 Integrate `DDLGenerator` and `FixtureLoader` into `RuntimeRunner` for automated environment setup.
   - [ ] 7.3.2 Verify result-set parity by comparing the output of executed procedures against expected results.
   - [ ] 7.3.3 Implement comprehensive error reporting for runtime failures (e.g., SQL syntax errors, type mismatches during execution).

--- a/src/runtime_runner.py
+++ b/src/runtime_runner.py
@@ -1,4 +1,6 @@
 from db_utils import get_db_connection
+from ddl_generator import DDLGenerator
+from fixture_loader import FixtureLoader
 
 class RuntimeRunner:
     """
@@ -17,6 +19,35 @@ class RuntimeRunner:
         if self.conn:
             self.conn.close()
             self.conn = None
+
+    def setup_schema(self, master_files):
+        """
+        Generates and executes DDL for the given list of MasterFile objects.
+        """
+        generator = DDLGenerator()
+        if not self.conn:
+            with self:
+                self._setup_schema_internal(generator, master_files)
+        else:
+            self._setup_schema_internal(generator, master_files)
+
+    def _setup_schema_internal(self, generator, master_files):
+        with self.conn.cursor() as cursor:
+            for master in master_files:
+                ddl = generator.generate(master)
+                cursor.execute(ddl)
+
+    def load_fixtures(self, fixtures_config):
+        """
+        Populates tables using FixtureLoader.
+        fixtures_config: list of (table_name, filepath) tuples.
+        """
+        loader = FixtureLoader()
+        for table_name, filepath in fixtures_config:
+            if filepath.endswith('.json'):
+                loader.load_json(table_name, filepath)
+            elif filepath.endswith('.csv'):
+                loader.load_csv(table_name, filepath)
 
     def run_procedure(self, sql, procedure_name="webfocus_procedure"):
         """

--- a/test/test_runtime_runner.py
+++ b/test/test_runtime_runner.py
@@ -48,5 +48,37 @@ class TestRuntimeRunner(unittest.TestCase):
 
         mock_conn.close.assert_called_once()
 
+    @patch('runtime_runner.DDLGenerator')
+    @patch('runtime_runner.get_db_connection')
+    def test_setup_schema(self, mock_get_conn, mock_ddl_gen_class):
+        mock_conn = MagicMock()
+        mock_get_conn.return_value = mock_conn
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+        mock_ddl_gen = mock_ddl_gen_class.return_value
+        mock_ddl_gen.generate.return_value = "CREATE TABLE TEST;"
+
+        master = MagicMock()
+        runner = RuntimeRunner()
+        runner.setup_schema([master])
+
+        mock_ddl_gen.generate.assert_called_once_with(master)
+        mock_cursor.execute.assert_called_once_with("CREATE TABLE TEST;")
+
+    @patch('runtime_runner.FixtureLoader')
+    def test_load_fixtures(self, mock_loader_class):
+        mock_loader = mock_loader_class.return_value
+
+        runner = RuntimeRunner()
+        fixtures_config = [
+            ('TABLE1', 'data1.json'),
+            ('TABLE2', 'data2.csv')
+        ]
+        runner.load_fixtures(fixtures_config)
+
+        mock_loader.load_json.assert_called_once_with('TABLE1', 'data1.json')
+        mock_loader.load_csv.assert_called_once_with('TABLE2', 'data2.csv')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change implements step 7.3.1.2 of the MIGRATION_ROADMAP.md by integrating the DDLGenerator and FixtureLoader into the RuntimeRunner class. This enables automated environment setup (schema creation and data loading) for runtime verification of transpiled PL/pgSQL procedures.

Key changes:
- `src/runtime_runner.py`: Added `setup_schema(master_files)` and `load_fixtures(fixtures_config)` methods.
- `test/test_runtime_runner.py`: Added unit tests for the new integration methods using mocking.
- `MIGRATION_ROADMAP.md`: Marked steps 4.1.2 (Variable Mapping), 7.2 (Data & Schema Fixtures), and 7.3.1.2 (Integration) as complete.

Fixes #339

---
*PR created automatically by Jules for task [9084364653143939382](https://jules.google.com/task/9084364653143939382) started by @chatelao*