### PR TITLE
Implement Field Usage Tracking for Data Lineage Analysis

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -337,4 +337,7 @@ Ensure the generated PL/pgSQL code is not only syntactically correct but also ex
 - [ ] **8.1 CLI Diagnostics:**
   - [x] 8.1.1 Source Code Statistics (LOC, Report and DM command counts) (completed at 2026-05-15 10:00:00)
   - [x] 8.1.2 Control Flow Analysis (Cyclomatic Complexity) (completed at 2026-05-15 10:00:00)
-  - [ ] 8.1.3 Data Lineage Analysis (Field-level usage tracking)
+  - [ ] 8.1.3 Data Lineage Analysis:
+    - [x] 8.1.3.1 Field Usage Tracking (Verbs, Sorts, and Filters)
+    - [ ] 8.1.3.2 Virtual Field Lineage (DEFINE/COMPUTE)
+    - [ ] 8.1.3.3 Data Source and Target Mapping (TABLE FILE / HOLD)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,10 @@
 - [ ] 6.2 Develop a CLI tool for automated WebFOCUS code analysis
   - [x] 6.2.1 Source Code Statistics (LOC, Report and DM command counts) (completed at 2026-05-15 10:00:00)
   - [x] 6.2.2 Control Flow Analysis (Cyclomatic Complexity) (completed at 2026-05-15 10:00:00)
-  - [ ] 6.2.3 Data Lineage Analysis (Field-level usage tracking)
+  - [ ] 6.2.3 Data Lineage Analysis
+    - [x] 6.2.3.1 Field Usage Tracking (Verbs, Sorts, and Filters) (completed at 2026-05-20 14:41:08)
+    - [ ] 6.2.3.2 Virtual Field Lineage (DEFINE/COMPUTE)
+    - [ ] 6.2.3.3 Data Source and Target Mapping (TABLE FILE / HOLD)
 - [x] 6.3 Create a comprehensive test suite for the transpiler using real-world WebFOCUS samples (completed at 2026-05-03 10:15:00)
   - [x] 6.3.1 Collect and organize real-world WebFOCUS samples in `test/samples/` (completed at 2026-04-25 03:28:06)
   - [x] 6.3.2 Implement an automated test runner for samples

--- a/scripts/transpile.py
+++ b/scripts/transpile.py
@@ -15,17 +15,19 @@ try:
     from ssa_transformer import SSATransformer
     from emitter import PostgresEmitter
     from metadata_registry import MetadataRegistry
+    from lineage_analyzer import LineageAnalyzer
 except ImportError as e:
     print(f"Error: Could not import transpiler modules. Ensure 'src' is in PYTHONPATH. {e}")
     sys.exit(1)
 
-def collect_stats(code, asg_nodes):
+def collect_stats(code, asg_nodes, cfg=None):
     """Collects metrics from the source code and ASG."""
     stats = {
         'loc': len(code.splitlines()),
         'report_requests': 0,
         'dm_commands': 0,
-        'details': {}
+        'details': {},
+        'lineage': None
     }
 
     dm_classes = (asg.Goto, asg.Label, asg.Repeat)
@@ -38,6 +40,11 @@ def collect_stats(code, asg_nodes):
             if class_name.endswith('DM') or isinstance(node, dm_classes):
                 stats['dm_commands'] += 1
                 stats['details'][class_name] = stats['details'].get(class_name, 0) + 1
+
+    if cfg:
+        analyzer = LineageAnalyzer()
+        stats['lineage'] = analyzer.analyze(cfg)
+
     return stats
 
 def calculate_complexity(cfg):
@@ -70,7 +77,7 @@ def transpile_code(code, metadata_registry):
     ssa_transformer = SSATransformer()
     ssa_transformer.transform(cfg)
 
-    stats = collect_stats(code, asg_nodes)
+    stats = collect_stats(code, asg_nodes, cfg)
     stats['complexity'] = calculate_complexity(cfg)
 
     # 5. Backend Emission
@@ -102,6 +109,15 @@ def transpile_file(input_path, output_path, metadata_registry, show_stats=False)
             for cmd, count in sorted(stats['details'].items()):
                 print(f"  - {cmd}: {count}")
             print(f"Cyclomatic Complexity: {stats['complexity']}")
