### PR TITLE
Implement Procedural Filter Detection for Relational Lifting

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -132,7 +132,7 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
       - [x] 3.4.1.4.2.2 Map `-READ` variables to Master File fields to determine the underlying relational source.
       - [x] 3.4.1.4.3 Detection of procedural aggregations and filters within data loops.
       - [x] 3.4.1.4.3.1 Pattern matching for procedural accumulators (e.g., `VAR = VAR + READ_VAR`).
-      - [ ] 3.4.1.4.3.2 Pattern matching for procedural filters (e.g., conditional jumps skipping logic based on `-READ` values).
+      - [x] 3.4.1.4.3.2 Pattern matching for procedural filters (e.g., conditional jumps skipping logic based on `-READ` values).
       - [ ] 3.4.1.4.4 Implementation of Relational Lift pass to map loops to set-based SQL.
       - [ ] 3.4.1.4.4.1 Synthesize SQL `SELECT` with `WHERE` and `GROUP BY` from detected patterns.
       - [ ] 3.4.1.4.4.2 Replace procedural loop with a single `ir.Report` instruction in the CFG.

--- a/src/ir_utils.py
+++ b/src/ir_utils.py
@@ -158,20 +158,21 @@ def find_simple_while_loop(cfg, header_name):
     if not (isinstance(last_instr, ir.Jump) and last_instr.target == header_name):
         return None
 
-    # Verify body is a linear sequence of blocks leading to the closing block
+    # Verify body is a sequence of blocks leading to the closing block
     body_blocks = []
-    curr = body_start
+    worklist = [body_start]
     visited = {header_name, after_block}
-    while curr != label:
-        if curr in visited:
-            return None
+    while worklist:
+        curr = worklist.pop(0)
+        if curr == label or curr in visited:
+            continue
         visited.add(curr)
         body_blocks.append(curr)
 
         b = cfg.blocks.get(curr)
-        if not b or len(b.successors) != 1:
-            return None
-        curr = b.successors[0].name
+        if not b: return None
+        for succ in b.successors:
+            worklist.append(succ.name)
 
     return {
         'type': 'WHILE',

--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -127,6 +127,68 @@ class RelationalLiftingOptimizer:
                             }
         return accumulators
 
