### PR TITLE
Verify WHERE/HAVING parity on live DB

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -334,6 +334,7 @@ Ensure the generated PL/pgSQL code is not only syntactically correct but also ex
     - [x] 7.3.2.4 Implement live database parity verification suite. (Completed: `test/test_live_parity.py` updated with aggregation tests)
     - [x] 7.3.2.5 Verify JOIN and multi-table parity on live DB.
     - [x] 7.3.2.6 Verify calculated fields (DEFINE/COMPUTE) parity on live DB.
+    - [x] 7.3.2.7 Verify WHERE and WHERE TOTAL (HAVING) parity on live DB.
   - [x] 7.3.3 Implement comprehensive error reporting for runtime failures (e.g., SQL syntax errors, type mismatches during execution). (Implemented in `src/runtime_runner.py`)
 
 ## Phase 8: Operational Excellence

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,6 @@
 # ROADMAP
-- [ ] 0.12 Implement a next, modest, very small, feasible and reasonable ROADMAP.md step of chapter 'Chapter 7: CI/CD & Verification' (#399)
+- [ ] 0.13 Implement a next, modest, very small, feasible and reasonable ROADMAP.md step of chapter 'Chapter 7: CI/CD & Verification'
+- [x] 0.12 Implement a next, modest, very small, feasible and reasonable ROADMAP.md step of chapter 'Chapter 7: CI/CD & Verification' (#399) (completed at 2026-05-21 09:42:14)
 - [x] 0.11 Implement a next, modest, very small, feasible and reasonable ROADMAP.md step of chapter 'Chapter 7: CI/CD & Verification' (#395) (completed at 2026-05-21 08:35:00)
 - [x] 0.10 Implement a next, modest, very small, feasible and reasonable ROADMAP.md step of chapter 'Chapter 7: CI/CD & Verification' (#393) (completed at 2026-05-21 07:10:00)
 - [x] 0.9 Verify calculated fields (DEFINE/COMPUTE) parity on live DB (#391)
@@ -106,4 +107,5 @@
     - [x] 7.3.2.2 Implement aggregation and grouping parity test on live DB (completed at 2026-05-21 05:57:08)
     - [x] 7.3.2.3 Verify JOIN and multi-table parity on live DB (completed at 2026-05-21 07:17:49)
     - [x] 7.3.2.4 Verify calculated fields (DEFINE/COMPUTE) parity on live DB
+      - [x] 7.3.2.5 Verify WHERE and WHERE TOTAL (HAVING) parity on live DB (completed at 2026-05-21 09:30:00)
   - [x] 7.3.3 Refactor FixtureLoader to support external cursors for transaction consistency (completed at 2026-05-20 19:02:13)

--- a/test/test_live_parity.py
+++ b/test/test_live_parity.py
@@ -104,6 +104,79 @@ class TestLiveParity(unittest.TestCase):
                 os.remove(fixture_path)
 
     @unittest.skipUnless(is_db_available(), "PostgreSQL not available")
+    def test_where_total_parity(self):
+        """
+        Verify WHERE (pre-aggregation) and WHERE TOTAL (post-aggregation) parity on a live database.
+        """
+        # 1. Define Metadata
+        registry = MetadataRegistry()
+        f1 = MasterFile(name="FILTER_DATA")
+        s1 = Segment(name="FILTER_DATA")
+        s1.fields = [
+            Field(name="REGION", alias="REG", usage="A10"),
+            Field(name="PRODUCT", alias="PROD", usage="A20"),
+            Field(name="SALES", alias="SALES", usage="I8")
+        ]
+        f1.segments = [s1]
+        registry.register_master_file(f1)
+
+        # 2. Prepare Fixtures
+        sample_data = [
+            {"REGION": "East", "PRODUCT": "Apples", "SALES": 100},
+            {"REGION": "East", "PRODUCT": "Apples", "SALES": 100},  # SUM=200
+            {"REGION": "West", "PRODUCT": "Apples", "SALES": 300},  # Skipped by WHERE
+            {"REGION": "East", "PRODUCT": "Oranges", "SALES": 50},  # SUM=50, skipped by WHERE TOTAL
+        ]
+        fixture_path = "filter_test_fixtures.json"
+        with open(fixture_path, "w") as f:
+            json.dump(sample_data, f)
+
+        try:
+            # 3. Transpile
+            fex_code = """
+            TABLE FILE FILTER_DATA
+            SUM SALES
+            BY PRODUCT
+            WHERE REGION EQ 'East'
+            WHERE TOTAL SALES GT 150
+            ON TABLE HOLD AS FILTER_RESULTS
+            END
+            """
+            input_stream = InputStream(fex_code)
+            lexer = WebFocusReportLexer(input_stream)
+            token_stream = CommonTokenStream(lexer)
+            parser = WebFocusReportParser(token_stream)
+            tree = parser.start()
+
+            asg_nodes = ReportASGBuilder().visit(tree)
+            cfg = IRBuilder().build(asg_nodes)
+            SSATransformer().transform(cfg)
+
+            emitter = PostgresEmitter(metadata_registry=registry)
+            sql_procedure = emitter.emit(cfg, "filter_parity_proc")
+
+            # 4. Execute on Live DB
+            with RuntimeRunner() as runner:
+                with runner.conn.cursor() as cursor:
+                    cursor.execute('DROP TABLE IF EXISTS "FILTER_DATA" CASCADE;')
+                    cursor.execute('DROP TABLE IF EXISTS "FILTER_RESULTS" CASCADE;')
+
+                runner.setup_schema([f1])
+                runner.load_fixtures([("FILTER_DATA", fixture_path)])
+                runner.run_procedure(sql_procedure, "filter_parity_proc")
+                results = runner.fetch_table("FILTER_RESULTS")
+
+            # 5. Verify
+            # Expected: Only Apples (East) with SUM=200
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0]['PRODUCT'].strip(), "Apples")
+            self.assertEqual(results[0]['SALES'], 200)
+
+        finally:
+            if os.path.exists(fixture_path):
+                os.remove(fixture_path)
+
+    @unittest.skipUnless(is_db_available(), "PostgreSQL not available")
     def test_aggregation_parity(self):
         """
         Verify aggregation (SUM) and grouping (BY) parity on a live database.


### PR DESCRIPTION
This change implements a modest step in the CI/CD & Verification chapter (Chapter 7) by adding end-to-end parity verification for WebFOCUS WHERE and WHERE TOTAL clauses against a live PostgreSQL database.

The implementation includes:
1. A new test case `test_where_total_parity` in `test/test_live_parity.py` which:
   - Defines metadata for a sample table.
   - Loads fixture data with multiple regions and products.
   - Transpiles a request with both pre-aggregation filtering (WHERE) and post-aggregation filtering (WHERE TOTAL).
   - Executes the resulting PL/pgSQL procedure.
   - Verifies the final results in the captured HOLD table.
2. Updates to ROADMAP.md and MIGRATION_ROADMAP.md to track and mark the completion of this verification step.
3. Proper cleanup of temporary database objects and fixture files during testing.

Fixes #399

---
*PR created automatically by Jules for task [10162559031943996276](https://jules.google.com/task/10162559031943996276) started by @chatelao*