### PR TITLE
Implement @example support for Railroad Diagrams

### DIFF
--- a/RAILROAD_ROADMAP.md
+++ b/RAILROAD_ROADMAP.md
@@ -64,6 +64,7 @@ This document outlines the tasks required to implement the automated railroad di
 
 ## Phase 8: Content Enrichment
 - [x] 8.1 Extract and display rule descriptions from ANTLR4 comments.
+- [ ] 8.2 Extract and display rule examples from @example tags.
 
 ## Phase 9: Advanced Rule Organization & Search
 - [x] 9.1 Implement rule categorization using `@category` tags.

--- a/docs/MasterFile.xhtml
+++ b/docs/MasterFile.xhtml
@@ -306,6 +306,33 @@
         background-color: #3b6edb;
     }
 
+    .rule-example-container {
+        margin-top: 10px;
+        margin-bottom: 10px;
+        background-color: #f8f9fa;
+        border-radius: 4px;
+        padding: 8px;
+        border-left: 3px solid #4D88FF;
+    }
+    .rule-example-header {
+        font-weight: bold;
+        color: #002b80;
+        font-size: 11px;
+        text-transform: uppercase;
+        margin-bottom: 4px;
+        font-family: 'Verdana', sans-serif;
+    }
+    .rule-example {
+        font-family: 'Courier New', monospace;
+        font-size: 13px;
+        color: #333;
+        white-space: pre-wrap;
+        display: block;
+        margin-bottom: 4px;
+    }
+    .rule-example:last-child {
+        margin-bottom: 0;
+    }
     .rule-description {
         font-style: italic;
         color: #555;

--- a/docs/WebFocusReport.xhtml
+++ b/docs/WebFocusReport.xhtml
@@ -306,6 +306,33 @@
         background-color: #3b6edb;
     }
 
