### PR TITLE
Enhance RuntimeRunner with fetch_table support

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -311,6 +311,6 @@ Ensure the generated PL/pgSQL code is not only syntactically correct but also ex
     - [x] 7.3.1.2 Integrate `DDLGenerator` and `FixtureLoader` into `RuntimeRunner` for automated environment setup.
   - [ ] 7.3.2 Verify result-set parity by comparing the output of executed procedures against expected results.
     - [x] 7.3.2.1 Support `HOLD` command in `PostgresEmitter` using `CREATE TEMP TABLE`.
-    - [ ] 7.3.2.2 Enhance `RuntimeRunner` to fetch and return result sets from temporary tables.
+    - [x] 7.3.2.2 Enhance `RuntimeRunner` to fetch and return result sets from temporary tables.
     - [ ] 7.3.2.3 Add integration tests for result-set parity verification.
   - [x] 7.3.3 Implement comprehensive error reporting for runtime failures (e.g., SQL syntax errors, type mismatches during execution). (Implemented in `src/runtime_runner.py`)

--- a/src/runtime_runner.py
+++ b/src/runtime_runner.py
@@ -1,4 +1,5 @@
 import psycopg2
+from psycopg2 import sql
 from db_utils import get_db_connection
 from ddl_generator import DDLGenerator
 from fixture_loader import FixtureLoader
@@ -59,7 +60,7 @@ class RuntimeRunner:
                 return self._run_internal(sql, procedure_name)
         return self._run_internal(sql, procedure_name)
 
-    def _run_internal(self, sql, procedure_name):
+    def _run_internal(self, procedure_sql, procedure_name):
         notices = []
         # Clear existing notices
         del self.conn.notices[:]
@@ -67,7 +68,7 @@ class RuntimeRunner:
         try:
             with self.conn.cursor() as cursor:
                 # 1. Define the procedure
-                cursor.execute(sql)
+                cursor.execute(procedure_sql)
 
                 # 2. Call the procedure
                 cursor.execute(f"CALL {procedure_name}();")
@@ -80,17 +81,45 @@ class RuntimeRunner:
                         clean_notice = clean_notice[len("NOTICE:  "):]
                     notices.append(clean_notice)
         except psycopg2.Error as e:
-            diag = getattr(e, 'diag', None)
-            if diag:
-                error_msg = f"PostgreSQL Runtime Error: {diag.message_primary}"
-                if diag.message_detail:
-                    error_msg += f"\nDetail: {diag.message_detail}"
-                if diag.context:
-                    error_msg += f"\nContext: {diag.context}"
-                if diag.internal_position:
-                    error_msg += f"\nPosition: {diag.internal_position}"
-                raise Exception(error_msg) from e
-            else:
-                raise Exception(f"PostgreSQL Runtime Error: {str(e)}") from e
+            self._handle_error(e)
 
         return notices
+
+    def fetch_table(self, table_name):
+        """
+        Retrieves all rows from a table (e.g., a HOLD table) as a list of dictionaries.
+        """
+        if not self.conn:
+            with self:
+                return self._fetch_internal(table_name)
+        return self._fetch_internal(table_name)
+
+    def _fetch_internal(self, table_name):
+        try:
+            with self.conn.cursor() as cursor:
+                cursor.execute(sql.SQL("SELECT * FROM {}").format(sql.Identifier(table_name)))
+
+                if cursor.description is None:
+                    return []
+
+                colnames = [desc[0] for desc in cursor.description]
+                results = []
+                for row in cursor.fetchall():
+                    results.append(dict(zip(colnames, row)))
+                return results
+        except psycopg2.Error as e:
+            self._handle_error(e)
+
+    def _handle_error(self, e):
+        diag = getattr(e, 'diag', None)
+        if diag:
+            error_msg = f"PostgreSQL Runtime Error: {diag.message_primary}"
+            if diag.message_detail:
+                error_msg += f"\nDetail: {diag.message_detail}"
+            if diag.context:
+                error_msg += f"\nContext: {diag.context}"
+            if diag.internal_position:
+                error_msg += f"\nPosition: {diag.internal_position}"
+            raise Exception(error_msg) from e
+        else:
+            raise Exception(f"PostgreSQL Runtime Error: {str(e)}") from e

--- a/test/test_runtime_runner.py
+++ b/test/test_runtime_runner.py
@@ -114,5 +114,30 @@ class TestRuntimeRunner(unittest.TestCase):
         self.assertIn("Context: Procedure context", str(cm.exception))
         self.assertIn("Position: 42", str(cm.exception))
 
+    @patch('runtime_runner.get_db_connection')
+    def test_fetch_table(self, mock_get_conn):
+        mock_conn = MagicMock()
+        mock_get_conn.return_value = mock_conn
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+        # Mock cursor.description and fetchall
+        mock_cursor.description = [('id',), ('name',)]
+        mock_cursor.fetchall.return_value = [(1, 'Alice'), (2, 'Bob')]
+
+        runner = RuntimeRunner()
+        results = runner.fetch_table("MYHOLD")
+
+        # Verify SQL execution
+        # Note: psycopg2.sql.SQL.format returns a Composed object,
+        # but in mocks it's often easier to check just that execute was called.
+        self.assertTrue(mock_cursor.execute.called)
+
+        expected = [
+            {'id': 1, 'name': 'Alice'},
+            {'id': 2, 'name': 'Bob'}
+        ]
+        self.assertEqual(results, expected)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Enhanced the `RuntimeRunner` class by adding a `fetch_table` method. This method allows the runner to retrieve all rows from a specified table (such as those created by the WebFOCUS `HOLD` command) as a list of dictionaries. The implementation uses `psycopg2.sql.Identifier` to prevent SQL injection and includes a refactored error handling mechanism to provide detailed PostgreSQL diagnostics. This change fulfills step 7.3.2.2 of the `MIGRATION_ROADMAP.md`.

Fixes #347

---
*PR created automatically by Jules for task [1743078707235971990](https://jules.google.com/task/1743078707235971990) started by @chatelao*