### PR TITLE
Implement HOLD command support and update roadmap

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -310,4 +310,7 @@ Ensure the generated PL/pgSQL code is not only syntactically correct but also ex
     - [x] 7.3.1.1 Implement procedure execution and notice capturing in `RuntimeRunner`. (Implemented in `src/runtime_runner.py`)
     - [x] 7.3.1.2 Integrate `DDLGenerator` and `FixtureLoader` into `RuntimeRunner` for automated environment setup.
   - [ ] 7.3.2 Verify result-set parity by comparing the output of executed procedures against expected results.
-  - [ ] 7.3.3 Implement comprehensive error reporting for runtime failures (e.g., SQL syntax errors, type mismatches during execution).
+    - [x] 7.3.2.1 Support `HOLD` command in `PostgresEmitter` using `CREATE TEMP TABLE`.
+    - [ ] 7.3.2.2 Enhance `RuntimeRunner` to fetch and return result sets from temporary tables.
+    - [ ] 7.3.2.3 Add integration tests for result-set parity verification.
+  - [x] 7.3.3 Implement comprehensive error reporting for runtime failures (e.g., SQL syntax errors, type mismatches during execution). (Implemented in `src/runtime_runner.py`)

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -716,6 +716,7 @@ class PostgresEmitter:
             return f"{table_name}.{fname}"
 
         report_comments = []
+        hold_command = None
 
         # Sort commands (BY, ACROSS)
         sort_commands = [c for c in instr.components if c.__class__.__name__ == 'SortCommand']
@@ -769,6 +770,8 @@ class PostgresEmitter:
                 centered = " CENTER" if getattr(comp, 'centered', False) else ""
                 report_comments.append(f"/* {class_name.upper()}{centered} \"{comp.text}\" */")
             elif class_name == 'OutputCommand':
+                if comp.output_type == 'HOLD':
+                    hold_command = comp
                 report_comments.append(self._emit_output_command(comp))
             elif class_name == 'StyleBlock':
                 report_comments.append("/* SET STYLE * */")
@@ -784,6 +787,8 @@ class PostgresEmitter:
                     elif action_class == 'RecapCommand':
                         report_comments.append(f"/* ON {comp.target} {self._format_recap(action)} */")
                     elif action_class == 'OutputCommand':
+                        if action.output_type == 'HOLD':
+                            hold_command = action
                         report_comments.append(f"/* ON {comp.target} {self._emit_output_command(action).lstrip('/*').rstrip('*/').strip()} */")
                     elif action_class == 'StyleBlock':
                         report_comments.append(f"/* ON {comp.target} SET STYLE * */")
@@ -978,6 +983,16 @@ class PostgresEmitter:
 
             if order_by_phrases:
                 sql += "\nORDER BY " + ", ".join(order_by_phrases)
+
+        if hold_command:
+            hold_name = hold_command.filename or "HOLD"
+            # Sanitize hold name for SQL table name
+            hold_name = hold_name.replace('.', '_').replace('-', '_')
+
+            hold_sql = f"DROP TABLE IF EXISTS {hold_name};\n"
+            hold_sql += f"CREATE TEMP TABLE {hold_name} AS\n"
+            hold_sql += sql
+            sql = hold_sql
 
         if merge_cmd:
             target_table = self._resolve_table_name(merge_cmd.filename)

--- a/test/test_hold_emitter.py
+++ b/test/test_hold_emitter.py
@@ -1,0 +1,55 @@
+import unittest
+import os
+import sys
+
+# Add src to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from emitter import PostgresEmitter
+import ir
+import asg
+
+class TestHoldEmitter(unittest.TestCase):
+    def test_emit_instruction_report_with_hold(self):
+        emitter = PostgresEmitter()
+        verb = asg.VerbCommand(verb="PRINT", fields=[asg.FieldSelection(name="FIELD1")])
+        hold = asg.OutputCommand(output_type="HOLD", filename="MYHOLD")
+
+        instr = ir.Report(filename="MYTABLE", components=[verb, hold])
+
+        sql = emitter.emit_instruction(instr)
+
+        self.assertIn("DROP TABLE IF EXISTS MYHOLD;", sql)
+        self.assertIn("CREATE TEMP TABLE MYHOLD AS", sql)
+        self.assertIn("SELECT FIELD1 FROM MYTABLE", sql)
+
+    def test_emit_instruction_report_with_on_table_hold(self):
+        emitter = PostgresEmitter()
+        verb = asg.VerbCommand(verb="PRINT", fields=[asg.FieldSelection(name="FIELD1")])
+        hold = asg.OutputCommand(output_type="HOLD", filename="ON_TABLE_HOLD")
+        on_table = asg.OnCommand(target="TABLE", actions=[hold])
+
+        instr = ir.Report(filename="MYTABLE", components=[verb, on_table])
+
+        sql = emitter.emit_instruction(instr)
+
+        self.assertIn("DROP TABLE IF EXISTS ON_TABLE_HOLD;", sql)
+        self.assertIn("CREATE TEMP TABLE ON_TABLE_HOLD AS", sql)
+        self.assertIn("SELECT FIELD1 FROM MYTABLE", sql)
+
+    def test_emit_instruction_report_with_hold_sanitization(self):
+        emitter = PostgresEmitter()
+        verb = asg.VerbCommand(verb="PRINT", fields=[asg.FieldSelection(name="FIELD1")])
+        # WebFOCUS filenames can have dots or hyphens
+        hold = asg.OutputCommand(output_type="HOLD", filename="MY-DATA.TMP")
+
+        instr = ir.Report(filename="MYTABLE", components=[verb, hold])
+
+        sql = emitter.emit_instruction(instr)
+
+        # Should be sanitized to MY_DATA_TMP
+        self.assertIn("DROP TABLE IF EXISTS MY_DATA_TMP;", sql)
+        self.assertIn("CREATE TEMP TABLE MY_DATA_TMP AS", sql)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented the `HOLD` command in `PostgresEmitter` to support capturing report results in temporary tables. This involved modifying `_emit_report` to detect `OutputCommand` nodes and wrap the generated `SELECT` in `DROP TABLE` and `CREATE TEMP TABLE ... AS` SQL. Also updated the `MIGRATION_ROADMAP.md` to break down Phase 7.3.2 into granular steps and marked the implemented step as complete. Added comprehensive unit tests for the new functionality.

Fixes #345

---
*PR created automatically by Jules for task [14673753086304790786](https://jules.google.com/task/14673753086304790786) started by @chatelao*