+    def identify_filters(self, cfg, loop, read_map):
+        """
+        Detects procedural filters (conditional jumps skipping logic).
+        Returns a list of ASG expressions that must be TRUE to NOT skip the logic.
+        """
+        filters = []
+        closing_block_name = loop['closing_block']
+
+        # We look for branches within the loop body that jump to the closing block
+        # (directly or through an empty block).
+        for b_name in loop['body_blocks']:
+            block = cfg.blocks.get(b_name)
+            if not block: continue
+
+            for instr in block.instructions:
+                if isinstance(instr, ir.Branch):
+                    # Check if true_target leads to closing_block and skips logic
+                    if self._is_skip_to_closing(cfg, instr.true_target, closing_block_name):
+                        # Filter is NOT condition (the logic is only executed if condition is FALSE)
+                        cond = asg.UnaryOperation(operator='NOT', operand=instr.condition)
+                        if self._can_be_sql_filter(cond, read_map):
+                            filters.append(cond)
+
+                    # Check if false_target leads to closing_block and skips logic
+                    elif self._is_skip_to_closing(cfg, instr.false_target, closing_block_name):
+                        # Filter is condition (the logic is only executed if condition is TRUE)
+                        cond = instr.condition
+                        if self._can_be_sql_filter(cond, read_map):
+                            filters.append(cond)
+
+        return filters
+
+    def _is_skip_to_closing(self, cfg, target_name, closing_block_name):
+        """Checks if a target branch leads directly or through an empty block to the loop end."""
+        if target_name == closing_block_name:
+            return True
+
+        target_block = cfg.blocks.get(target_name)
+        # An "empty" block in this context has only a Jump to the closing block
+        if target_block and len(target_block.instructions) == 1:
+            instr = target_block.instructions[0]
+            if isinstance(instr, ir.Jump) and instr.target == closing_block_name:
+                return True
+        return False
+
+    def _can_be_sql_filter(self, expr, read_map):
+        """Recursively checks if an expression only uses variables from read_map or literals."""
+        if isinstance(expr, asg.Literal):
+            return True
+        if isinstance(expr, (asg.AmperVar, asg.Identifier)):
+            return get_base_name(expr.name) in read_map
+        if isinstance(expr, asg.BinaryOperation):
+            return self._can_be_sql_filter(expr.left, read_map) and \
+                   self._can_be_sql_filter(expr.right, read_map)
+        if isinstance(expr, asg.UnaryOperation):
+            return self._can_be_sql_filter(expr.operand, read_map)
+        if isinstance(expr, asg.IfExpression):
+            return self._can_be_sql_filter(expr.condition, read_map) and \
+                   self._can_be_sql_filter(expr.then_expr, read_map) and \
+                   self._can_be_sql_filter(expr.else_expr, read_map)
+        return False
+
 class ConstantPropagator:
     """
     Performs constant propagation and constant folding on a CFG in SSA form.

--- a/test/test_relational_lifting.py
+++ b/test/test_relational_lifting.py
@@ -15,6 +15,7 @@ from ssa_transformer import SSATransformer
 from optimizer import RelationalLiftingOptimizer
 from metadata_registry import MetadataRegistry
 from asg import MasterFile, Segment, Field
+import asg
 
 class TestRelationalLifting(unittest.TestCase):
     def _get_cfg(self, fex_code):
@@ -142,6 +143,41 @@ class TestRelationalLifting(unittest.TestCase):
 
         self.assertEqual(read_map["&VAR1"], ("MYFILE", "FIELD1"))
         self.assertEqual(read_map["&VAR2"], ("MYFILE", "FIELD2"))
+
+    def test_identify_filters(self):
+        fex = """
+        -REPEAT LBL WHILE &I LE 10;
+        -READ MYFILE &VAR1 &VAR2
+        -IF &VAR1 EQ 'SKIP' GOTO LBL;
+        -SET &TOTAL = &TOTAL + &VAR2;
+        -LBL
+        """
+        # Setup metadata
+        registry = MetadataRegistry()
+        mf = MasterFile(name="MYFILE")
+        seg = Segment(name="S1")
+        seg.fields = [Field(name="FIELD1"), Field(name="FIELD2")]
+        mf.segments = [seg]
+        registry.register_master_file(mf)
+
+        cfg = self._get_cfg(fex)
+        optimizer = RelationalLiftingOptimizer()
+        data_loops = optimizer.find_data_loops(cfg)
+        self.assertEqual(len(data_loops), 1)
+
+        read_map = optimizer.map_read_variables(cfg, data_loops[0], registry)
+        filters = optimizer.identify_filters(cfg, data_loops[0], read_map)
+
+        self.assertEqual(len(filters), 1)
+        # Condition should be NOT (&VAR1 EQ 'SKIP')
+        cond = filters[0]
+        self.assertTrue(isinstance(cond, asg.UnaryOperation))
+        self.assertEqual(cond.operator, "NOT")
+        bin_op = cond.operand
+        self.assertTrue(isinstance(bin_op, asg.BinaryOperation))
+        self.assertEqual(bin_op.operator, "EQ")
+        self.assertEqual(bin_op.left.name, "&VAR1")
+        self.assertEqual(bin_op.right.value, "SKIP")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR implements procedural filter detection, a key component of the Relational Lifting phase (Phase 3.4.1.4). 

Procedural filters are common in legacy WebFOCUS code where `-IF ... GOTO ...` is used within a `-READ` loop to skip records that don't meet certain criteria. 

Key changes:
1.  **`src/optimizer.py`**: Added `identify_filters`, which identifies `ir.Branch` instructions jumping to the loop's latch. It extracts the condition and ensures it only depends on source data.
2.  **`src/ir_utils.py`**: Refactored `find_simple_while_loop` to use a reachability-based worklist algorithm. This allows the compiler to recognize loops with internal branching (like filters), which was previously restricted to linear bodies.
3.  **`test/test_relational_lifting.py`**: Added a comprehensive test case simulating a typical procedural skip pattern.
4.  **Roadmap**: Updated `MIGRATION_ROADMAP.md` to track progress.

All tests passed (39 total in the optimization/IR suite).

Fixes #352

---
*PR created automatically by Jules for task [10276134416336403031](https://jules.google.com/task/10276134416336403031) started by @chatelao*