+
+            if stats['lineage']:
+                print("Data Lineage:")
+                print(f"  Sources: {', '.join(stats['lineage']['sources'])}")
+                if stats['lineage']['targets']:
+                    print(f"  Targets: {', '.join(stats['lineage']['targets'])}")
+                print(f"  Fields (Select): {', '.join(stats['lineage']['fields']['select'])}")
+                print(f"  Fields (Sort): {', '.join(stats['lineage']['fields']['sort'])}")
+                print(f"  Fields (Filter): {', '.join(stats['lineage']['fields']['filter'])}")
 
         return stats
     except Exception as e:

--- a/src/emitter.py
+++ b/src/emitter.py
@@ -5,7 +5,10 @@ import asg
 from type_inferrer import TypeInferrer
 from type_mapper import map_wf_type_to_pg
 from jinja2 import Environment, FileSystemLoader, select_autoescape
-from ir_utils import get_base_name, find_simple_for_loop, find_simple_while_loop
+from ir_utils import (
+    get_base_name, find_simple_for_loop, find_simple_while_loop,
+    collect_fields_from_component, collect_fields_from_expression
+)
 
 class PostgresEmitter:
     """
@@ -637,7 +640,7 @@ class PostgresEmitter:
             elif fname in report_virtual_fields:
                 expr, fmt, s_fn = report_virtual_fields[fname]
                 used_files.add(s_fn)
-                self._collect_used_files_in_expr(expr, mark_field_used, s_fn)
+                collect_fields_from_expression(expr, mark_field_used, s_fn)
             else:
                 # Unqualified name.
                 # Without metadata, we assume it's the primary file,
@@ -648,7 +651,7 @@ class PostgresEmitter:
         file_virtual_fields = {f: (e_fmt[0], e_fmt[1]) for f, e_fmt in report_virtual_fields.items()}
 
         for comp in instr.components:
-            self._collect_used_files_recursive(comp, mark_field_used, used_files)
+            collect_fields_from_component(comp, mark_field_used, used_files)
 
         # If * was found, we add all potential join targets
         if '*' in used_files:
@@ -1353,59 +1356,6 @@ class PostgresEmitter:
                 res.append(f"{target} := {source};")
 
         return "\n".join(res)
-
-    def _collect_used_files_recursive(self, node, mark_field_used, used_files=None):
-        if node is None: return
-        class_name = node.__class__.__name__
-
-        if class_name == 'VerbCommand':
-            for f in node.fields:
-                if f.name == '*':
-                    # If PRINT * is used, we must keep all files
-                    if used_files is not None:
-                        used_files.add('*')
-                else:
-                    mark_field_used(f.name)
-        elif class_name == 'SortCommand':
-            mark_field_used(node.field.name)
-        elif class_name == 'ComputeCommand':
-            self._collect_used_files_in_expr(node.expression, mark_field_used)
-        elif class_name == 'WhereClause':
-            self._collect_used_files_in_expr(node.condition, mark_field_used)
-        elif class_name == 'WhenCommand':
-            self._collect_used_files_in_expr(node.condition, mark_field_used)
-        elif class_name == 'OnCommand':
-            for action in node.actions:
-                self._collect_used_files_recursive(action, mark_field_used)
-
-    def _collect_used_files_in_expr(self, expr, mark_field_used, source_fn=None):
-        if expr is None: return
-        class_name = expr.__class__.__name__
-
-        if class_name == 'Identifier':
-            mark_field_used(expr.name, source_fn)
-        elif class_name == 'BinaryOperation':
-            self._collect_used_files_in_expr(expr.left, mark_field_used, source_fn)
-            self._collect_used_files_in_expr(expr.right, mark_field_used, source_fn)
-        elif class_name == 'UnaryOperation':
-            self._collect_used_files_in_expr(expr.operand, mark_field_used, source_fn)
-        elif class_name == 'FunctionCall':
-            for arg in expr.arguments:
-                self._collect_used_files_in_expr(arg, mark_field_used, source_fn)
-        elif class_name == 'IfExpression':
-            self._collect_used_files_in_expr(expr.condition, mark_field_used, source_fn)
-            self._collect_used_files_in_expr(expr.then_expr, mark_field_used, source_fn)
-            self._collect_used_files_in_expr(expr.else_expr, mark_field_used, source_fn)
-        elif class_name == 'BetweenExpression':
-            self._collect_used_files_in_expr(expr.expression, mark_field_used, source_fn)
-            self._collect_used_files_in_expr(expr.lower, mark_field_used, source_fn)
-            self._collect_used_files_in_expr(expr.upper, mark_field_used, source_fn)
-        elif class_name == 'InExpression':
-            self._collect_used_files_in_expr(expr.expression, mark_field_used, source_fn)
-            for val in expr.values:
-                self._collect_used_files_in_expr(val, mark_field_used, source_fn)
-        elif class_name == 'IsMissingExpression':
-            self._collect_used_files_in_expr(expr.expression, mark_field_used, source_fn)
 
     def _apply_prefixes(self, sql_expr, prefixes, verb=None, group_by=None):
         """

