### PR TITLE
Implement COUNT * and LIST verb support in PostgresEmitter

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -139,7 +139,7 @@ Transform the ASG into a Control Flow Graph (CFG) using Static Single Assignment
     - [/] 3.4.1.5 Advanced Pattern Matching for Relational Lifting:
       - [x] 3.4.1.5.1 Recognition of `COUNT` patterns (e.g., `VAR = VAR + 1`).
       - [x] 3.4.1.5.2 Recognition of conditional accumulation (e.g., `IF cond THEN VAR = VAR + VAL`).
-      - [/] 3.4.1.5.3 Recognition of MIN/MAX patterns (e.g., `IF VAL < VAR THEN VAR = VAL`).
+      - [x] 3.4.1.5.3 Recognition of MIN/MAX patterns (e.g., `IF VAL < VAR THEN VAR = VAL`).
   - [x] 3.4.2 Predicate Pushdown:
     - [x] 3.4.2.1 Filter Lifting: Move WHERE conditions to SQL. (Implemented in `src/emitter.py`)
     - [x] 3.4.2.2 Total Lifting: Move WHERE TOTAL conditions to SQL HAVING. (Implemented in `src/emitter.py`)
@@ -186,6 +186,7 @@ Use Jinja2 templates to generate the final PostgreSQL and middle-tier code.
       - [x] 4.3.1.5.3 Statistical operators: MDN, MDE, ASQ (Median, Mode, Average Square). (Implemented in `src/emitter.py`)
       - [x] 4.3.1.5.4 Percentage operators: PCT, RPCT (Percentage, Row Percentage). (Implemented in `src/emitter.py`)
       - [x] 4.3.1.5.5 Rank and Distinct: RNK, DST. (Implemented in `src/emitter.py`)
+      - [x] 4.3.1.5.6 Support for COUNT * and basic LIST verb in PostgresEmitter. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.6 Post-Aggregation Filtering: Mapping WHERE TOTAL to SQL `HAVING`. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.7 Sorting: Mapping sort options to SQL `ORDER BY`. (Implemented in `src/emitter.py`)
     - [x] 4.3.1.8 Calculated Values: Mapping COMPUTE command to SQL expressions. (Implemented in `src/emitter.py`)

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -809,9 +809,15 @@ class PostgresEmitter:
             if is_aggregating: break
 
         for vc in verb_commands:
+            if vc.verb == 'LIST':
+                select_fields.append('ROW_NUMBER() OVER () AS "LIST"')
+
             for field_sel in vc.fields:
                 if field_sel.name == '*':
-                    select_fields.append('*')
+                    if vc.verb == 'COUNT':
+                        select_fields.append('COUNT(*) AS "COUNT"')
+                    else:
+                        select_fields.append('*')
                     continue
 
                 field_name = field_sel.name

--- a/test/test_verbs_extended.py
+++ b/test/test_verbs_extended.py
@@ -1,0 +1,66 @@
+import unittest
+import sys
+import os
+from antlr4 import CommonTokenStream, InputStream
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from WebFocusReportLexer import WebFocusReportLexer
+from WebFocusReportParser import WebFocusReportParser
+from asg_builder import ReportASGBuilder
+from ir_builder import IRBuilder
+from ssa_transformer import SSATransformer
+from emitter import PostgresEmitter
+
+class TestVerbsExtended(unittest.TestCase):
+    def test_count_star(self):
+        fex_code = """
+        TABLE FILE EMPLOYEE
+        COUNT *
+        END
+        """
+        input_stream = InputStream(fex_code)
+        lexer = WebFocusReportLexer(input_stream)
+        token_stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(token_stream)
+        tree = parser.start()
+
+        builder = ReportASGBuilder()
+        asg_nodes = builder.visit(tree)
+
+        ir_builder = IRBuilder()
+        cfg = ir_builder.build(asg_nodes)
+
+        emitter = PostgresEmitter()
+        sql_output = emitter.emit(cfg)
+
+        self.assertIn('COUNT(*) AS "COUNT"', sql_output)
+
+    def test_list_verb(self):
+        fex_code = """
+        TABLE FILE EMPLOYEE
+        LIST LAST_NAME FIRST_NAME
+        END
+        """
+        input_stream = InputStream(fex_code)
+        lexer = WebFocusReportLexer(input_stream)
+        token_stream = CommonTokenStream(lexer)
+        parser = WebFocusReportParser(token_stream)
+        tree = parser.start()
+
+        builder = ReportASGBuilder()
+        asg_nodes = builder.visit(tree)
+
+        ir_builder = IRBuilder()
+        cfg = ir_builder.build(asg_nodes)
+
+        emitter = PostgresEmitter()
+        sql_output = emitter.emit(cfg)
+
+        self.assertIn('ROW_NUMBER() OVER () AS "LIST"', sql_output)
+        self.assertIn('LAST_NAME', sql_output)
+        self.assertIn('FIRST_NAME', sql_output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented the `LIST` verb and `COUNT *` syntax in `PostgresEmitter`. The `LIST` verb now generates a `ROW_NUMBER() OVER ()` column aliased as "LIST", and `COUNT *` is correctly emitted as `COUNT(*) AS "COUNT"`. Updated the migration roadmap and added unit tests to verify the implementation.

Fixes #368

---
*PR created automatically by Jules for task [8996512969832643012](https://jules.google.com/task/8996512969832643012) started by @chatelao*