+    .rule-example-container {
+        margin-top: 10px;
+        margin-bottom: 10px;
+        background-color: #f8f9fa;
+        border-radius: 4px;
+        padding: 8px;
+        border-left: 3px solid #4D88FF;
+    }
+    .rule-example-header {
+        font-weight: bold;
+        color: #002b80;
+        font-size: 11px;
+        text-transform: uppercase;
+        margin-bottom: 4px;
+        font-family: 'Verdana', sans-serif;
+    }
+    .rule-example {
+        font-family: 'Courier New', monospace;
+        font-size: 13px;
+        color: #333;
+        white-space: pre-wrap;
+        display: block;
+        margin-bottom: 4px;
+    }
+    .rule-example:last-child {
+        margin-bottom: 0;
+    }
     .rule-description {
         font-style: italic;
         color: #555;
@@ -8344,6 +8371,10 @@
    </div>
    <div class="category-header">Report Requests</div>
    <div class="rule-container" id="request" data-rule="request" data-description="">
+      <div class="rule-example-container">
+          <div class="rule-example-header">Examples</div>
+          <code class="rule-example">TABLE FILE CAR PRINT * END</code>
+      </div>
       <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="request">request:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="697" height="791">
          <defs>
             <style type="text/css">
@@ -9359,6 +9390,10 @@
    </div>
    <div class="category-header">Environment</div>
    <div class="rule-container" id="join_command" data-rule="join_command" data-description="">
+      <div class="rule-example-container">
+          <div class="rule-example-header">Examples</div>
+          <code class="rule-example">JOIN CAR.BODY.COUNTRY TO ALL COUNTRY.COUNTRY.COUNTRY AS J1</code>
+      </div>
       <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="join_command">join_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="1303" height="297">
          <defs>
             <style type="text/css">

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@
 <body>
     <h1>WebFocus Syntax Railroad Diagrams</h1>
     <p>Visual representation of the WebFocus grammars.</p>
-    <div class="metadata">Generated on: 2026-05-21 07:21:58</div>
+    <div class="metadata">Generated on: 2026-05-21 10:08:07</div>
     <ul>
         <li><a href="WebFocusReport.xhtml">WebFocusReport.g4</a></li><li><a href="MasterFile.xhtml">MasterFile.g4</a></li>
     </ul>

--- a/scripts/antlr4_to_ebnf.py
+++ b/scripts/antlr4_to_ebnf.py
@@ -2,7 +2,7 @@ import re
 import sys
 
 class Rule:
-    def __init__(self, name, body, tags, description="", is_fragment=False, is_lexer=False, category=None):
+    def __init__(self, name, body, tags, description="", is_fragment=False, is_lexer=False, category=None, examples=None):
         self.name = name
         self.body = body
         self.tags = tags
@@ -10,6 +10,7 @@ class Rule:
         self.is_fragment = is_fragment
         self.is_lexer = is_lexer
         self.category = category
+        self.examples = examples or []
 
 def convert_antlr_to_ebnf(antlr_content):
     """
@@ -18,54 +19,73 @@ def convert_antlr_to_ebnf(antlr_content):
     # Rule regex that handles strings correctly.
     rule_regex = r'(?m)^\s*(fragment\s+)?([a-zA-Z]\w*)\s*:\s*((?:\'(?:\'\'|[^\'])*\'|"(?:\"\"|[^\"])*"|[^;])+)\s*;'
 
+
     rules = {}
 
     # 1. Extraction
+    last_end = 0
     for match in re.finditer(rule_regex, antlr_content):
         fragment, name, body = match.groups()
         start_pos = match.start()
 
         # Search for tags and descriptions in the comments before this rule
-        prev_content = antlr_content[:start_pos]
-        last_semi = prev_content.rfind(';')
-        if last_semi == -1:
-            search_window = prev_content
-        else:
-            search_window = prev_content[last_semi:]
+        # We look back to the previous rule's end or start of file.
+        search_window = antlr_content[last_end:start_pos]
+        last_end = match.end()
 
-        tags = [t[1:] for t in re.findall(r'@\w+', search_window)]
+        # Extract all comments in the search window to look for tags
+        comments_list = re.findall(r'/\*.*?\*/|//[^\r\n]*', search_window, re.DOTALL)
 
-        # Extract category if present
-        category_match = re.search(r'@category\s+([^\r\n*]+)', search_window)
-        category = category_match.group(1).strip() if category_match else None
+        # Pre-process comments to extract tags and examples
+        tags = []
+        category = None
+        examples = []
+
+        for comment in comments_list:
+            if comment.startswith('//'):
+                content = comment[2:]
+            else:
+                content = comment[2:-2]
+
+            # Clean up content (remove leading *)
+            lines = [line.strip().lstrip('*').strip() for line in content.split('\n')]
+            clean_content = "\n".join(lines)
+
+            tags.extend([t[1:] for t in re.findall(r'@\w+', clean_content)])
+
+            # Remove tags from description extraction by cleaning them out
+            tag_free_content = re.sub(r'@\w+(\s+[^\r\n]*)?', '', clean_content).strip()
+
+            cat_match = re.search(r'@category\s+([^\r\n]+)', clean_content)
+            if cat_match and not category:
+                category = cat_match.group(1).strip()
+
+            examples.extend([m.group(1).strip() for m in re.finditer(r'@example\s+([^\r\n]+)', clean_content)])
 
         # Extract description (all comments that are not tags)
-        description = ""
-        # Find all comments: /* ... */ or // ...
-        # Using (?ms) for multiline and dotall, but // should only match until end of line.
-        comment_matches = re.findall(r'/\*.*?\*/|//[^\r\n]*', search_window, re.DOTALL)
-        if comment_matches:
-            description_lines = []
-            for comment in comment_matches:
-                # Strip // or /* */
-                if comment.startswith('//'):
-                    line = comment[2:].strip()
-                else:
-                    line = comment[2:-2].strip()
+        description_lines = []
+        for comment in comments_list:
+            if comment.startswith('//'):
+                content = comment[2:]
+            else:
+                content = comment[2:-2]
 
-                # Clean up individual lines in multiline comments
-                lines = [l.strip().lstrip('*').strip() for l in line.split('\n')]
-                # Filter out lines that only contain tags
-                filtered_lines = [l for l in lines if l and not re.match(r'^\s*@\w+(\s+[^\r\n*]+)?\s*$', l)]
-                if filtered_lines:
-                    description_lines.extend(filtered_lines)
+            lines = [line.strip().lstrip('*').strip() for line in content.split('\n')]
+            for line in lines:
+                # Skip lines that are just tags
+                if not line or re.match(r'^\s*@\w+(\s+[^\r\n]*)?$', line):
+                    continue
+                # Clean tags from lines that might have them and other text (though unlikely)
+                clean_line = re.sub(r'@\w+(\s+[^\r\n]*)?', '', line).strip()
+                if clean_line:
+                    description_lines.append(clean_line)
 
-            description = "\n".join(description_lines).strip()
+        description = "\n".join(description_lines).strip()
 
         is_lexer = name[0].isupper()
         body = format_body(body, is_lexer=is_lexer)
 
-        rules[name] = Rule(name, body, tags, description=description, is_fragment=bool(fragment), is_lexer=is_lexer, category=category)
+        rules[name] = Rule(name, body, tags, description=description, is_fragment=bool(fragment), is_lexer=is_lexer, category=category, examples=examples)
 
     # 2. Inlining
     to_inline = [name for name, rule in rules.items() if 'inline' in rule.tags or 'internal' in rule.tags]
@@ -248,8 +268,9 @@ if __name__ == "__main__":
         metadata = {
             name: {
                 "description": rule.description,
-                "category": rule.category
-            } for name, rule in rules.items() if rule.description or rule.category
+                "category": rule.category,
+                "examples": rule.examples
+            } for name, rule in rules.items() if rule.description or rule.category or rule.examples
         }
         with open(args.metadata, 'w') as f:
             json.dump(metadata, f, indent=2)

--- a/scripts/generate_railroad.py
+++ b/scripts/generate_railroad.py
@@ -156,6 +156,33 @@ def post_process_xhtml(filepath, metadata=None):
 
     # Add styling for rule descriptions
     oracle_styles += """
+    .rule-example-container {
+        margin-top: 10px;
+        margin-bottom: 10px;
+        background-color: #f8f9fa;
+        border-radius: 4px;
+        padding: 8px;
+        border-left: 3px solid #4D88FF;
+    }
+    .rule-example-header {
+        font-weight: bold;
+        color: #002b80;
+        font-size: 11px;
+        text-transform: uppercase;
+        margin-bottom: 4px;
+        font-family: 'Verdana', sans-serif;
+    }
+    .rule-example {
+        font-family: 'Courier New', monospace;
+        font-size: 13px;
+        color: #333;
+        white-space: pre-wrap;
+        display: block;
+        margin-bottom: 4px;
+    }
+    .rule-example:last-child {
+        margin-bottom: 0;
+    }
     .rule-description {
         font-style: italic;
         color: #555;
@@ -315,12 +342,14 @@ def wrap_rules_in_containers(content, metadata):
 
         description = meta.get("description", "")
         category = meta.get("category") or "Other Rules"
+        examples = meta.get("examples") or []
 
         rule_blocks.append({
             "name": rule_name,
             "body": rule_body.strip(),
             "description": description,
-            "category": category
+            "category": category,
+            "examples": examples
         })
 
     # Group by category
@@ -342,6 +371,7 @@ def wrap_rules_in_containers(content, metadata):
         for block in category_map[cat_name]:
             rule_name = block["name"]
             description = block["description"]
+            examples = block["examples"]
             safe_desc_attr = html.escape(description)
 
             new_content += f'   <div class="rule-container" id="{rule_name}" data-rule="{rule_name}" data-description="{safe_desc_attr}">\n'
@@ -349,6 +379,13 @@ def wrap_rules_in_containers(content, metadata):
             if description:
                 safe_desc_html = html.escape(description).replace('\n', '<br/>')
                 new_content += f'      <div class="rule-description">{safe_desc_html}</div>\n'
+
+            if examples:
+                new_content += '      <div class="rule-example-container">\n'
+                new_content += '          <div class="rule-example-header">Examples</div>\n'
+                for example in examples:
+                    new_content += f'          <code class="rule-example">{html.escape(example)}</code>\n'
+                new_content += '      </div>\n'
 
             new_content += f'      {block["body"]}\n'
             new_content += '   </div>\n'

--- a/src/WebFocusReport.g4
+++ b/src/WebFocusReport.g4
@@ -3,6 +3,7 @@ grammar WebFocusReport;
 start: (request | match_request | dm_command | join_command | set_command | define_file | compound_layout_block)* EOF;
 
 // @category Report Requests
+// @example TABLE FILE CAR PRINT * END
 request: table_file (request_element)* more_phrase? end_command;
 
 // @category Report Requests
@@ -59,6 +60,7 @@ recap_option: as_phrase
 format_name: NAME (DOT NUMBER)? (NAME | NUMBER)*;
 
 // @category Environment
+// @example JOIN CAR.BODY.COUNTRY TO ALL COUNTRY.COUNTRY.COUNTRY AS J1
 join_command: JOIN (CLEAR asterisk | (LEFT? OUTER)? qualified_name IN qualified_name TO ALL? qualified_name IN qualified_name (AS NAME)?) SEMI?;
 
 // @category Environment
@@ -193,6 +195,8 @@ dm_float: NUMBER DOT NUMBER;
 amper_var: AMPER_VAR;
 
 // @inline
+// @example TABLE FILE CAR
+// @example TABLE FILE SALES
 table_file: TABLE FILE qualified_name;
 
 // @category Report Requests

--- a/test/test_antlr4_to_ebnf.py
+++ b/test/test_antlr4_to_ebnf.py
@@ -206,3 +206,21 @@ def test_coverage_check_recursive_inline_preserved():
     assert "a ::= a 'x' | 'y'" in ebnf
     missing = check_coverage(antlr, ebnf)
     assert missing == []
+
+def test_example_extraction():
+    antlr = """
+    // @example TABLE FILE CAR
+    // @example JOIN CAR.BODY.COUNTRY TO ALL COUNTRY.COUNTRY.COUNTRY AS J1
+    rule1: 'A';
+
+    /*
+     * @example -SET &VAR = 1;
+     */
+    rule2: 'B';
+    """
+    _, rules = convert_antlr_to_ebnf(antlr)
+    assert rules['rule1'].examples == [
+        "TABLE FILE CAR",
+        "JOIN CAR.BODY.COUNTRY TO ALL COUNTRY.COUNTRY.COUNTRY AS J1"
+    ]
+    assert rules['rule2'].examples == ["-SET &VAR = 1;"]


### PR DESCRIPTION
Implemented extraction and display of rule examples from ANTLR4 grammar comments. The pipeline now captures `@example` tags and renders them within the railroad diagram documentation, providing better context for language constructs. Refined the metadata extraction logic to be more robust across different comment styles and rule boundaries.

Fixes #400

---
*PR created automatically by Jules for task [1913000984150971374](https://jules.google.com/task/1913000984150971374) started by @chatelao*