--- a/src/ir_utils.py
+++ b/src/ir_utils.py
@@ -120,6 +120,65 @@ def find_simple_for_loop(cfg, header_name):
         'after_block': after_block
     }
 
+def collect_fields_from_component(node, mark_field_used, used_files=None):
+    """
+    Recursively collects field references from report components.
+    """
+    if node is None: return
+    class_name = node.__class__.__name__
+
+    if class_name == 'VerbCommand':
+        for f in node.fields:
+            if f.name == '*':
+                # If PRINT * is used, we must keep all files
+                if used_files is not None:
+                    used_files.add('*')
+            else:
+                mark_field_used(f.name)
+    elif class_name == 'SortCommand':
+        mark_field_used(node.field.name)
+    elif class_name == 'ComputeCommand':
+        collect_fields_from_expression(node.expression, mark_field_used)
+    elif class_name == 'WhereClause':
+        collect_fields_from_expression(node.condition, mark_field_used)
+    elif class_name == 'WhenCommand':
+        collect_fields_from_expression(node.condition, mark_field_used)
+    elif class_name == 'OnCommand':
+        for action in node.actions:
+            collect_fields_from_component(action, mark_field_used, used_files)
+
+def collect_fields_from_expression(expr, mark_field_used, source_fn=None):
+    """
+    Recursively collects field references from ASG expressions.
+    """
+    if expr is None: return
+    class_name = expr.__class__.__name__
+
+    if class_name == 'Identifier':
+        mark_field_used(expr.name, source_fn)
+    elif class_name == 'BinaryOperation':
+        collect_fields_from_expression(expr.left, mark_field_used, source_fn)
+        collect_fields_from_expression(expr.right, mark_field_used, source_fn)
+    elif class_name == 'UnaryOperation':
+        collect_fields_from_expression(expr.operand, mark_field_used, source_fn)
+    elif class_name == 'FunctionCall':
+        for arg in expr.arguments:
+            collect_fields_from_expression(arg, mark_field_used, source_fn)
+    elif class_name == 'IfExpression':
+        collect_fields_from_expression(expr.condition, mark_field_used, source_fn)
+        collect_fields_from_expression(expr.then_expr, mark_field_used, source_fn)
+        collect_fields_from_expression(expr.else_expr, mark_field_used, source_fn)
+    elif class_name == 'BetweenExpression':
+        collect_fields_from_expression(expr.expression, mark_field_used, source_fn)
+        collect_fields_from_expression(expr.lower, mark_field_used, source_fn)
+        collect_fields_from_expression(expr.upper, mark_field_used, source_fn)
+    elif class_name == 'InExpression':
+        collect_fields_from_expression(expr.expression, mark_field_used, source_fn)
+        for val in expr.values:
+            collect_fields_from_expression(val, mark_field_used, source_fn)
+    elif class_name == 'IsMissingExpression':
+        collect_fields_from_expression(expr.expression, mark_field_used, source_fn)
+
 def find_simple_while_loop(cfg, header_name):
     """
     Identifies if a block is the header of a simple REPEAT...WHILE or REPEAT...UNTIL loop.

--- a/src/lineage_analyzer.py
+++ b/src/lineage_analyzer.py
@@ -1,0 +1,100 @@
+import ir
+from ir_utils import collect_fields_from_expression
+
+class LineageAnalyzer:
+    """
+    Analyzes the Control Flow Graph to track field usage and data lineage.
+    """
+    def __init__(self):
+        pass
+
+    def analyze(self, cfg):
+        """
+        Traverses the CFG and collects field usage from report and match instructions.
+        Returns a dictionary of usage information.
+        """
+        lineage = {
+            'fields': {
+                'select': set(),
+                'sort': set(),
+                'filter': set()
+            },
+            'sources': set(),
+            'targets': set()
+        }
+
+        if not cfg:
+            return lineage
+
+        for block in cfg.blocks.values():
+            for instr in block.instructions:
+                if isinstance(instr, ir.Report):
+                    lineage['sources'].add(instr.filename)
+                    self._analyze_report(instr, lineage)
+                elif isinstance(instr, ir.Match):
+                    lineage['sources'].add(instr.filename)
+                    self._analyze_match(instr, lineage)
+                elif isinstance(instr, ir.Join):
+                    lineage['sources'].add(instr.right_file)
+                elif isinstance(instr, ir.Define):
+                    lineage['sources'].add(instr.filename)
+
+        # Convert sets to sorted lists for stable output
+        lineage['fields']['select'] = sorted(list(lineage['fields']['select']))
+        lineage['fields']['sort'] = sorted(list(lineage['fields']['sort']))
+        lineage['fields']['filter'] = sorted(list(lineage['fields']['filter']))
+        lineage['sources'] = sorted(list(lineage['sources']))
+        lineage['targets'] = sorted(list(lineage['targets']))
+
+        return lineage
+
+    def _analyze_report(self, instr, lineage):
+        """Analyzes an ir.Report instruction for field usage."""
+        for comp in instr.components:
+            self._analyze_component(comp, lineage)
+
+    def _analyze_match(self, instr, lineage):
+        """Analyzes an ir.Match instruction for field usage."""
+        # Main file components
+        for comp in instr.components:
+            self._analyze_component(comp, lineage)
+
+        # Sub-matches
+        for sub in instr.sub_matches:
+            lineage['sources'].add(sub.filename)
+            for comp in sub.components:
+                self._analyze_component(comp, lineage)
+            if sub.after_match and sub.after_match.output_command:
+                self._analyze_component(sub.after_match.output_command, lineage)
+
+    def _analyze_component(self, comp, lineage):
+        """Analyzes a report component and categorizes field usage."""
+        class_name = comp.__class__.__name__
+
+        def mark_select(name, source_fn=None):
+            lineage['fields']['select'].add(name)
+
+        def mark_sort(name, source_fn=None):
+            lineage['fields']['sort'].add(name)
+
+        def mark_filter(name, source_fn=None):
+            lineage['fields']['filter'].add(name)
+
+        if class_name == 'VerbCommand':
+            for f in comp.fields:
+                if f.name != '*':
+                    lineage['fields']['select'].add(f.name)
+        elif class_name == 'SortCommand':
+            lineage['fields']['sort'].add(comp.field.name)
+        elif class_name == 'ComputeCommand':
+            collect_fields_from_expression(comp.expression, mark_select)
+        elif class_name == 'WhereClause':
+            collect_fields_from_expression(comp.condition, mark_filter)
+        elif class_name == 'WhenCommand':
+            collect_fields_from_expression(comp.condition, mark_filter)
+        elif class_name == 'OnCommand':
+            for action in comp.actions:
+                self._analyze_component(action, lineage)
+        elif class_name == 'OutputCommand':
+            if comp.filename:
+                lineage['targets'].add(comp.filename)

--- a/test/test_lineage_analyzer.py
+++ b/test/test_lineage_analyzer.py
@@ -1,0 +1,110 @@
+import unittest
+import ir
+import asg
+from lineage_analyzer import LineageAnalyzer
+
+class TestLineageAnalyzer(unittest.TestCase):
+    def setUp(self):
+        self.analyzer = LineageAnalyzer()
+
+    def test_basic_report_lineage(self):
+        # TABLE FILE CAR
+        # PRINT MODEL
+        # BY COUNTRY
+        # WHERE SEATS GT 2
+        # END
+        report = ir.Report(
+            filename="CAR",
+            components=[
+                asg.VerbCommand(verb="PRINT", fields=[asg.FieldSelection(name="MODEL")]),
+                asg.SortCommand(sort_type="BY", field=asg.FieldSelection(name="COUNTRY")),
+                asg.WhereClause(condition=asg.BinaryOperation(
+                    left=asg.Identifier(name="SEATS"),
+                    operator="GT",
+                    right=asg.Literal(value=2)
+                ))
+            ]
+        )
+        cfg = ir.ControlFlowGraph()
+        block = ir.BasicBlock(name="B1")
+        block.add_instruction(report)
+        cfg.add_block(block)
+
+        lineage = self.analyzer.analyze(cfg)
+
+        self.assertIn("CAR", lineage['sources'])
+        self.assertIn("MODEL", lineage['fields']['select'])
+        self.assertIn("COUNTRY", lineage['fields']['sort'])
+        self.assertIn("SEATS", lineage['fields']['filter'])
+
+    def test_match_lineage(self):
+        # MATCH FILE CAR
+        # PRINT MODEL BY BODYTYPE
+        # RUN
+        # FILE SALES
+        # PRINT RETAIL_COST BY BODYTYPE
+        # AFTER MATCH HOLD AS MATCHED_DATA
+        # END
+        match = ir.Match(
+            filename="CAR",
+            components=[
+                asg.VerbCommand(verb="PRINT", fields=[asg.FieldSelection(name="MODEL")]),
+                asg.SortCommand(sort_type="BY", field=asg.FieldSelection(name="BODYTYPE"))
+            ],
+            sub_matches=[
+                asg.SubMatch(
+                    filename="SALES",
+                    components=[
+                        asg.VerbCommand(verb="PRINT", fields=[asg.FieldSelection(name="RETAIL_COST")]),
+                        asg.SortCommand(sort_type="BY", field=asg.FieldSelection(name="BODYTYPE"))
+                    ],
+                    after_match=asg.AfterMatchPhrase(merge_type="OLD_OR_NEW", output_command=asg.OutputCommand(output_type="HOLD", filename="MATCHED_DATA"))
+                )
+            ]
+        )
+        cfg = ir.ControlFlowGraph()
+        block = ir.BasicBlock(name="B1")
+        block.add_instruction(match)
+        cfg.add_block(block)
+
+        lineage = self.analyzer.analyze(cfg)
+
+        self.assertIn("CAR", lineage['sources'])
+        self.assertIn("SALES", lineage['sources'])
+        self.assertIn("MATCHED_DATA", lineage['targets'])
+        self.assertIn("MODEL", lineage['fields']['select'])
+        self.assertIn("RETAIL_COST", lineage['fields']['select'])
+        self.assertIn("BODYTYPE", lineage['fields']['sort'])
+
+    def test_compute_and_on_lineage(self):
+        # TABLE FILE CAR
+        # SUM SALES
+        # COMPUTE MARGIN = SALES - COST;
+        # ON COUNTRY SUM SALES
+        # END
+        report = ir.Report(
+            filename="CAR",
+            components=[
+                asg.VerbCommand(verb="SUM", fields=[asg.FieldSelection(name="SALES")]),
+                asg.ComputeCommand(name="MARGIN", expression=asg.BinaryOperation(
+                    left=asg.Identifier(name="SALES"),
+                    operator="-",
+                    right=asg.Identifier(name="COST")
+                )),
+                asg.OnCommand(target="COUNTRY", actions=[
+                    asg.VerbCommand(verb="SUM", fields=[asg.FieldSelection(name="SALES")])
+                ])
+            ]
+        )
+        cfg = ir.ControlFlowGraph()
+        block = ir.BasicBlock(name="B1")
+        block.add_instruction(report)
+        cfg.add_block(block)
+
+        lineage = self.analyzer.analyze(cfg)
+
+        self.assertIn("SALES", lineage['fields']['select'])
+        self.assertIn("COST", lineage['fields']['select'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR implements the first step of the Data Lineage Analysis feature for the WebFOCUS analysis CLI.

Key changes:
1.  **Roadmap Breakdown**: The "Data Lineage Analysis" task in `ROADMAP.md` and `MIGRATION_ROADMAP.md` has been expanded into three modest sub-tasks: Field Usage Tracking, Virtual Field Lineage, and Data Source/Target Mapping.
2.  **Refactoring**: Extracted ASG field collection logic from `PostgresEmitter` into `src/ir_utils.py` (`collect_fields_from_component` and `collect_fields_from_expression`) to enable reuse by analysis tools without duplication.
3.  **LineageAnalyzer**: Introduced a new `LineageAnalyzer` class that traverses the Control Flow Graph to identify field usage (categorized by purpose) and tracks data sources and targets from `Report`, `Match`, `Join`, and `Define` instructions.
4.  **CLI Integration**: Enhanced `scripts/transpile.py` to include a "Data Lineage" section in its `--stats` output, providing insights into used fields, sources, and targets for each transpiled file.
5.  **Testing**: Added `test/test_lineage_analyzer.py` with comprehensive unit tests for various reporting and matching scenarios. Verified that existing transpiler and parser tests pass.

This completes roadmap step 6.2.3.1 / 8.1.3.1.

Fixes #377

---
*PR created automatically by Jules for task [15814574807523147245](https://jules.google.com/task/15814574807523147245) started by @chatelao*