### PR TITLE
Add 'Copy' button to railroad diagram examples

### DIFF
--- a/RAILROAD_ROADMAP.md
+++ b/RAILROAD_ROADMAP.md
@@ -71,3 +71,6 @@ This document outlines the tasks required to implement the automated railroad di
 - [x] 9.1 Implement rule categorization using `@category` tags.
 - [x] 9.2 Group rules by category in the generated documentation.
 - [x] 9.3 Enhance search functionality to include rule descriptions and handle category groupings.
+
+## Phase 10: UI & Interactivity
+- [x] 10.1 Add a 'Copy' button to all rule examples for easy extraction.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,5 @@
 # ROADMAP
-- [ ] 0.13 Implement a next, modest, very small, feasible and reasonable RAILROAD_ROADMAP.md step (#405)
+- [x] 0.13 Implement a next, modest, very small, feasible and reasonable RAILROAD_ROADMAP.md step (#405) (completed at 2026-05-23 12:58:41)
 - [x] 0.12 Implement a next, modest, very small, feasible and reasonable RAILROAD_ROADMAP.md step (#403) (completed at 2026-05-21 12:03:01)
 - [x] 0.11 Implement a next, modest, very small, feasible and reasonable ROADMAP.md step of chapter 'Chapter 7: CI/CD & Verification' (#395) (completed at 2026-05-21 08:35:00)
 - [x] 0.10 Implement a next, modest, very small, feasible and reasonable ROADMAP.md step of chapter 'Chapter 7: CI/CD & Verification' (#393) (completed at 2026-05-21 07:10:00)

--- a/docs_test/WebFocusReport.xhtml
+++ b/docs_test/WebFocusReport.xhtml
@@ -1,0 +1,10566 @@
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <meta name="generator" content="Railroad Diagram Generator 1.63" />
+      <style type="text/css">
+    ::-moz-selection
+    {
+      color: #F0F5FF;
+      background: #00050F;
+    }
+    ::selection
+    {
+      color: #F0F5FF;
+      background: #00050F;
+    }
+    .ebnf a, .grammar a
+    {
+      text-decoration: none;
+    }
+    .ebnf a:hover, .grammar a:hover
+    {
+      color: #000205;
+      text-decoration: underline;
+    }
+    .signature
+    {
+      color: #002B80;
+      font-size: 11px;
+      text-align: right;
+    }
+    body
+    {
+      font: normal 12px Verdana, sans-serif;
+      color: #00050F;
+      background: #F0F5FF;
+    }
+    a:link, a:visited
+    {
+      color: #00050F;
+    }
+    a:link.signature, a:visited.signature
+    {
+      color: #002B80;
+    }
+    a.button, #tabs li a
+    {
+      padding: 0.25em 0.5em;
+      border: 1px solid #002B80;
+      background: #C6D4F1;
+      color: #002B80;
+      text-decoration: none;
+      font-weight: bold;
+    }
+    a.button:hover, #tabs li a:hover
+    {
+      color: #000205;
+      background: #D1E0FF;
+      border-color: #000205;
+    }
+    #tabs
+    {
+      padding: 3px 10px;
+      margin-left: 0;
+      margin-top: 58px;
+      border-bottom: 1px solid #00050F;
+    }
+    #tabs li
+    {
+      list-style: none;
+      margin-left: 5px;
+      display: inline;
+    }
+    #tabs li a
+    {
+      border-bottom: 1px solid #00050F;
+    }
+    #tabs li a.active
+    {
+      color: #00050F;
+      background: #F0F5FF;
+      border-color: #00050F;
+      border-bottom: 1px solid #F0F5FF;
+      outline: none;
+    }
+    #divs div
+    {
+      display: none;
+      overflow:auto;
+    }
+    #divs div.active
+    {
+      display: block;
+    }
+    #text
+    {
+      border-color: #002B80;
+      background: #FAFCFF;
+      color: #000205;
+    }
+    .small
+    {
+      vertical-align: top;
+      text-align: right;
+      font-size: 9px;
+      font-weight: normal;
+      line-height: 120%;
+    }
+    td.small
+    {
+      padding-top: 0px;
+    }
+    .hidden
+    {
+      visibility: hidden;
+    }
+    td:hover .hidden
+    {
+      visibility: visible;
+    }
+    div.download
+    {
+      display: none;
+      background: #F0F5FF;
+      position: absolute;
+      right: 34px;
+      top: 94px;
+      padding: 10px;
+      border: 1px dotted #00050F;
+    }
+    #divs div.ebnf, .ebnf code
+    {
+      display: block;
+      padding: 10px;
+      background: #D1E0FF;
+      width: 992px;
+    }
+    #divs div.grammar
+    {
+      display: block;
+      padding-left: 16px;
+      padding-top: 2px;
+      padding-bottom: 2px;
+      background: #D1E0FF;
+    }
+    pre
+    {
+      margin: 0px;
+    }
+    .ebnf div
+    {
+      padding-left: 13ch;
+      text-indent: -13ch;
+    }
+    .ebnf code, .grammar code, textarea, pre
+    {
+      font:12px SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;
+    }
+    tr.option-line td:first-child
+    {
+      text-align: right
+    }
+    tr.option-text td
+    {
+      padding-bottom: 10px
+    }
+    table.palette
+    {
+      border-top: 1px solid #000205;
+      border-right: 1px solid #000205;
+      margin-bottom: 4px
+    }
+    td.palette
+    {
+      border-bottom: 1px solid #000205;
+      border-left: 1px solid #000205;
+    }
+    a.palette
+    {
+      padding: 2px 3px 2px 10px;
+      text-decoration: none;
+    }
+    .palette
+    {
+      -webkit-user-select: none;
+      -khtml-user-select: none;
+      -moz-user-select: none;
+      -o-user-select: none;
+      -ms-user-select: none;
+    }
+
+    /* Oracle Style Overrides */
+    body {
+        margin: 0;
+        padding: 0;
+        background-color: #f0f5ff;
+    }
+    .line                 { stroke: #444444 !important; stroke-width: 1.5 !important; }
+    .bold-line            { stroke: #222222 !important; stroke-width: 2 !important; }
+    .filled               { fill: #444444 !important; }
+    rect.terminal         { fill: #eef4ff !important; stroke: #002b80 !important; stroke-width: 1.5 !important; }
+    rect.nonterminal      { fill: #ffffff !important; stroke: #444444 !important; stroke-width: 1.5 !important; }
+    text.terminal         { fill: #002b80 !important; font-weight: bold !important; font-family: 'Verdana', sans-serif !important; }
+    text.nonterminal      { fill: #222222 !important; font-family: 'Verdana', sans-serif !important; }
+
+    /* Navigation Bar */
+    .nav-bar {
+        position: sticky;
+        top: 0;
+        z-index: 1000;
+        background-color: #002b80;
+        padding: 10px 20px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        font-family: 'Verdana', sans-serif;
+        box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+    }
+    .nav-bar a {
+        color: #ffffff;
+        text-decoration: none;
+        font-weight: bold;
+    }
+    .nav-bar a:hover {
+        text-decoration: underline;
+    }
+    .search-container {
+        display: flex;
+        align-items: center;
+    }
+    #rule-search {
+        padding: 5px 10px;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        font-size: 14px;
+        width: 250px;
+    }
+
+    /* Content Layout */
+    .content-area {
+        padding: 20px;
+    }
+    .rule-container {
+        background-color: #ffffff;
+        border: 1px solid #d0d7de;
+        border-radius: 6px;
+        padding: 15px;
+        margin-bottom: 20px;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    }
+    .rule-container:hover {
+        border-color: #002b80;
+    }
+    .rule-container:target {
+        border: 2px solid #002b80;
+        background-color: #f8faff;
+        scroll-margin-top: 70px;
+    }
+
+    .category-header {
+        background-color: #002b80;
+        color: #ffffff;
+        padding: 8px 15px;
+        margin-top: 30px;
+        margin-bottom: 20px;
+        border-radius: 4px;
+        font-family: 'Verdana', sans-serif;
+        font-size: 18px;
+        font-weight: bold;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+
+    /* Clickable non-terminals */
+    a[xlink|href], a[href] {
+        cursor: pointer;
+    }
+    a:hover rect.nonterminal {
+        fill: #f0f5ff !important;
+        stroke: #002b80 !important;
+    }
+    a:active rect.nonterminal {
+        fill: #eef4ff !important;
+    }
+    a:hover text.nonterminal {
+        fill: #002b80 !important;
+        text-decoration: underline;
+    }
+
+    #result-count {
+        color: #ffffff;
+        font-size: 14px;
+        margin-right: 15px;
+    }
+    #clear-search {
+        background-color: #4D88FF;
+        color: white;
+        border: none;
+        padding: 5px 10px;
+        border-radius: 4px;
+        cursor: pointer;
+        margin-left: 10px;
+        font-size: 14px;
+    }
+    #clear-search:hover {
+        background-color: #3b6edb;
+    }
+
+    .rule-example-container {
+        margin-top: 10px;
+        margin-bottom: 10px;
+        background-color: #f8f9fa;
+        border-radius: 4px;
+        padding: 8px;
+        border-left: 3px solid #4D88FF;
+    }
+    .rule-example-header {
+        font-weight: bold;
+        color: #002b80;
+        font-size: 11px;
+        text-transform: uppercase;
+        margin-bottom: 8px;
+        font-family: 'Verdana', sans-serif;
+    }
+    .example-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 6px;
+        background-color: #ffffff;
+        padding: 4px 8px;
+        border-radius: 4px;
+        border: 1px solid #eef0f2;
+    }
+    .example-row:last-child {
+        margin-bottom: 0;
+    }
+    .rule-example {
+        font-family: 'Courier New', monospace;
+        font-size: 13px;
+        color: #333;
+        white-space: pre-wrap;
+        display: block;
+        flex-grow: 1;
+    }
+    .copy-button {
+        background-color: #f0f5ff;
+        color: #002b80;
+        border: 1px solid #d0d7de;
+        border-radius: 3px;
+        padding: 2px 8px;
+        font-size: 10px;
+        cursor: pointer;
+        margin-left: 10px;
+        font-family: 'Verdana', sans-serif;
+        text-transform: uppercase;
+        font-weight: bold;
+        transition: all 0.2s;
+    }
+    .copy-button:hover {
+        background-color: #002b80;
+        color: #ffffff;
+    }
+    .rule-example:last-child {
+        margin-bottom: 0;
+    }
+    .rule-description {
+        font-style: italic;
+        color: #555;
+        margin-top: 5px;
+        margin-bottom: 15px;
+        font-family: 'Verdana', sans-serif;
+        font-size: 13px;
+        line-height: 1.4;
+        border-left: 3px solid #002b80;
+        padding-left: 10px;
+    }
+    .used-by-container {
+        margin-top: 10px;
+        margin-bottom: 10px;
+        font-family: 'Verdana', sans-serif;
+        font-size: 11px;
+    }
+    .used-by-header {
+        font-weight: bold;
+        color: #666;
+        text-transform: uppercase;
+        margin-bottom: 4px;
+        display: inline-block;
+        margin-right: 8px;
+    }
+    .used-by-link {
+        color: #4D88FF;
+        text-decoration: none;
+        margin-right: 10px;
+        background-color: #f0f5ff;
+        padding: 2px 6px;
+        border-radius: 3px;
+        border: 1px solid #d0d7de;
+        display: inline-block;
+        margin-bottom: 4px;
+    }
+    .used-by-link:hover {
+        text-decoration: underline;
+        background-color: #eef4ff;
+        border-color: #002b80;
+    }
+      </style><svg xmlns="http://www.w3.org/2000/svg">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs></svg></head>
+   <body>
+      <div class="nav-bar">
+        <a href="index.html">&larr; Back to Index</a>
+        <div class="search-container">
+            <span id="result-count"></span>
+            <input type="text" id="rule-search" placeholder="Search rules..." />
+            <button id="clear-search">Clear</button>
+        </div>
+    </div>
+      <div class="content-area">
+   <div class="category-header">Other Rules</div>
+   <div class="rule-container" id="start" data-rule="start" data-description="">
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="start">start:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="337" height="335">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 315 1 311 1 319"></polygon>
+         <polygon points="17 315 9 311 9 319"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#request" xlink:title="request">
+            <rect x="51" y="267" width="68" height="32"></rect>
+            <rect x="49" y="265" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="285">request</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#match_request" xlink:title="match_request">
+            <rect x="51" y="223" width="116" height="32"></rect>
+            <rect x="49" y="221" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="241">match_request</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_command" xlink:title="dm_command">
+            <rect x="51" y="179" width="108" height="32"></rect>
+            <rect x="49" y="177" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">dm_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#join_command" xlink:title="join_command">
+            <rect x="51" y="135" width="112" height="32"></rect>
+            <rect x="49" y="133" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">join_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#set_command" xlink:title="set_command">
+            <rect x="51" y="91" width="108" height="32"></rect>
+            <rect x="49" y="89" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">set_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#define_file" xlink:title="define_file">
+            <rect x="51" y="47" width="86" height="32"></rect>
+            <rect x="49" y="45" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">define_file</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#compound_layout_block" xlink:title="compound_layout_block">
+            <rect x="51" y="3" width="174" height="32"></rect>
+            <rect x="49" y="1" width="174" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">compound_layout_block</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EOF" xlink:title="EOF">
+            <rect x="265" y="301" width="44" height="32"></rect>
+            <rect x="263" y="299" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="273" y="319">EOF</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 315 h2 m20 0 h10 m0 0 h184 m-214 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m194 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-194 0 h10 m68 0 h10 m0 0 h106 m-204 10 l0 -44 q0 -10 10 -10 m204 54 l0 -44 q0 -10 -10 -10 m-194 0 h10 m116 0 h10 m0 0 h58 m-204 10 l0 -44 q0 -10 10 -10 m204 54 l0 -44 q0 -10 -10 -10 m-194 0 h10 m108 0 h10 m0 0 h66 m-204 10 l0 -44 q0 -10 10 -10 m204 54 l0 -44 q0 -10 -10 -10 m-194 0 h10 m112 0 h10 m0 0 h62 m-204 10 l0 -44 q0 -10 10 -10 m204 54 l0 -44 q0 -10 -10 -10 m-194 0 h10 m108 0 h10 m0 0 h66 m-204 10 l0 -44 q0 -10 10 -10 m204 54 l0 -44 q0 -10 -10 -10 m-194 0 h10 m86 0 h10 m0 0 h88 m-204 10 l0 -44 q0 -10 10 -10 m204 54 l0 -44 q0 -10 -10 -10 m-194 0 h10 m174 0 h10 m20 298 h10 m44 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="327 315 335 311 335 319"></polygon>
+         <polygon points="327 315 319 311 319 319"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#start" title="start">start</a>    ::= ( <a href="#request" title="request">request</a> | <a href="#match_request" title="match_request">match_request</a> | <a href="#dm_command" title="dm_command">dm_command</a> | <a href="#join_command" title="join_command">join_command</a> | <a href="#set_command" title="set_command">set_command</a> | <a href="#define_file" title="define_file">define_file</a> | <a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</a> )* <a href="#EOF" title="EOF">EOF</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">no references</xhtml:p>
+   </div>
+   <div class="rule-container" id="layout_value" data-rule="layout_value" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="layout_value">layout_value:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="633" height="599">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 95 1 91 1 99"></polygon>
+         <polygon points="17 95 9 91 9 99"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="51" y="81" width="118" height="32"></rect>
+            <rect x="49" y="79" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="99">qualified_name</text></a><rect x="209" y="81" width="26" height="32" rx="10"></rect>
+         <rect x="207" y="79" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="217" y="99">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#layout_value" xlink:title="layout_value">
+            <rect x="255" y="81" width="102" height="32"></rect>
+            <rect x="253" y="79" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="263" y="99">layout_value</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#layout_value" xlink:title="layout_value">
+            <rect x="397" y="47" width="102" height="32"></rect>
+            <rect x="395" y="45" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="405" y="65">layout_value</text></a><rect x="397" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="395" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="405" y="21">,</text>
+         <rect x="539" y="81" width="26" height="32" rx="10"></rect>
+         <rect x="537" y="79" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="547" y="99">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="51" y="147" width="72" height="32"></rect>
+            <rect x="49" y="145" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="165">NUMBER</text></a><rect x="163" y="179" width="24" height="32" rx="10"></rect>
+         <rect x="161" y="177" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="171" y="197">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="207" y="179" width="72" height="32"></rect>
+            <rect x="205" y="177" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="215" y="197">NUMBER</text></a><rect x="51" y="301" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="299" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="319">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#layout_value" xlink:title="layout_value">
+            <rect x="97" y="301" width="102" height="32"></rect>
+            <rect x="95" y="299" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="319">layout_value</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#layout_value" xlink:title="layout_value">
+            <rect x="239" y="267" width="102" height="32"></rect>
+            <rect x="237" y="265" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="247" y="285">layout_value</text></a><rect x="239" y="223" width="24" height="32" rx="10"></rect>
+         <rect x="237" y="221" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="247" y="241">,</text>
+         <rect x="381" y="301" width="26" height="32" rx="10"></rect>
+         <rect x="379" y="299" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="389" y="319">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="51" y="345" width="66" height="32"></rect>
+            <rect x="49" y="343" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="363">STRING</text></a><rect x="51" y="389" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="387" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="407">ON</text>
+         <rect x="51" y="433" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="431" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="451">OFF</text>
+         <rect x="51" y="477" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="475" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="495">LANDSCAPE</text>
+         <rect x="51" y="521" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="519" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="539">PORTRAIT</text>
+         <rect x="51" y="565" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="563" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="583">REPORT</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 95 h2 m20 0 h10 m118 0 h10 m20 0 h10 m26 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h112 m-142 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m122 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-122 0 h10 m102 0 h10 m-132 10 l0 -44 q0 -10 10 -10 m132 54 l0 -44 q0 -10 -10 -10 m-122 0 h10 m24 0 h10 m0 0 h78 m20 78 h10 m26 0 h10 m-396 0 h20 m376 0 h20 m-416 0 q10 0 10 10 m396 0 q0 -10 10 -10 m-406 10 v14 m396 0 v-14 m-396 14 q0 10 10 10 m376 0 q10 0 10 -10 m-386 10 h10 m0 0 h366 m-554 -34 h20 m554 0 h20 m-594 0 q10 0 10 10 m574 0 q0 -10 10 -10 m-584 10 v46 m574 0 v-46 m-574 46 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h286 m-564 -10 v20 m574 0 v-20 m-574 20 v134 m574 0 v-134 m-574 134 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m26 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h112 m-142 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m122 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-122 0 h10 m102 0 h10 m-132 10 l0 -44 q0 -10 10 -10 m132 54 l0 -44 q0 -10 -10 -10 m-122 0 h10 m24 0 h10 m0 0 h78 m20 78 h10 m26 0 h10 m0 0 h178 m-564 -10 v20 m574 0 v-20 m-574 20 v24 m574 0 v-24 m-574 24 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m66 0 h10 m0 0 h468 m-564 -10 v20 m574 0 v-20 m-574 20 v24 m574 0 v-24 m-574 24 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m40 0 h10 m0 0 h494 m-564 -10 v20 m574 0 v-20 m-574 20 v24 m574 0 v-24 m-574 24 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m46 0 h10 m0 0 h488 m-564 -10 v20 m574 0 v-20 m-574 20 v24 m574 0 v-24 m-574 24 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m102 0 h10 m0 0 h432 m-564 -10 v20 m574 0 v-20 m-574 20 v24 m574 0 v-24 m-574 24 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m90 0 h10 m0 0 h444 m-564 -10 v20 m574 0 v-20 m-574 20 v24 m574 0 v-24 m-574 24 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m74 0 h10 m0 0 h460 m23 -484 h-3"></svg:path>
+         <polygon points="623 95 631 91 631 99"></polygon>
+         <polygon points="623 95 615 91 615 99"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#layout_value" title="layout_value">layout_value</a></div>
+               <div>         ::= <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' <a href="#layout_value" title="layout_value">layout_value</a> ( <a href="#layout_value" title="layout_value">layout_value</a> | ',' )* ')' )?</div>
+               <div>           | <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )?</div>
+               <div>           | '(' <a href="#layout_value" title="layout_value">layout_value</a> ( <a href="#layout_value" title="layout_value">layout_value</a> | ',' )* ')'</div>
+               <div>           | <a href="#STRING" title="STRING">STRING</a></div>
+               <div>           | 'ON'</div>
+               <div>           | 'OFF'</div>
+               <div>           | 'LANDSCAPE'</div>
+               <div>           | 'PORTRAIT'</div>
+               <div>           | 'REPORT'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#layout_value" title="layout_value">layout_value</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="define_file" data-rule="define_file" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#start" class="used-by-link">start</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="define_file">define_file:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="605" height="71">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 51 1 47 1 55"></polygon>
+         <polygon points="17 51 9 47 9 55"></polygon>
+         <rect x="31" y="37" width="70" height="32" rx="10"></rect>
+         <rect x="29" y="35" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="55">DEFINE</text>
+         <rect x="121" y="37" width="50" height="32" rx="10"></rect>
+         <rect x="119" y="35" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="129" y="55">FILE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="191" y="37" width="118" height="32"></rect>
+            <rect x="189" y="35" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="199" y="55">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#define_assignment" xlink:title="define_assignment">
+            <rect x="349" y="3" width="140" height="32"></rect>
+            <rect x="347" y="1" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="357" y="21">define_assignment</text></a><rect x="529" y="37" width="48" height="32" rx="10"></rect>
+         <rect x="527" y="35" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="537" y="55">END</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 51 h2 m0 0 h10 m70 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h150 m-180 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m160 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-160 0 h10 m140 0 h10 m20 34 h10 m48 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="595 51 603 47 603 55"></polygon>
+         <polygon points="595 51 587 47 587 55"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#define_file" title="define_file">define_file</a></div>
+               <div>         ::= 'DEFINE' 'FILE' <a href="#qualified_name" title="qualified_name">qualified_name</a> <a href="#define_assignment" title="define_assignment">define_assignment</a>* 'END'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#start" title="start">start</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="define_assignment" data-rule="define_assignment" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#define_file" class="used-by-link">define_file</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="define_assignment">define_assignment:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="667" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="31" y="3" width="118" height="32"></rect>
+            <rect x="29" y="1" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">qualified_name</text></a><rect x="189" y="35" width="28" height="32" rx="10"></rect>
+         <rect x="187" y="33" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="197" y="53">/</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#format_name" xlink:title="format_name">
+            <rect x="237" y="35" width="106" height="32"></rect>
+            <rect x="235" y="33" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="245" y="53">format_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="383" y="3" width="36" height="32"></rect>
+            <rect x="381" y="1" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="391" y="21">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="439" y="3" width="116" height="32"></rect>
+            <rect x="437" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="447" y="21">dm_expression</text></a><rect x="595" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="593" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="603" y="53">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m28 0 h10 m0 0 h10 m106 0 h10 m20 -32 h10 m36 0 h10 m0 0 h10 m116 0 h10 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="657 17 665 13 665 21"></polygon>
+         <polygon points="657 17 649 13 649 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#define_assignment" title="define_assignment">define_assignment</a></div>
+               <div>         ::= <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '/' <a href="#format_name" title="format_name">format_name</a> )? <a href="#EQ" title="EQ">EQ</a> <a href="#dm_expression" title="dm_expression">dm_expression</a> ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#define_file" title="define_file">define_file</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="compute_command" data-rule="compute_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#request" class="used-by-link">request</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="compute_command">compute_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="937" height="155">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="35" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="33" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="53">AND</text>
+         <rect x="139" y="3" width="86" height="32" rx="10"></rect>
+         <rect x="137" y="1" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="21">COMPUTE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="245" y="3" width="118" height="32"></rect>
+            <rect x="243" y="1" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="253" y="21">qualified_name</text></a><rect x="403" y="35" width="28" height="32" rx="10"></rect>
+         <rect x="401" y="33" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="411" y="53">/</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#format_name" xlink:title="format_name">
+            <rect x="451" y="35" width="106" height="32"></rect>
+            <rect x="449" y="33" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="459" y="53">format_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="597" y="3" width="36" height="32"></rect>
+            <rect x="595" y="1" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="605" y="21">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="653" y="3" width="116" height="32"></rect>
+            <rect x="651" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="661" y="21">dm_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#as_phrase" xlink:title="as_phrase">
+            <rect x="809" y="35" width="86" height="32"></rect>
+            <rect x="807" y="33" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="817" y="53">as_phrase</text></a><rect x="865" y="121" width="24" height="32" rx="10"></rect>
+         <rect x="863" y="119" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="873" y="139">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m86 0 h10 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m28 0 h10 m0 0 h10 m106 0 h10 m20 -32 h10 m36 0 h10 m0 0 h10 m116 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-114 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="927 103 935 99 935 107"></polygon>
+         <polygon points="927 103 919 99 919 107"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#compute_command" title="compute_command">compute_command</a></div>
+               <div>         ::= 'AND'? 'COMPUTE' <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '/' <a href="#format_name" title="format_name">format_name</a> )? <a href="#EQ" title="EQ">EQ</a> <a href="#dm_expression" title="dm_expression">dm_expression</a> <a href="#as_phrase" title="as_phrase">as_phrase</a>? ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="recap_command" data-rule="recap_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#on_field_options" class="used-by-link">on_field_options</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#request" class="used-by-link">request</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="recap_command">recap_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="319" height="53">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <rect x="31" y="19" width="64" height="32" rx="10"></rect>
+         <rect x="29" y="17" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="37">RECAP</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#recap_assignment" xlink:title="recap_assignment">
+            <rect x="135" y="19" width="136" height="32"></rect>
+            <rect x="133" y="17" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="37">recap_assignment</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m0 0 h10 m64 0 h10 m20 0 h10 m136 0 h10 m-176 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m156 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-156 0 h10 m0 0 h146 m23 32 h-3"></svg:path>
+         <polygon points="309 33 317 29 317 37"></polygon>
+         <polygon points="309 33 301 29 301 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#recap_command" title="recap_command">recap_command</a></div>
+               <div>         ::= 'RECAP' <a href="#recap_assignment" title="recap_assignment">recap_assignment</a>+</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_field_options" title="on_field_options">on_field_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="recap_assignment" data-rule="recap_assignment" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#recap_command" class="used-by-link">recap_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="recap_assignment">recap_assignment:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="845" height="201">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="31" y="3" width="118" height="32"></rect>
+            <rect x="29" y="1" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">qualified_name</text></a><rect x="189" y="35" width="26" height="32" rx="10"></rect>
+         <rect x="187" y="33" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="197" y="53">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="235" y="35" width="116" height="32"></rect>
+            <rect x="233" y="33" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="243" y="53">dm_expression</text></a><rect x="371" y="35" width="26" height="32" rx="10"></rect>
+         <rect x="369" y="33" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="379" y="53">)</text>
+         <rect x="457" y="35" width="28" height="32" rx="10"></rect>
+         <rect x="455" y="33" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="465" y="53">/</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#format_name" xlink:title="format_name">
+            <rect x="505" y="35" width="106" height="32"></rect>
+            <rect x="503" y="33" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="513" y="53">format_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="651" y="3" width="36" height="32"></rect>
+            <rect x="649" y="1" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="659" y="21">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="707" y="3" width="116" height="32"></rect>
+            <rect x="705" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="715" y="21">dm_expression</text></a><rect x="713" y="167" width="24" height="32" rx="10"></rect>
+         <rect x="711" y="165" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="721" y="185">;</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#recap_option" xlink:title="recap_option">
+            <rect x="693" y="101" width="104" height="32"></rect>
+            <rect x="691" y="99" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="701" y="119">recap_option</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h218 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v12 m248 0 v-12 m-248 12 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m40 -32 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m28 0 h10 m0 0 h10 m106 0 h10 m20 -32 h10 m36 0 h10 m0 0 h10 m116 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-194 132 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m20 -32 h40 m-144 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m124 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-124 0 h10 m104 0 h10 m23 34 h-3"></svg:path>
+         <polygon points="835 149 843 145 843 153"></polygon>
+         <polygon points="835 149 827 145 827 153"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#recap_assignment" title="recap_assignment">recap_assignment</a></div>
+               <div>         ::= <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' )? ( '/' <a href="#format_name" title="format_name">format_name</a> )? <a href="#EQ" title="EQ">EQ</a> <a href="#dm_expression" title="dm_expression">dm_expression</a> ';'? ( <a href="#recap_option" title="recap_option">recap_option</a> ';'? )*</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#recap_command" title="recap_command">recap_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="recap_option" data-rule="recap_option" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#recap_assignment" class="used-by-link">recap_assignment</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="recap_option">recap_option:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="263" height="125">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#as_phrase" xlink:title="as_phrase">
+            <rect x="51" y="3" width="86" height="32"></rect>
+            <rect x="49" y="1" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">as_phrase</text></a><rect x="51" y="47" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">INDENT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="143" y="47" width="72" height="32"></rect>
+            <rect x="141" y="45" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="151" y="65">NUMBER</text></a><rect x="51" y="91" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">NOPRINT</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m86 0 h10 m0 0 h78 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m72 0 h10 m0 0 h10 m72 0 h10 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m84 0 h10 m0 0 h80 m23 -88 h-3"></svg:path>
+         <polygon points="253 17 261 13 261 21"></polygon>
+         <polygon points="253 17 245 13 245 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#recap_option" title="recap_option">recap_option</a></div>
+               <div>         ::= <a href="#as_phrase" title="as_phrase">as_phrase</a></div>
+               <div>           | 'INDENT' <a href="#NUMBER" title="NUMBER">NUMBER</a></div>
+               <div>           | 'NOPRINT'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#recap_assignment" title="recap_assignment">recap_assignment</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="format_name" data-rule="format_name" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compute_command" class="used-by-link">compute_command</a>
+          <a href="#define_assignment" class="used-by-link">define_assignment</a>
+          <a href="#dm_read" class="used-by-link">dm_read</a>
+          <a href="#field" class="used-by-link">field</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#recap_assignment" class="used-by-link">recap_assignment</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="format_name">format_name:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="421" height="147">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 95 1 91 1 99"></polygon>
+         <polygon points="17 95 9 91 9 99"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="31" y="81" width="54" height="32"></rect>
+            <rect x="29" y="79" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="99">NAME</text></a><rect x="125" y="113" width="24" height="32" rx="10"></rect>
+         <rect x="123" y="111" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="133" y="131">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="169" y="113" width="72" height="32"></rect>
+            <rect x="167" y="111" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="177" y="131">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="301" y="47" width="54" height="32"></rect>
+            <rect x="299" y="45" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="309" y="65">NAME</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="301" y="3" width="72" height="32"></rect>
+            <rect x="299" y="1" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="309" y="21">NUMBER</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 95 h2 m0 0 h10 m54 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m40 -32 h10 m0 0 h82 m-112 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m92 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-92 0 h10 m54 0 h10 m0 0 h18 m-102 10 l0 -44 q0 -10 10 -10 m102 54 l0 -44 q0 -10 -10 -10 m-92 0 h10 m72 0 h10 m23 78 h-3"></svg:path>
+         <polygon points="411 95 419 91 419 99"></polygon>
+         <polygon points="411 95 403 91 403 99"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#format_name" title="format_name">format_name</a></div>
+               <div>         ::= <a href="#NAME" title="NAME">NAME</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? ( <a href="#NAME" title="NAME">NAME</a> | <a href="#NUMBER" title="NUMBER">NUMBER</a> )*</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compute_command" title="compute_command">compute_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#define_assignment" title="define_assignment">define_assignment</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_read" title="dm_read">dm_read</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#field" title="field">field</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#recap_assignment" title="recap_assignment">recap_assignment</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="set_value" data-rule="set_value" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#set_command" class="used-by-link">set_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="set_value">set_value:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="239" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#hyphenated_name" xlink:title="hyphenated_name">
+            <rect x="51" y="3" width="140" height="32"></rect>
+            <rect x="49" y="1" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">hyphenated_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="51" y="47" width="66" height="32"></rect>
+            <rect x="49" y="45" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">STRING</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m140 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m66 0 h10 m0 0 h74 m23 -44 h-3"></svg:path>
+         <polygon points="229 17 237 13 237 21"></polygon>
+         <polygon points="229 17 221 13 221 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#set_value" title="set_value">set_value</a></div>
+               <div>         ::= <a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</a></div>
+               <div>           | <a href="#STRING" title="STRING">STRING</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#set_command" title="set_command">set_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="hyphenated_name" data-rule="hyphenated_name" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#set_command" class="used-by-link">set_command</a>
+          <a href="#set_value" class="used-by-link">set_value</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="hyphenated_name">hyphenated_name:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="621" height="4425">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="51" y="19" width="54" height="32"></rect>
+            <rect x="49" y="17" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="37">NAME</text></a><rect x="51" y="63" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="61" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="81">AVE</text>
+         <rect x="51" y="107" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="105" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="125">MIN</text>
+         <rect x="51" y="151" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="149" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="169">MAX</text>
+         <rect x="51" y="195" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="193" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="213">CNT</text>
+         <rect x="51" y="239" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="237" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="257">FST</text>
+         <rect x="51" y="283" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="281" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="301">LST</text>
+         <rect x="51" y="327" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="325" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="345">ASQ</text>
+         <rect x="51" y="371" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="369" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="389">MDN</text>
+         <rect x="51" y="415" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="413" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="433">MDE</text>
+         <rect x="51" y="459" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="457" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="477">PCT</text>
+         <rect x="51" y="503" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="501" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="521">RPCT</text>
+         <rect x="51" y="547" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="545" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="565">RNK</text>
+         <rect x="51" y="591" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="589" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="609">DST</text>
+         <rect x="51" y="635" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="633" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="653">TOT</text>
+         <rect x="51" y="679" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="677" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="697">SUM</text>
+         <rect x="51" y="723" width="36" height="32" rx="10"></rect>
+         <rect x="49" y="721" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="741">CT</text>
+         <rect x="51" y="767" width="36" height="32" rx="10"></rect>
+         <rect x="49" y="765" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="785">IS</text>
+         <rect x="51" y="811" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="809" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="829">CONTAINS</text>
+         <rect x="51" y="855" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="853" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="873">OMITS</text>
+         <rect x="51" y="899" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="897" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="917">LIKE</text>
+         <rect x="51" y="943" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="941" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="961">TOTAL</text>
+         <rect x="51" y="987" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="985" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1005">MISSING</text>
+         <rect x="51" y="1031" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="1029" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1049">INCLUDES</text>
+         <rect x="51" y="1075" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="1073" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1093">EXCLUDES</text>
+         <rect x="51" y="1119" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1117" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1137">EXCEEDS</text>
+         <rect x="51" y="1163" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="1161" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1181">ALL</text>
+         <rect x="51" y="1207" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1205" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1225">LESS</text>
+         <rect x="51" y="1251" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="1249" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1269">THAN</text>
+         <rect x="51" y="1295" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="1293" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1313">MORE</text>
+         <rect x="51" y="1339" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1337" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1357">GREATER</text>
+         <rect x="51" y="1383" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="1381" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1401">OFF</text>
+         <rect x="51" y="1427" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="1425" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1445">ON</text>
+         <rect x="51" y="1471" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="1469" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1489">RECAP</text>
+         <rect x="51" y="1515" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="1513" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1533">INDENT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ACROSS_TOTAL" xlink:title="ACROSS_TOTAL">
+            <rect x="51" y="1559" width="118" height="32"></rect>
+            <rect x="49" y="1557" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1577">ACROSS_TOTAL</text></a><rect x="51" y="1603" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1601" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1621">COMPOUND</text>
+         <rect x="51" y="1647" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="1645" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1665">LAYOUT</text>
+         <rect x="51" y="1691" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1689" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1709">SECTION</text>
+         <rect x="51" y="1735" width="110" height="32" rx="10"></rect>
+         <rect x="49" y="1733" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1753">PAGELAYOUT</text>
+         <rect x="51" y="1779" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="1777" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1797">COMPONENT</text>
+         <rect x="51" y="1823" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="1821" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1841">MERGE</text>
+         <rect x="51" y="1867" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="1865" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1885">ORIENTATION</text>
+         <rect x="51" y="1911" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="1909" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1929">LANDSCAPE</text>
+         <rect x="51" y="1955" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="1953" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1973">PORTRAIT</text>
+         <rect x="51" y="1999" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1997" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2017">TYPE</text>
+         <rect x="51" y="2043" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="2041" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2061">POSITION</text>
+         <rect x="51" y="2087" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="2085" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2105">DIMENSION</text>
+         <rect x="51" y="2131" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="2129" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2149">STYLE</text>
+         <rect x="51" y="2175" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="2173" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2193">ENDSTYLE</text>
+         <rect x="51" y="2219" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="2217" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2237">MATCH</text>
+         <rect x="51" y="2263" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="2261" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2281">AFTER</text>
+         <rect x="51" y="2307" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="2305" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2325">RUN</text>
+         <rect x="51" y="2351" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="2349" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2369">OLD</text>
+         <rect x="51" y="2395" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="2393" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2413">NEW</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_OR_NEW_KW" xlink:title="OLD_OR_NEW_KW">
+            <rect x="51" y="2439" width="138" height="32"></rect>
+            <rect x="49" y="2437" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="2457">OLD_OR_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_AND_NEW_KW" xlink:title="OLD_AND_NEW_KW">
+            <rect x="51" y="2483" width="146" height="32"></rect>
+            <rect x="49" y="2481" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="2501">OLD_AND_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_NOT_NEW_KW" xlink:title="OLD_NOT_NEW_KW">
+            <rect x="51" y="2527" width="146" height="32"></rect>
+            <rect x="49" y="2525" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="2545">OLD_NOT_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NEW_NOT_OLD_KW" xlink:title="NEW_NOT_OLD_KW">
+            <rect x="51" y="2571" width="146" height="32"></rect>
+            <rect x="49" y="2569" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="2589">NEW_NOT_OLD_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_NOR_NEW_KW" xlink:title="OLD_NOR_NEW_KW">
+            <rect x="51" y="2615" width="148" height="32"></rect>
+            <rect x="49" y="2613" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="2633">OLD_NOR_NEW_KW</text></a><rect x="51" y="2659" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="2657" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2677">MATCHING</text>
+         <rect x="51" y="2703" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="2701" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2721">MATCHED</text>
+         <rect x="51" y="2747" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="2745" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2765">UPDATE</text>
+         <rect x="51" y="2791" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="2789" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2809">INSERT</text>
+         <rect x="51" y="2835" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="2833" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2853">INTO</text>
+         <rect x="51" y="2879" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="2877" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2897">HEADING</text>
+         <rect x="51" y="2923" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="2921" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2941">FOOTING</text>
+         <rect x="51" y="2967" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="2965" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2985">SUBHEAD</text>
+         <rect x="51" y="3011" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="3009" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3029">SUBFOOT</text>
+         <rect x="51" y="3055" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="3053" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3073">FORMAT</text>
+         <rect x="51" y="3099" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="3097" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3117">TIMES</text>
+         <rect x="51" y="3143" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="3141" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3161">WHILE</text>
+         <rect x="51" y="3187" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="3185" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3205">UNTIL</text>
+         <rect x="51" y="3231" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="3229" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3249">FOR</text>
+         <rect x="51" y="3275" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="3273" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3293">STEP</text>
+         <rect x="51" y="3319" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="3317" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3337">TOP</text>
+         <rect x="51" y="3363" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="3361" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3381">BOTTOM</text>
+         <rect x="51" y="3407" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="3405" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3425">RANKED</text>
+         <rect x="51" y="3451" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="3449" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3469">NOPRINT</text>
+         <rect x="51" y="3495" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="3493" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3513">AS</text>
+         <rect x="51" y="3539" width="36" height="32" rx="10"></rect>
+         <rect x="49" y="3537" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3557">IN</text>
+         <rect x="51" y="3583" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="3581" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3601">HIERARCHY</text>
+         <rect x="51" y="3627" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="3625" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3645">WHEN</text>
+         <rect x="51" y="3671" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="3669" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3689">SHOW</text>
+         <rect x="51" y="3715" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="3713" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3733">UP</text>
+         <rect x="51" y="3759" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="3757" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3777">DOWN</text>
+         <rect x="51" y="3803" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="3801" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3821">OPEN</text>
+         <rect x="51" y="3847" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="3845" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3865">CLOSE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#PAGE_BREAK" xlink:title="PAGE_BREAK">
+            <rect x="51" y="3891" width="102" height="32"></rect>
+            <rect x="49" y="3889" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="3909">PAGE_BREAK</text></a><rect x="51" y="3935" width="130" height="32" rx="10"></rect>
+         <rect x="49" y="3933" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3953">DRILLTHROUGH</text>
+         <rect x="51" y="3979" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="3977" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3997">COLUMN</text>
+         <rect x="51" y="4023" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="4021" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4041">LINE</text>
+         <rect x="51" y="4067" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="4065" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4085">ITEM</text>
+         <rect x="51" y="4111" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="4109" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4129">COLOR</text>
+         <rect x="51" y="4155" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="4153" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4173">DEFAULT</text>
+         <rect x="51" y="4199" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="4197" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4217">READ</text>
+         <rect x="51" y="4243" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="4241" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4261">WRITE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="51" y="4287" width="72" height="32"></rect>
+            <rect x="49" y="4285" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="4305">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="51" y="4331" width="94" height="32"></rect>
+            <rect x="49" y="4329" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="4349">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_token" xlink:title="dm_token">
+            <rect x="299" y="19" width="84" height="32"></rect>
+            <rect x="297" y="17" width="84" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="307" y="37">dm_token</text></a><rect x="299" y="63" width="26" height="32" rx="10"></rect>
+         <rect x="297" y="61" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="307" y="81">-</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="365" y="63" width="54" height="32"></rect>
+            <rect x="363" y="61" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="81">NAME</text></a><rect x="365" y="107" width="46" height="32" rx="10"></rect>
+         <rect x="363" y="105" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="125">AVE</text>
+         <rect x="365" y="151" width="48" height="32" rx="10"></rect>
+         <rect x="363" y="149" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="169">MIN</text>
+         <rect x="365" y="195" width="50" height="32" rx="10"></rect>
+         <rect x="363" y="193" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="213">MAX</text>
+         <rect x="365" y="239" width="46" height="32" rx="10"></rect>
+         <rect x="363" y="237" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="257">CNT</text>
+         <rect x="365" y="283" width="44" height="32" rx="10"></rect>
+         <rect x="363" y="281" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="301">FST</text>
+         <rect x="365" y="327" width="44" height="32" rx="10"></rect>
+         <rect x="363" y="325" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="345">LST</text>
+         <rect x="365" y="371" width="48" height="32" rx="10"></rect>
+         <rect x="363" y="369" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="389">ASQ</text>
+         <rect x="365" y="415" width="50" height="32" rx="10"></rect>
+         <rect x="363" y="413" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="433">MDN</text>
+         <rect x="365" y="459" width="50" height="32" rx="10"></rect>
+         <rect x="363" y="457" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="477">MDE</text>
+         <rect x="365" y="503" width="46" height="32" rx="10"></rect>
+         <rect x="363" y="501" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="521">PCT</text>
+         <rect x="365" y="547" width="56" height="32" rx="10"></rect>
+         <rect x="363" y="545" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="565">RPCT</text>
+         <rect x="365" y="591" width="48" height="32" rx="10"></rect>
+         <rect x="363" y="589" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="609">RNK</text>
+         <rect x="365" y="635" width="46" height="32" rx="10"></rect>
+         <rect x="363" y="633" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="653">DST</text>
+         <rect x="365" y="679" width="46" height="32" rx="10"></rect>
+         <rect x="363" y="677" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="697">TOT</text>
+         <rect x="365" y="723" width="50" height="32" rx="10"></rect>
+         <rect x="363" y="721" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="741">SUM</text>
+         <rect x="365" y="767" width="36" height="32" rx="10"></rect>
+         <rect x="363" y="765" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="785">CT</text>
+         <rect x="365" y="811" width="36" height="32" rx="10"></rect>
+         <rect x="363" y="809" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="829">IS</text>
+         <rect x="365" y="855" width="92" height="32" rx="10"></rect>
+         <rect x="363" y="853" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="873">CONTAINS</text>
+         <rect x="365" y="899" width="66" height="32" rx="10"></rect>
+         <rect x="363" y="897" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="917">OMITS</text>
+         <rect x="365" y="943" width="52" height="32" rx="10"></rect>
+         <rect x="363" y="941" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="961">LIKE</text>
+         <rect x="365" y="987" width="64" height="32" rx="10"></rect>
+         <rect x="363" y="985" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1005">TOTAL</text>
+         <rect x="365" y="1031" width="82" height="32" rx="10"></rect>
+         <rect x="363" y="1029" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1049">MISSING</text>
+         <rect x="365" y="1075" width="90" height="32" rx="10"></rect>
+         <rect x="363" y="1073" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1093">INCLUDES</text>
+         <rect x="365" y="1119" width="90" height="32" rx="10"></rect>
+         <rect x="363" y="1117" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1137">EXCLUDES</text>
+         <rect x="365" y="1163" width="82" height="32" rx="10"></rect>
+         <rect x="363" y="1161" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1181">EXCEEDS</text>
+         <rect x="365" y="1207" width="44" height="32" rx="10"></rect>
+         <rect x="363" y="1205" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1225">ALL</text>
+         <rect x="365" y="1251" width="54" height="32" rx="10"></rect>
+         <rect x="363" y="1249" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1269">LESS</text>
+         <rect x="365" y="1295" width="58" height="32" rx="10"></rect>
+         <rect x="363" y="1293" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1313">THAN</text>
+         <rect x="365" y="1339" width="60" height="32" rx="10"></rect>
+         <rect x="363" y="1337" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1357">MORE</text>
+         <rect x="365" y="1383" width="82" height="32" rx="10"></rect>
+         <rect x="363" y="1381" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1401">GREATER</text>
+         <rect x="365" y="1427" width="46" height="32" rx="10"></rect>
+         <rect x="363" y="1425" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1445">OFF</text>
+         <rect x="365" y="1471" width="40" height="32" rx="10"></rect>
+         <rect x="363" y="1469" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1489">ON</text>
+         <rect x="365" y="1515" width="64" height="32" rx="10"></rect>
+         <rect x="363" y="1513" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1533">RECAP</text>
+         <rect x="365" y="1559" width="72" height="32" rx="10"></rect>
+         <rect x="363" y="1557" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1577">INDENT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ACROSS_TOTAL" xlink:title="ACROSS_TOTAL">
+            <rect x="365" y="1603" width="118" height="32"></rect>
+            <rect x="363" y="1601" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="1621">ACROSS_TOTAL</text></a><rect x="365" y="1647" width="100" height="32" rx="10"></rect>
+         <rect x="363" y="1645" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1665">COMPOUND</text>
+         <rect x="365" y="1691" width="74" height="32" rx="10"></rect>
+         <rect x="363" y="1689" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1709">LAYOUT</text>
+         <rect x="365" y="1735" width="82" height="32" rx="10"></rect>
+         <rect x="363" y="1733" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1753">SECTION</text>
+         <rect x="365" y="1779" width="110" height="32" rx="10"></rect>
+         <rect x="363" y="1777" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1797">PAGELAYOUT</text>
+         <rect x="365" y="1823" width="108" height="32" rx="10"></rect>
+         <rect x="363" y="1821" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1841">COMPONENT</text>
+         <rect x="365" y="1867" width="66" height="32" rx="10"></rect>
+         <rect x="363" y="1865" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1885">MERGE</text>
+         <rect x="365" y="1911" width="118" height="32" rx="10"></rect>
+         <rect x="363" y="1909" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1929">ORIENTATION</text>
+         <rect x="365" y="1955" width="102" height="32" rx="10"></rect>
+         <rect x="363" y="1953" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="1973">LANDSCAPE</text>
+         <rect x="365" y="1999" width="90" height="32" rx="10"></rect>
+         <rect x="363" y="1997" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2017">PORTRAIT</text>
+         <rect x="365" y="2043" width="54" height="32" rx="10"></rect>
+         <rect x="363" y="2041" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2061">TYPE</text>
+         <rect x="365" y="2087" width="90" height="32" rx="10"></rect>
+         <rect x="363" y="2085" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2105">POSITION</text>
+         <rect x="365" y="2131" width="102" height="32" rx="10"></rect>
+         <rect x="363" y="2129" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2149">DIMENSION</text>
+         <rect x="365" y="2175" width="62" height="32" rx="10"></rect>
+         <rect x="363" y="2173" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2193">STYLE</text>
+         <rect x="365" y="2219" width="90" height="32" rx="10"></rect>
+         <rect x="363" y="2217" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2237">ENDSTYLE</text>
+         <rect x="365" y="2263" width="68" height="32" rx="10"></rect>
+         <rect x="363" y="2261" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2281">MATCH</text>
+         <rect x="365" y="2307" width="62" height="32" rx="10"></rect>
+         <rect x="363" y="2305" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2325">AFTER</text>
+         <rect x="365" y="2351" width="48" height="32" rx="10"></rect>
+         <rect x="363" y="2349" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2369">RUN</text>
+         <rect x="365" y="2395" width="48" height="32" rx="10"></rect>
+         <rect x="363" y="2393" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2413">OLD</text>
+         <rect x="365" y="2439" width="52" height="32" rx="10"></rect>
+         <rect x="363" y="2437" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2457">NEW</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_OR_NEW_KW" xlink:title="OLD_OR_NEW_KW">
+            <rect x="365" y="2483" width="138" height="32"></rect>
+            <rect x="363" y="2481" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="2501">OLD_OR_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_AND_NEW_KW" xlink:title="OLD_AND_NEW_KW">
+            <rect x="365" y="2527" width="146" height="32"></rect>
+            <rect x="363" y="2525" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="2545">OLD_AND_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_NOT_NEW_KW" xlink:title="OLD_NOT_NEW_KW">
+            <rect x="365" y="2571" width="146" height="32"></rect>
+            <rect x="363" y="2569" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="2589">OLD_NOT_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NEW_NOT_OLD_KW" xlink:title="NEW_NOT_OLD_KW">
+            <rect x="365" y="2615" width="146" height="32"></rect>
+            <rect x="363" y="2613" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="2633">NEW_NOT_OLD_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_NOR_NEW_KW" xlink:title="OLD_NOR_NEW_KW">
+            <rect x="365" y="2659" width="148" height="32"></rect>
+            <rect x="363" y="2657" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="2677">OLD_NOR_NEW_KW</text></a><rect x="365" y="2703" width="94" height="32" rx="10"></rect>
+         <rect x="363" y="2701" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2721">MATCHING</text>
+         <rect x="365" y="2747" width="86" height="32" rx="10"></rect>
+         <rect x="363" y="2745" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2765">MATCHED</text>
+         <rect x="365" y="2791" width="74" height="32" rx="10"></rect>
+         <rect x="363" y="2789" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2809">UPDATE</text>
+         <rect x="365" y="2835" width="70" height="32" rx="10"></rect>
+         <rect x="363" y="2833" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2853">INSERT</text>
+         <rect x="365" y="2879" width="56" height="32" rx="10"></rect>
+         <rect x="363" y="2877" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2897">INTO</text>
+         <rect x="365" y="2923" width="84" height="32" rx="10"></rect>
+         <rect x="363" y="2921" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2941">HEADING</text>
+         <rect x="365" y="2967" width="84" height="32" rx="10"></rect>
+         <rect x="363" y="2965" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="2985">FOOTING</text>
+         <rect x="365" y="3011" width="84" height="32" rx="10"></rect>
+         <rect x="363" y="3009" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3029">SUBHEAD</text>
+         <rect x="365" y="3055" width="86" height="32" rx="10"></rect>
+         <rect x="363" y="3053" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3073">SUBFOOT</text>
+         <rect x="365" y="3099" width="76" height="32" rx="10"></rect>
+         <rect x="363" y="3097" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3117">FORMAT</text>
+         <rect x="365" y="3143" width="62" height="32" rx="10"></rect>
+         <rect x="363" y="3141" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3161">TIMES</text>
+         <rect x="365" y="3187" width="66" height="32" rx="10"></rect>
+         <rect x="363" y="3185" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3205">WHILE</text>
+         <rect x="365" y="3231" width="62" height="32" rx="10"></rect>
+         <rect x="363" y="3229" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3249">UNTIL</text>
+         <rect x="365" y="3275" width="48" height="32" rx="10"></rect>
+         <rect x="363" y="3273" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3293">FOR</text>
+         <rect x="365" y="3319" width="54" height="32" rx="10"></rect>
+         <rect x="363" y="3317" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3337">STEP</text>
+         <rect x="365" y="3363" width="48" height="32" rx="10"></rect>
+         <rect x="363" y="3361" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3381">TOP</text>
+         <rect x="365" y="3407" width="78" height="32" rx="10"></rect>
+         <rect x="363" y="3405" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3425">BOTTOM</text>
+         <rect x="365" y="3451" width="76" height="32" rx="10"></rect>
+         <rect x="363" y="3449" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3469">RANKED</text>
+         <rect x="365" y="3495" width="84" height="32" rx="10"></rect>
+         <rect x="363" y="3493" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3513">NOPRINT</text>
+         <rect x="365" y="3539" width="38" height="32" rx="10"></rect>
+         <rect x="363" y="3537" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3557">AS</text>
+         <rect x="365" y="3583" width="36" height="32" rx="10"></rect>
+         <rect x="363" y="3581" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3601">IN</text>
+         <rect x="365" y="3627" width="100" height="32" rx="10"></rect>
+         <rect x="363" y="3625" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3645">HIERARCHY</text>
+         <rect x="365" y="3671" width="62" height="32" rx="10"></rect>
+         <rect x="363" y="3669" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3689">WHEN</text>
+         <rect x="365" y="3715" width="64" height="32" rx="10"></rect>
+         <rect x="363" y="3713" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3733">SHOW</text>
+         <rect x="365" y="3759" width="38" height="32" rx="10"></rect>
+         <rect x="363" y="3757" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3777">UP</text>
+         <rect x="365" y="3803" width="64" height="32" rx="10"></rect>
+         <rect x="363" y="3801" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3821">DOWN</text>
+         <rect x="365" y="3847" width="58" height="32" rx="10"></rect>
+         <rect x="363" y="3845" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3865">OPEN</text>
+         <rect x="365" y="3891" width="64" height="32" rx="10"></rect>
+         <rect x="363" y="3889" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3909">CLOSE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#PAGE_BREAK" xlink:title="PAGE_BREAK">
+            <rect x="365" y="3935" width="102" height="32"></rect>
+            <rect x="363" y="3933" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="3953">PAGE_BREAK</text></a><rect x="365" y="3979" width="130" height="32" rx="10"></rect>
+         <rect x="363" y="3977" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="3997">DRILLTHROUGH</text>
+         <rect x="365" y="4023" width="78" height="32" rx="10"></rect>
+         <rect x="363" y="4021" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="4041">COLUMN</text>
+         <rect x="365" y="4067" width="52" height="32" rx="10"></rect>
+         <rect x="363" y="4065" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="4085">LINE</text>
+         <rect x="365" y="4111" width="54" height="32" rx="10"></rect>
+         <rect x="363" y="4109" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="4129">ITEM</text>
+         <rect x="365" y="4155" width="68" height="32" rx="10"></rect>
+         <rect x="363" y="4153" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="4173">COLOR</text>
+         <rect x="365" y="4199" width="80" height="32" rx="10"></rect>
+         <rect x="363" y="4197" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="4217">DEFAULT</text>
+         <rect x="365" y="4243" width="56" height="32" rx="10"></rect>
+         <rect x="363" y="4241" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="4261">READ</text>
+         <rect x="365" y="4287" width="66" height="32" rx="10"></rect>
+         <rect x="363" y="4285" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="4305">WRITE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="365" y="4331" width="72" height="32"></rect>
+            <rect x="363" y="4329" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="4349">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="365" y="4375" width="94" height="32"></rect>
+            <rect x="363" y="4373" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="4393">AMPER_VAR</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m20 0 h10 m54 0 h10 m0 0 h94 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m92 0 h10 m0 0 h56 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m58 0 h10 m0 0 h90 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m60 0 h10 m0 0 h88 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m40 0 h10 m0 0 h108 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m72 0 h10 m0 0 h76 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m118 0 h10 m0 0 h30 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m100 0 h10 m0 0 h48 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m74 0 h10 m0 0 h74 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m110 0 h10 m0 0 h38 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m108 0 h10 m0 0 h40 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m118 0 h10 m0 0 h30 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m68 0 h10 m0 0 h80 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m138 0 h10 m0 0 h10 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m148 0 h10 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m94 0 h10 m0 0 h54 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m86 0 h10 m0 0 h62 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m74 0 h10 m0 0 h74 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m70 0 h10 m0 0 h78 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m86 0 h10 m0 0 h62 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m76 0 h10 m0 0 h72 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m78 0 h10 m0 0 h70 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m76 0 h10 m0 0 h72 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m38 0 h10 m0 0 h110 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m100 0 h10 m0 0 h48 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m38 0 h10 m0 0 h110 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m58 0 h10 m0 0 h90 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m130 0 h10 m0 0 h18 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m78 0 h10 m0 0 h70 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m68 0 h10 m0 0 h80 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m80 0 h10 m0 0 h68 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m72 0 h10 m0 0 h76 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m94 0 h10 m0 0 h54 m80 -4312 h10 m84 0 h10 m0 0 h150 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m26 0 h10 m20 0 h10 m54 0 h10 m0 0 h94 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m92 0 h10 m0 0 h56 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m58 0 h10 m0 0 h90 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m60 0 h10 m0 0 h88 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m40 0 h10 m0 0 h108 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m72 0 h10 m0 0 h76 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m118 0 h10 m0 0 h30 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m100 0 h10 m0 0 h48 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m74 0 h10 m0 0 h74 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m110 0 h10 m0 0 h38 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m108 0 h10 m0 0 h40 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m118 0 h10 m0 0 h30 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m68 0 h10 m0 0 h80 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m138 0 h10 m0 0 h10 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m148 0 h10 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m94 0 h10 m0 0 h54 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m86 0 h10 m0 0 h62 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m74 0 h10 m0 0 h74 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m70 0 h10 m0 0 h78 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m86 0 h10 m0 0 h62 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m76 0 h10 m0 0 h72 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m78 0 h10 m0 0 h70 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m76 0 h10 m0 0 h72 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m38 0 h10 m0 0 h110 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m100 0 h10 m0 0 h48 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m38 0 h10 m0 0 h110 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m58 0 h10 m0 0 h90 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m130 0 h10 m0 0 h18 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m78 0 h10 m0 0 h70 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m68 0 h10 m0 0 h80 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m80 0 h10 m0 0 h68 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m72 0 h10 m0 0 h76 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m94 0 h10 m0 0 h54 m-274 -4356 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m294 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-294 0 h10 m0 0 h284 m-334 32 h20 m334 0 h20 m-374 0 q10 0 10 10 m354 0 q0 -10 10 -10 m-364 10 v4370 m354 0 v-4370 m-354 4370 q0 10 10 10 m334 0 q10 0 10 -10 m-344 10 h10 m0 0 h324 m23 -4390 h-3"></svg:path>
+         <polygon points="611 33 619 29 619 37"></polygon>
+         <polygon points="611 33 603 29 603 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</a></div>
+               <div>         ::= ( <a href="#NAME" title="NAME">NAME</a> | 'AVE' | 'MIN' | 'MAX' | 'CNT' | 'FST' | 'LST' | 'ASQ' | 'MDN' | 'MDE' | 'PCT' |
+                  'RPCT' | 'RNK' | 'DST' | 'TOT' | 'SUM' | 'CT' | 'IS' | 'CONTAINS' | 'OMITS' | 'LIKE'
+                  | 'TOTAL' | 'MISSING' | 'INCLUDES' | 'EXCLUDES' | 'EXCEEDS' | 'ALL' | 'LESS' | 'THAN'
+                  | 'MORE' | 'GREATER' | 'OFF' | 'ON' | 'RECAP' | 'INDENT' | <a href="#ACROSS_TOTAL" title="ACROSS_TOTAL">ACROSS_TOTAL</a> | 'COMPOUND' | 'LAYOUT' | 'SECTION' | 'PAGELAYOUT' | 'COMPONENT' | 'MERGE' | 'ORIENTATION'
+                  | 'LANDSCAPE' | 'PORTRAIT' | 'TYPE' | 'POSITION' | 'DIMENSION' | 'STYLE' | 'ENDSTYLE'
+                  | 'MATCH' | 'AFTER' | 'RUN' | 'OLD' | 'NEW' | <a href="#OLD_OR_NEW_KW" title="OLD_OR_NEW_KW">OLD_OR_NEW_KW</a> | <a href="#OLD_AND_NEW_KW" title="OLD_AND_NEW_KW">OLD_AND_NEW_KW</a> | <a href="#OLD_NOT_NEW_KW" title="OLD_NOT_NEW_KW">OLD_NOT_NEW_KW</a> | <a href="#NEW_NOT_OLD_KW" title="NEW_NOT_OLD_KW">NEW_NOT_OLD_KW</a> | <a href="#OLD_NOR_NEW_KW" title="OLD_NOR_NEW_KW">OLD_NOR_NEW_KW</a> | 'MATCHING' | 'MATCHED' | 'UPDATE' | 'INSERT' | 'INTO' | 'HEADING' | 'FOOTING' |
+                  'SUBHEAD' | 'SUBFOOT' | 'FORMAT' | 'TIMES' | 'WHILE' | 'UNTIL' | 'FOR' | 'STEP' |
+                  'TOP' | 'BOTTOM' | 'RANKED' | 'NOPRINT' | 'AS' | 'IN' | 'HIERARCHY' | 'WHEN' | 'SHOW'
+                  | 'UP' | 'DOWN' | 'OPEN' | 'CLOSE' | <a href="#PAGE_BREAK" title="PAGE_BREAK">PAGE_BREAK</a> | 'DRILLTHROUGH' | 'COLUMN' | 'LINE' | 'ITEM' | 'COLOR' | 'DEFAULT' | 'READ' | 'WRITE'
+                  | <a href="#NUMBER" title="NUMBER">NUMBER</a> | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> ) ( <a href="#dm_token" title="dm_token">dm_token</a> | '-' ( <a href="#NAME" title="NAME">NAME</a> | 'AVE' | 'MIN' | 'MAX' | 'CNT' | 'FST' | 'LST' | 'ASQ' | 'MDN' | 'MDE' | 'PCT' |
+                  'RPCT' | 'RNK' | 'DST' | 'TOT' | 'SUM' | 'CT' | 'IS' | 'CONTAINS' | 'OMITS' | 'LIKE'
+                  | 'TOTAL' | 'MISSING' | 'INCLUDES' | 'EXCLUDES' | 'EXCEEDS' | 'ALL' | 'LESS' | 'THAN'
+                  | 'MORE' | 'GREATER' | 'OFF' | 'ON' | 'RECAP' | 'INDENT' | <a href="#ACROSS_TOTAL" title="ACROSS_TOTAL">ACROSS_TOTAL</a> | 'COMPOUND' | 'LAYOUT' | 'SECTION' | 'PAGELAYOUT' | 'COMPONENT' | 'MERGE' | 'ORIENTATION'
+                  | 'LANDSCAPE' | 'PORTRAIT' | 'TYPE' | 'POSITION' | 'DIMENSION' | 'STYLE' | 'ENDSTYLE'
+                  | 'MATCH' | 'AFTER' | 'RUN' | 'OLD' | 'NEW' | <a href="#OLD_OR_NEW_KW" title="OLD_OR_NEW_KW">OLD_OR_NEW_KW</a> | <a href="#OLD_AND_NEW_KW" title="OLD_AND_NEW_KW">OLD_AND_NEW_KW</a> | <a href="#OLD_NOT_NEW_KW" title="OLD_NOT_NEW_KW">OLD_NOT_NEW_KW</a> | <a href="#NEW_NOT_OLD_KW" title="NEW_NOT_OLD_KW">NEW_NOT_OLD_KW</a> | <a href="#OLD_NOR_NEW_KW" title="OLD_NOR_NEW_KW">OLD_NOR_NEW_KW</a> | 'MATCHING' | 'MATCHED' | 'UPDATE' | 'INSERT' | 'INTO' | 'HEADING' | 'FOOTING' |
+                  'SUBHEAD' | 'SUBFOOT' | 'FORMAT' | 'TIMES' | 'WHILE' | 'UNTIL' | 'FOR' | 'STEP' |
+                  'TOP' | 'BOTTOM' | 'RANKED' | 'NOPRINT' | 'AS' | 'IN' | 'HIERARCHY' | 'WHEN' | 'SHOW'
+                  | 'UP' | 'DOWN' | 'OPEN' | 'CLOSE' | <a href="#PAGE_BREAK" title="PAGE_BREAK">PAGE_BREAK</a> | 'DRILLTHROUGH' | 'COLUMN' | 'LINE' | 'ITEM' | 'COLOR' | 'DEFAULT' | 'READ' | 'WRITE'
+                  | <a href="#NUMBER" title="NUMBER">NUMBER</a> | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> ) )*</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#set_command" title="set_command">set_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#set_value" title="set_value">set_value</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_token" data-rule="dm_token" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#hyphenated_name" class="used-by-link">hyphenated_name</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_token">dm_token:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="203" height="389">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#LABEL_DM" xlink:title="LABEL_DM">
+            <rect x="51" y="3" width="86" height="32"></rect>
+            <rect x="49" y="1" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">LABEL_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#SET_DM" xlink:title="SET_DM">
+            <rect x="51" y="47" width="70" height="32"></rect>
+            <rect x="49" y="45" width="70" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">SET_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#GOTO_DM" xlink:title="GOTO_DM">
+            <rect x="51" y="91" width="82" height="32"></rect>
+            <rect x="49" y="89" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">GOTO_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#REPEAT_DM" xlink:title="REPEAT_DM">
+            <rect x="51" y="135" width="94" height="32"></rect>
+            <rect x="49" y="133" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">REPEAT_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IF_DM" xlink:title="IF_DM">
+            <rect x="51" y="179" width="58" height="32"></rect>
+            <rect x="49" y="177" width="58" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">IF_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#TYPE_DM" xlink:title="TYPE_DM">
+            <rect x="51" y="223" width="78" height="32"></rect>
+            <rect x="49" y="221" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="241">TYPE_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#INCLUDE_DM" xlink:title="INCLUDE_DM">
+            <rect x="51" y="267" width="104" height="32"></rect>
+            <rect x="49" y="265" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="285">INCLUDE_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#RUN_DM" xlink:title="RUN_DM">
+            <rect x="51" y="311" width="74" height="32"></rect>
+            <rect x="49" y="309" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="329">RUN_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EXIT_DM" xlink:title="EXIT_DM">
+            <rect x="51" y="355" width="76" height="32"></rect>
+            <rect x="49" y="353" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="373">EXIT_DM</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m86 0 h10 m0 0 h18 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m70 0 h10 m0 0 h34 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m82 0 h10 m0 0 h22 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m94 0 h10 m0 0 h10 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m58 0 h10 m0 0 h46 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m78 0 h10 m0 0 h26 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m104 0 h10 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m74 0 h10 m0 0 h30 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m76 0 h10 m0 0 h28 m23 -352 h-3"></svg:path>
+         <polygon points="193 17 201 13 201 21"></polygon>
+         <polygon points="193 17 185 13 185 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_token" title="dm_token">dm_token</a> ::= <a href="#LABEL_DM" title="LABEL_DM">LABEL_DM</a></div>
+               <div>           | <a href="#SET_DM" title="SET_DM">SET_DM</a></div>
+               <div>           | <a href="#GOTO_DM" title="GOTO_DM">GOTO_DM</a></div>
+               <div>           | <a href="#REPEAT_DM" title="REPEAT_DM">REPEAT_DM</a></div>
+               <div>           | <a href="#IF_DM" title="IF_DM">IF_DM</a></div>
+               <div>           | <a href="#TYPE_DM" title="TYPE_DM">TYPE_DM</a></div>
+               <div>           | <a href="#INCLUDE_DM" title="INCLUDE_DM">INCLUDE_DM</a></div>
+               <div>           | <a href="#RUN_DM" title="RUN_DM">RUN_DM</a></div>
+               <div>           | <a href="#EXIT_DM" title="EXIT_DM">EXIT_DM</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_read" data-rule="dm_read" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_read">dm_read:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="765" height="101">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#READ_DM" xlink:title="READ_DM">
+            <rect x="31" y="19" width="80" height="32"></rect>
+            <rect x="29" y="17" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="37">READ_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="131" y="19" width="118" height="32"></rect>
+            <rect x="129" y="17" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="139" y="37">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="309" y="19" width="94" height="32"></rect>
+            <rect x="307" y="17" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="317" y="37">AMPER_VAR</text></a><rect x="443" y="51" width="24" height="32" rx="10"></rect>
+         <rect x="441" y="49" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="451" y="69">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#format_name" xlink:title="format_name">
+            <rect x="487" y="51" width="106" height="32"></rect>
+            <rect x="485" y="49" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="495" y="69">format_name</text></a><rect x="693" y="51" width="24" height="32" rx="10"></rect>
+         <rect x="691" y="49" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="701" y="69">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m0 0 h10 m80 0 h10 m0 0 h10 m118 0 h10 m40 0 h10 m94 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m24 0 h10 m0 0 h10 m106 0 h10 m-324 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m324 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-324 0 h10 m0 0 h314 m-364 32 h20 m364 0 h20 m-404 0 q10 0 10 10 m384 0 q0 -10 10 -10 m-394 10 v46 m384 0 v-46 m-384 46 q0 10 10 10 m364 0 q10 0 10 -10 m-374 10 h10 m0 0 h354 m40 -66 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="755 33 763 29 763 37"></polygon>
+         <polygon points="755 33 747 29 747 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_read" title="dm_read">dm_read</a>  ::= <a href="#READ_DM" title="READ_DM">READ_DM</a> <a href="#qualified_name" title="qualified_name">qualified_name</a> ( <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> ( '.' <a href="#format_name" title="format_name">format_name</a> )? )* ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_write" data-rule="dm_write" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_write">dm_write:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="975" height="403">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#WRITE_DM" xlink:title="WRITE_DM">
+            <rect x="31" y="19" width="88" height="32"></rect>
+            <rect x="29" y="17" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="37">WRITE_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="139" y="19" width="118" height="32"></rect>
+            <rect x="137" y="17" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="37">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="337" y="19" width="72" height="32"></rect>
+            <rect x="335" y="17" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="345" y="37">NUMBER</text></a><rect x="449" y="51" width="24" height="32" rx="10"></rect>
+         <rect x="447" y="49" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="457" y="69">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="493" y="51" width="72" height="32"></rect>
+            <rect x="491" y="49" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="501" y="69">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="337" y="95" width="144" height="32"></rect>
+            <rect x="335" y="93" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="345" y="113">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="337" y="183" width="118" height="32"></rect>
+            <rect x="335" y="181" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="345" y="201">qualified_name</text></a><rect x="495" y="183" width="26" height="32" rx="10"></rect>
+         <rect x="493" y="181" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="503" y="201">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="581" y="183" width="116" height="32"></rect>
+            <rect x="579" y="181" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="589" y="201">dm_expression</text></a><rect x="581" y="139" width="24" height="32" rx="10"></rect>
+         <rect x="579" y="137" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="589" y="157">,</text>
+         <rect x="757" y="183" width="26" height="32" rx="10"></rect>
+         <rect x="755" y="181" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="765" y="201">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="337" y="265" width="94" height="32"></rect>
+            <rect x="335" y="263" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="345" y="283">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="337" y="309" width="66" height="32"></rect>
+            <rect x="335" y="307" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="345" y="327">STRING</text></a><rect x="337" y="353" width="26" height="32" rx="10"></rect>
+         <rect x="335" y="351" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="345" y="371">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="383" y="353" width="116" height="32"></rect>
+            <rect x="381" y="351" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="391" y="371">dm_expression</text></a><rect x="519" y="353" width="26" height="32" rx="10"></rect>
+         <rect x="517" y="351" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="527" y="371">)</text>
+         <rect x="903" y="51" width="24" height="32" rx="10"></rect>
+         <rect x="901" y="49" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="911" y="69">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m0 0 h10 m88 0 h10 m0 0 h10 m118 0 h10 m60 0 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m-526 -334 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m526 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-526 0 h10 m0 0 h516 m-566 32 h20 m566 0 h20 m-606 0 q10 0 10 10 m586 0 q0 -10 10 -10 m-596 10 v348 m586 0 v-348 m-586 348 q0 10 10 10 m566 0 q10 0 10 -10 m-576 10 h10 m0 0 h556 m40 -368 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="965 33 973 29 973 37"></polygon>
+         <polygon points="965 33 957 29 957 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_write" title="dm_write">dm_write</a> ::= <a href="#WRITE_DM" title="WRITE_DM">WRITE_DM</a> <a href="#qualified_name" title="qualified_name">qualified_name</a> ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' )* ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_default" data-rule="dm_default" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_default">dm_default:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="601" height="125">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#DEFAULT_DM" xlink:title="DEFAULT_DM">
+            <rect x="51" y="3" width="102" height="32"></rect>
+            <rect x="49" y="1" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">DEFAULT_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#DEFAULTS_DM" xlink:title="DEFAULTS_DM">
+            <rect x="51" y="47" width="110" height="32"></rect>
+            <rect x="49" y="45" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">DEFAULTS_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#DEFAULTH_DM" xlink:title="DEFAULTH_DM">
+            <rect x="51" y="91" width="112" height="32"></rect>
+            <rect x="49" y="89" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">DEFAULTH_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="203" y="3" width="94" height="32"></rect>
+            <rect x="201" y="1" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="211" y="21">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="317" y="3" width="36" height="32"></rect>
+            <rect x="315" y="1" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="325" y="21">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="373" y="3" width="116" height="32"></rect>
+            <rect x="371" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="381" y="21">dm_expression</text></a><rect x="529" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="527" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="537" y="53">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m102 0 h10 m0 0 h10 m-152 0 h20 m132 0 h20 m-172 0 q10 0 10 10 m152 0 q0 -10 10 -10 m-162 10 v24 m152 0 v-24 m-152 24 q0 10 10 10 m132 0 q10 0 10 -10 m-142 10 h10 m110 0 h10 m0 0 h2 m-142 -10 v20 m152 0 v-20 m-152 20 v24 m152 0 v-24 m-152 24 q0 10 10 10 m132 0 q10 0 10 -10 m-142 10 h10 m112 0 h10 m20 -88 h10 m94 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m116 0 h10 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="591 17 599 13 599 21"></polygon>
+         <polygon points="591 17 583 13 583 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_default" title="dm_default">dm_default</a></div>
+               <div>         ::= ( <a href="#DEFAULT_DM" title="DEFAULT_DM">DEFAULT_DM</a> | <a href="#DEFAULTS_DM" title="DEFAULTS_DM">DEFAULTS_DM</a> | <a href="#DEFAULTH_DM" title="DEFAULTH_DM">DEFAULTH_DM</a> ) <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> <a href="#EQ" title="EQ">EQ</a> <a href="#dm_expression" title="dm_expression">dm_expression</a> ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_set" data-rule="dm_set" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_set">dm_set:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="519" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#SET_DM" xlink:title="SET_DM">
+            <rect x="31" y="3" width="70" height="32"></rect>
+            <rect x="29" y="1" width="70" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">SET_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="121" y="3" width="94" height="32"></rect>
+            <rect x="119" y="1" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="129" y="21">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="235" y="3" width="36" height="32"></rect>
+            <rect x="233" y="1" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="243" y="21">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="291" y="3" width="116" height="32"></rect>
+            <rect x="289" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="299" y="21">dm_expression</text></a><rect x="447" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="445" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="455" y="53">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m116 0 h10 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="509 17 517 13 517 21"></polygon>
+         <polygon points="509 17 501 13 501 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_set" title="dm_set">dm_set</a>   ::= <a href="#SET_DM" title="SET_DM">SET_DM</a> <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> <a href="#EQ" title="EQ">EQ</a> <a href="#dm_expression" title="dm_expression">dm_expression</a> ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_goto" data-rule="dm_goto" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_goto">dm_goto:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="299" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#GOTO_DM" xlink:title="GOTO_DM">
+            <rect x="31" y="3" width="82" height="32"></rect>
+            <rect x="29" y="1" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">GOTO_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="133" y="3" width="54" height="32"></rect>
+            <rect x="131" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="141" y="21">NAME</text></a><rect x="227" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="225" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="235" y="53">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m82 0 h10 m0 0 h10 m54 0 h10 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="289 17 297 13 297 21"></polygon>
+         <polygon points="289 17 281 13 281 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_goto" title="dm_goto">dm_goto</a>  ::= <a href="#GOTO_DM" title="GOTO_DM">GOTO_DM</a> <a href="#NAME" title="NAME">NAME</a> ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_repeat" data-rule="dm_repeat" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_repeat">dm_repeat:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="2079" height="1005">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#REPEAT_DM" xlink:title="REPEAT_DM">
+            <rect x="31" y="3" width="94" height="32"></rect>
+            <rect x="29" y="1" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">REPEAT_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="145" y="3" width="54" height="32"></rect>
+            <rect x="143" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="153" y="21">NAME</text></a><rect x="65" y="69" width="66" height="32" rx="10"></rect>
+         <rect x="63" y="67" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="73" y="87">WHILE</text>
+         <rect x="65" y="113" width="62" height="32" rx="10"></rect>
+         <rect x="63" y="111" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="73" y="131">UNTIL</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_logical_expression" xlink:title="dm_logical_expression">
+            <rect x="171" y="69" width="164" height="32"></rect>
+            <rect x="169" y="67" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="179" y="87">dm_logical_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="65" y="157" width="72" height="32"></rect>
+            <rect x="63" y="155" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="73" y="175">NUMBER</text></a><rect x="177" y="189" width="24" height="32" rx="10"></rect>
+         <rect x="175" y="187" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="185" y="207">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="221" y="189" width="72" height="32"></rect>
+            <rect x="219" y="187" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="229" y="207">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="65" y="233" width="144" height="32"></rect>
+            <rect x="63" y="231" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="73" y="251">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="65" y="321" width="118" height="32"></rect>
+            <rect x="63" y="319" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="73" y="339">qualified_name</text></a><rect x="223" y="321" width="26" height="32" rx="10"></rect>
+         <rect x="221" y="319" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="231" y="339">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="309" y="321" width="116" height="32"></rect>
+            <rect x="307" y="319" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="317" y="339">dm_expression</text></a><rect x="309" y="277" width="24" height="32" rx="10"></rect>
+         <rect x="307" y="275" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="317" y="295">,</text>
+         <rect x="485" y="321" width="26" height="32" rx="10"></rect>
+         <rect x="483" y="319" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="493" y="339">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="65" y="403" width="94" height="32"></rect>
+            <rect x="63" y="401" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="73" y="421">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="65" y="447" width="66" height="32"></rect>
+            <rect x="63" y="445" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="73" y="465">STRING</text></a><rect x="65" y="491" width="26" height="32" rx="10"></rect>
+         <rect x="63" y="489" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="73" y="509">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="111" y="491" width="116" height="32"></rect>
+            <rect x="109" y="489" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="119" y="509">dm_expression</text></a><rect x="247" y="491" width="26" height="32" rx="10"></rect>
+         <rect x="245" y="489" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="255" y="509">)</text>
+         <rect x="571" y="157" width="62" height="32" rx="10"></rect>
+         <rect x="569" y="155" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="579" y="175">TIMES</text>
+         <rect x="45" y="535" width="48" height="32" rx="10"></rect>
+         <rect x="43" y="533" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="553">FOR</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="113" y="535" width="94" height="32"></rect>
+            <rect x="111" y="533" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="121" y="553">AMPER_VAR</text></a><rect x="227" y="535" width="60" height="32" rx="10"></rect>
+         <rect x="225" y="533" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="235" y="553">FROM</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="327" y="535" width="72" height="32"></rect>
+            <rect x="325" y="533" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="335" y="553">NUMBER</text></a><rect x="439" y="567" width="24" height="32" rx="10"></rect>
+         <rect x="437" y="565" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="447" y="585">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="483" y="567" width="72" height="32"></rect>
+            <rect x="481" y="565" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="491" y="585">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="327" y="611" width="144" height="32"></rect>
+            <rect x="325" y="609" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="335" y="629">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="327" y="699" width="118" height="32"></rect>
+            <rect x="325" y="697" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="335" y="717">qualified_name</text></a><rect x="485" y="699" width="26" height="32" rx="10"></rect>
+         <rect x="483" y="697" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="493" y="717">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="571" y="699" width="116" height="32"></rect>
+            <rect x="569" y="697" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="579" y="717">dm_expression</text></a><rect x="571" y="655" width="24" height="32" rx="10"></rect>
+         <rect x="569" y="653" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="579" y="673">,</text>
+         <rect x="747" y="699" width="26" height="32" rx="10"></rect>
+         <rect x="745" y="697" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="755" y="717">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="327" y="781" width="94" height="32"></rect>
+            <rect x="325" y="779" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="335" y="799">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="327" y="825" width="66" height="32"></rect>
+            <rect x="325" y="823" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="335" y="843">STRING</text></a><rect x="327" y="869" width="26" height="32" rx="10"></rect>
+         <rect x="325" y="867" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="335" y="887">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="373" y="869" width="116" height="32"></rect>
+            <rect x="371" y="867" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="381" y="887">dm_expression</text></a><rect x="509" y="869" width="26" height="32" rx="10"></rect>
+         <rect x="507" y="867" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="517" y="887">)</text>
+         <rect x="833" y="535" width="38" height="32" rx="10"></rect>
+         <rect x="831" y="533" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="841" y="553">TO</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="911" y="535" width="72" height="32"></rect>
+            <rect x="909" y="533" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="919" y="553">NUMBER</text></a><rect x="1023" y="567" width="24" height="32" rx="10"></rect>
+         <rect x="1021" y="565" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1031" y="585">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="1067" y="567" width="72" height="32"></rect>
+            <rect x="1065" y="565" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1075" y="585">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="911" y="611" width="144" height="32"></rect>
+            <rect x="909" y="609" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="919" y="629">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="911" y="699" width="118" height="32"></rect>
+            <rect x="909" y="697" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="919" y="717">qualified_name</text></a><rect x="1069" y="699" width="26" height="32" rx="10"></rect>
+         <rect x="1067" y="697" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1077" y="717">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="1155" y="699" width="116" height="32"></rect>
+            <rect x="1153" y="697" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1163" y="717">dm_expression</text></a><rect x="1155" y="655" width="24" height="32" rx="10"></rect>
+         <rect x="1153" y="653" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1163" y="673">,</text>
+         <rect x="1331" y="699" width="26" height="32" rx="10"></rect>
+         <rect x="1329" y="697" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1339" y="717">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="911" y="781" width="94" height="32"></rect>
+            <rect x="909" y="779" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="919" y="799">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="911" y="825" width="66" height="32"></rect>
+            <rect x="909" y="823" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="919" y="843">STRING</text></a><rect x="911" y="869" width="26" height="32" rx="10"></rect>
+         <rect x="909" y="867" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="919" y="887">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="957" y="869" width="116" height="32"></rect>
+            <rect x="955" y="867" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="965" y="887">dm_expression</text></a><rect x="1093" y="869" width="26" height="32" rx="10"></rect>
+         <rect x="1091" y="867" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1101" y="887">)</text>
+         <rect x="1437" y="535" width="54" height="32" rx="10"></rect>
+         <rect x="1435" y="533" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1445" y="553">STEP</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="1531" y="535" width="72" height="32"></rect>
+            <rect x="1529" y="533" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1539" y="553">NUMBER</text></a><rect x="1643" y="567" width="24" height="32" rx="10"></rect>
+         <rect x="1641" y="565" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1651" y="585">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="1687" y="567" width="72" height="32"></rect>
+            <rect x="1685" y="565" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1695" y="585">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="1531" y="611" width="144" height="32"></rect>
+            <rect x="1529" y="609" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1539" y="629">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="1531" y="699" width="118" height="32"></rect>
+            <rect x="1529" y="697" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1539" y="717">qualified_name</text></a><rect x="1689" y="699" width="26" height="32" rx="10"></rect>
+         <rect x="1687" y="697" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1697" y="717">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="1775" y="699" width="116" height="32"></rect>
+            <rect x="1773" y="697" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1783" y="717">dm_expression</text></a><rect x="1775" y="655" width="24" height="32" rx="10"></rect>
+         <rect x="1773" y="653" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1783" y="673">,</text>
+         <rect x="1951" y="699" width="26" height="32" rx="10"></rect>
+         <rect x="1949" y="697" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1959" y="717">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="1531" y="781" width="94" height="32"></rect>
+            <rect x="1529" y="779" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1539" y="799">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="1531" y="825" width="66" height="32"></rect>
+            <rect x="1529" y="823" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1539" y="843">STRING</text></a><rect x="1531" y="869" width="26" height="32" rx="10"></rect>
+         <rect x="1529" y="867" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1539" y="887">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="1577" y="869" width="116" height="32"></rect>
+            <rect x="1575" y="867" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1585" y="887">dm_expression</text></a><rect x="1713" y="869" width="26" height="32" rx="10"></rect>
+         <rect x="1711" y="867" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1721" y="887">)</text>
+         <rect x="2007" y="971" width="24" height="32" rx="10"></rect>
+         <rect x="2005" y="969" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="2015" y="989">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m94 0 h10 m0 0 h10 m54 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-218 66 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m66 0 h10 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v24 m106 0 v-24 m-106 24 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m62 0 h10 m0 0 h4 m20 -44 h10 m164 0 h10 m0 0 h1702 m-2032 0 h20 m2012 0 h20 m-2052 0 q10 0 10 10 m2032 0 q0 -10 10 -10 m-2042 10 v68 m2032 0 v-68 m-2032 68 q0 10 10 10 m2012 0 q10 0 10 -10 m-2002 10 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m20 -334 h10 m62 0 h10 m0 0 h1404 m-2022 -10 v20 m2032 0 v-20 m-2032 20 v358 m2032 0 v-358 m-2032 358 q0 10 10 10 m2012 0 q10 0 10 -10 m-2022 10 h10 m48 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m60 0 h10 m20 0 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m20 -334 h10 m38 0 h10 m20 0 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m40 -334 h10 m54 0 h10 m20 0 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m-600 -334 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v348 m620 0 v-348 m-620 348 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m0 0 h590 m42 -834 l2 0 m2 0 l2 0 m2 0 l2 0 m-114 870 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="2069 953 2077 949 2077 957"></polygon>
+         <polygon points="2069 953 2061 949 2061 957"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_repeat" title="dm_repeat">dm_repeat</a></div>
+               <div>         ::= <a href="#REPEAT_DM" title="REPEAT_DM">REPEAT_DM</a> <a href="#NAME" title="NAME">NAME</a> ( ( 'WHILE' | 'UNTIL' ) <a href="#dm_logical_expression" title="dm_logical_expression">dm_logical_expression</a> | ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' ) 'TIMES' | 'FOR' <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> 'FROM' ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' ) 'TO' ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' ) ( 'STEP' ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' ) )? ) ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_label" data-rule="dm_label" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_label">dm_label:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="145" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#LABEL_DM" xlink:title="LABEL_DM">
+            <rect x="31" y="3" width="86" height="32"></rect>
+            <rect x="29" y="1" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">LABEL_DM</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m86 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="135 17 143 13 143 21"></polygon>
+         <polygon points="135 17 127 13 127 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_label" title="dm_label">dm_label</a> ::= <a href="#LABEL_DM" title="LABEL_DM">LABEL_DM</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_if" data-rule="dm_if" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_if">dm_if:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="961" height="113">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IF_DM" xlink:title="IF_DM">
+            <rect x="31" y="3" width="58" height="32"></rect>
+            <rect x="29" y="1" width="58" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">IF_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_logical_expression" xlink:title="dm_logical_expression">
+            <rect x="109" y="3" width="164" height="32"></rect>
+            <rect x="107" y="1" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="117" y="21">dm_logical_expression</text></a><rect x="313" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="311" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="321" y="21">THEN</text>
+         <rect x="409" y="35" width="60" height="32" rx="10"></rect>
+         <rect x="407" y="33" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="417" y="53">GOTO</text>
+         <rect x="313" y="79" width="60" height="32" rx="10"></rect>
+         <rect x="311" y="77" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="321" y="97">GOTO</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="529" y="3" width="54" height="32"></rect>
+            <rect x="527" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="537" y="21">NAME</text></a><rect x="623" y="35" width="52" height="32" rx="10"></rect>
+         <rect x="621" y="33" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="631" y="53">ELSE</text>
+         <rect x="695" y="35" width="60" height="32" rx="10"></rect>
+         <rect x="693" y="33" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="703" y="53">GOTO</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="775" y="35" width="54" height="32"></rect>
+            <rect x="773" y="33" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="783" y="53">NAME</text></a><rect x="889" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="887" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="897" y="53">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m164 0 h10 m20 0 h10 m56 0 h10 m20 0 h10 m0 0 h70 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v12 m100 0 v-12 m-100 12 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m60 0 h10 m-196 -32 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v56 m216 0 v-56 m-216 56 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m60 0 h10 m0 0 h116 m20 -76 h10 m54 0 h10 m20 0 h10 m0 0 h216 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v12 m246 0 v-12 m-246 12 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m52 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m54 0 h10 m40 -32 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="951 17 959 13 959 21"></polygon>
+         <polygon points="951 17 943 13 943 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_if" title="dm_if">dm_if</a>    ::= <a href="#IF_DM" title="IF_DM">IF_DM</a> <a href="#dm_logical_expression" title="dm_logical_expression">dm_logical_expression</a> ( 'THEN' 'GOTO'? | 'GOTO' ) <a href="#NAME" title="NAME">NAME</a> ( 'ELSE' 'GOTO' <a href="#NAME" title="NAME">NAME</a> )? ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_type" data-rule="dm_type" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_type">dm_type:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="827" height="403">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#TYPE_DM" xlink:title="TYPE_DM">
+            <rect x="31" y="19" width="78" height="32"></rect>
+            <rect x="29" y="17" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="37">TYPE_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="189" y="19" width="72" height="32"></rect>
+            <rect x="187" y="17" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="197" y="37">NUMBER</text></a><rect x="301" y="51" width="24" height="32" rx="10"></rect>
+         <rect x="299" y="49" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="309" y="69">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="345" y="51" width="72" height="32"></rect>
+            <rect x="343" y="49" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="353" y="69">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="189" y="95" width="144" height="32"></rect>
+            <rect x="187" y="93" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="197" y="113">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="189" y="183" width="118" height="32"></rect>
+            <rect x="187" y="181" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="197" y="201">qualified_name</text></a><rect x="347" y="183" width="26" height="32" rx="10"></rect>
+         <rect x="345" y="181" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="355" y="201">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="433" y="183" width="116" height="32"></rect>
+            <rect x="431" y="181" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="441" y="201">dm_expression</text></a><rect x="433" y="139" width="24" height="32" rx="10"></rect>
+         <rect x="431" y="137" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="441" y="157">,</text>
+         <rect x="609" y="183" width="26" height="32" rx="10"></rect>
+         <rect x="607" y="181" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="617" y="201">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="189" y="265" width="94" height="32"></rect>
+            <rect x="187" y="263" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="197" y="283">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="189" y="309" width="66" height="32"></rect>
+            <rect x="187" y="307" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="197" y="327">STRING</text></a><rect x="189" y="353" width="26" height="32" rx="10"></rect>
+         <rect x="187" y="351" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="197" y="371">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="235" y="353" width="116" height="32"></rect>
+            <rect x="233" y="351" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="243" y="371">dm_expression</text></a><rect x="371" y="353" width="26" height="32" rx="10"></rect>
+         <rect x="369" y="351" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="379" y="371">)</text>
+         <rect x="755" y="51" width="24" height="32" rx="10"></rect>
+         <rect x="753" y="49" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="763" y="69">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m0 0 h10 m78 0 h10 m60 0 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m-526 -334 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m526 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-526 0 h10 m0 0 h516 m-566 32 h20 m566 0 h20 m-606 0 q10 0 10 10 m586 0 q0 -10 10 -10 m-596 10 v348 m586 0 v-348 m-586 348 q0 10 10 10 m566 0 q10 0 10 -10 m-576 10 h10 m0 0 h556 m40 -368 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="817 33 825 29 825 37"></polygon>
+         <polygon points="817 33 809 29 809 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_type" title="dm_type">dm_type</a>  ::= <a href="#TYPE_DM" title="TYPE_DM">TYPE_DM</a> ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' )* ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_include" data-rule="dm_include" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_include">dm_include:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="385" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#INCLUDE_DM" xlink:title="INCLUDE_DM">
+            <rect x="31" y="3" width="104" height="32"></rect>
+            <rect x="29" y="1" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">INCLUDE_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="155" y="3" width="118" height="32"></rect>
+            <rect x="153" y="1" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="163" y="21">qualified_name</text></a><rect x="313" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="311" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="321" y="53">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m104 0 h10 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="375 17 383 13 383 21"></polygon>
+         <polygon points="375 17 367 13 367 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_include" title="dm_include">dm_include</a></div>
+               <div>         ::= <a href="#INCLUDE_DM" title="INCLUDE_DM">INCLUDE_DM</a> <a href="#qualified_name" title="qualified_name">qualified_name</a> ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_run" data-rule="dm_run" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_run">dm_run:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="217" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#RUN_DM" xlink:title="RUN_DM">
+            <rect x="31" y="3" width="74" height="32"></rect>
+            <rect x="29" y="1" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">RUN_DM</text></a><rect x="145" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="143" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="53">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="207 17 215 13 215 21"></polygon>
+         <polygon points="207 17 199 13 199 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_run" title="dm_run">dm_run</a>   ::= <a href="#RUN_DM" title="RUN_DM">RUN_DM</a> ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_exit" data-rule="dm_exit" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_exit">dm_exit:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="219" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EXIT_DM" xlink:title="EXIT_DM">
+            <rect x="31" y="3" width="76" height="32"></rect>
+            <rect x="29" y="1" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">EXIT_DM</text></a><rect x="147" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="145" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="155" y="53">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="209 17 217 13 217 21"></polygon>
+         <polygon points="209 17 201 13 201 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_exit" title="dm_exit">dm_exit</a>  ::= <a href="#EXIT_DM" title="EXIT_DM">EXIT_DM</a> ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_htmlform" data-rule="dm_htmlform" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_command" class="used-by-link">dm_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_htmlform">dm_htmlform:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="435" height="113">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#HTMLFORM_BLOCK" xlink:title="HTMLFORM_BLOCK">
+            <rect x="51" y="3" width="138" height="32"></rect>
+            <rect x="49" y="1" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">HTMLFORM_BLOCK</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#HTMLFORM_DM" xlink:title="HTMLFORM_DM">
+            <rect x="51" y="47" width="114" height="32"></rect>
+            <rect x="49" y="45" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">HTMLFORM_DM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="185" y="47" width="118" height="32"></rect>
+            <rect x="183" y="45" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="193" y="65">qualified_name</text></a><rect x="343" y="79" width="24" height="32" rx="10"></rect>
+         <rect x="341" y="77" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="351" y="97">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m138 0 h10 m0 0 h198 m-376 0 h20 m356 0 h20 m-396 0 q10 0 10 10 m376 0 q0 -10 10 -10 m-386 10 v24 m376 0 v-24 m-376 24 q0 10 10 10 m356 0 q10 0 10 -10 m-366 10 h10 m114 0 h10 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m43 -76 h-3"></svg:path>
+         <polygon points="425 17 433 13 433 21"></polygon>
+         <polygon points="425 17 417 13 417 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_htmlform" title="dm_htmlform">dm_htmlform</a></div>
+               <div>         ::= <a href="#HTMLFORM_BLOCK" title="HTMLFORM_BLOCK">HTMLFORM_BLOCK</a></div>
+               <div>           | <a href="#HTMLFORM_DM" title="HTMLFORM_DM">HTMLFORM_DM</a> <a href="#qualified_name" title="qualified_name">qualified_name</a> ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_command" title="dm_command">dm_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_logical_expression" data-rule="dm_logical_expression" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_if" class="used-by-link">dm_if</a>
+          <a href="#dm_if_expression" class="used-by-link">dm_if_expression</a>
+          <a href="#dm_repeat" class="used-by-link">dm_repeat</a>
+          <a href="#when_command" class="used-by-link">when_command</a>
+          <a href="#where_command" class="used-by-link">where_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_logical_expression">dm_logical_expression:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="595" height="213">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_logical_expression" xlink:title="dm_logical_expression">
+            <rect x="97" y="3" width="164" height="32"></rect>
+            <rect x="95" y="1" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="21">dm_logical_expression</text></a><rect x="281" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="279" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="289" y="21">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_relational_expression" xlink:title="dm_relational_expression">
+            <rect x="51" y="47" width="184" height="32"></rect>
+            <rect x="49" y="45" width="184" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">dm_relational_expression</text></a><rect x="71" y="91" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="89" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="109">NOT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_logical_expression" xlink:title="dm_logical_expression">
+            <rect x="71" y="135" width="164" height="32"></rect>
+            <rect x="69" y="133" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="153">dm_logical_expression</text></a><rect x="275" y="135" width="48" height="32" rx="10"></rect>
+         <rect x="273" y="133" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="283" y="153">AND</text>
+         <rect x="275" y="179" width="40" height="32" rx="10"></rect>
+         <rect x="273" y="177" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="283" y="197">OR</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_logical_expression" xlink:title="dm_logical_expression">
+            <rect x="383" y="91" width="164" height="32"></rect>
+            <rect x="381" y="89" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="391" y="109">dm_logical_expression</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m26 0 h10 m0 0 h10 m164 0 h10 m0 0 h10 m26 0 h10 m0 0 h240 m-536 0 h20 m516 0 h20 m-556 0 q10 0 10 10 m536 0 q0 -10 10 -10 m-546 10 v24 m536 0 v-24 m-536 24 q0 10 10 10 m516 0 q10 0 10 -10 m-526 10 h10 m184 0 h10 m0 0 h312 m-526 -10 v20 m536 0 v-20 m-536 20 v24 m536 0 v-24 m-536 24 q0 10 10 10 m516 0 q10 0 10 -10 m-506 10 h10 m48 0 h10 m0 0 h224 m-312 0 h20 m292 0 h20 m-332 0 q10 0 10 10 m312 0 q0 -10 10 -10 m-322 10 v24 m312 0 v-24 m-312 24 q0 10 10 10 m292 0 q10 0 10 -10 m-302 10 h10 m164 0 h10 m20 0 h10 m48 0 h10 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v24 m88 0 v-24 m-88 24 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m40 0 h10 m0 0 h8 m40 -88 h10 m164 0 h10 m23 -88 h-3"></svg:path>
+         <polygon points="585 17 593 13 593 21"></polygon>
+         <polygon points="585 17 577 13 577 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_logical_expression" title="dm_logical_expression">dm_logical_expression</a></div>
+               <div>         ::= '(' <a href="#dm_logical_expression" title="dm_logical_expression">dm_logical_expression</a> ')'</div>
+               <div>           | <a href="#dm_relational_expression" title="dm_relational_expression">dm_relational_expression</a></div>
+               <div>           | ( 'NOT' | <a href="#dm_logical_expression" title="dm_logical_expression">dm_logical_expression</a> ( 'AND' | 'OR' ) ) <a href="#dm_logical_expression" title="dm_logical_expression">dm_logical_expression</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_if" title="dm_if">dm_if</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_if_expression" title="dm_if_expression">dm_if_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_logical_expression" title="dm_logical_expression">dm_logical_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_repeat" title="dm_repeat">dm_repeat</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#when_command" title="when_command">when_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#where_command" title="where_command">where_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_relational_expression" data-rule="dm_relational_expression" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_logical_expression" class="used-by-link">dm_logical_expression</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_relational_expression">dm_relational_expression:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="965" height="1989">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="11 237 3 233 3 241"></polygon>
+         <polygon points="19 237 11 233 11 241"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_unary_expression" xlink:title="dm_unary_expression">
+            <rect x="53" y="223" width="160" height="32"></rect>
+            <rect x="51" y="221" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="61" y="241">dm_unary_expression</text></a><rect x="53" y="179" width="28" height="32" rx="10"></rect>
+         <rect x="51" y="177" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="61" y="197">*</text>
+         <rect x="53" y="135" width="28" height="32" rx="10"></rect>
+         <rect x="51" y="133" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="61" y="153">/</text>
+         <rect x="53" y="91" width="30" height="32" rx="10"></rect>
+         <rect x="51" y="89" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="61" y="109">+</text>
+         <rect x="53" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="51" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="61" y="65">-</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CONCAT" xlink:title="CONCAT">
+            <rect x="53" y="3" width="72" height="32"></rect>
+            <rect x="51" y="1" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="61" y="21">CONCAT</text></a><rect x="65" y="341" width="36" height="32" rx="10"></rect>
+         <rect x="63" y="339" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="73" y="359">IS</text>
+         <rect x="161" y="405" width="26" height="32" rx="10"></rect>
+         <rect x="159" y="403" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="169" y="423">-</text>
+         <rect x="227" y="373" width="48" height="32" rx="10"></rect>
+         <rect x="225" y="371" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="235" y="391">NOT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="65" y="449" width="36" height="32"></rect>
+            <rect x="63" y="447" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="73" y="467">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NE" xlink:title="NE">
+            <rect x="65" y="493" width="36" height="32"></rect>
+            <rect x="63" y="491" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="73" y="511">NE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IS_NOT" xlink:title="IS_NOT">
+            <rect x="65" y="537" width="66" height="32"></rect>
+            <rect x="63" y="535" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="73" y="555">IS_NOT</text></a><rect x="335" y="309" width="82" height="32" rx="10"></rect>
+         <rect x="333" y="307" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="343" y="327">MISSING</text>
+         <rect x="125" y="833" width="36" height="32" rx="10"></rect>
+         <rect x="123" y="831" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="133" y="851">IS</text>
+         <rect x="125" y="877" width="48" height="32" rx="10"></rect>
+         <rect x="123" y="875" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="133" y="895">NOT</text>
+         <rect x="233" y="865" width="26" height="32" rx="10"></rect>
+         <rect x="231" y="863" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="241" y="883">-</text>
+         <rect x="319" y="801" width="60" height="32" rx="10"></rect>
+         <rect x="317" y="799" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="327" y="819">FROM</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IS_FROM" xlink:title="IS_FROM">
+            <rect x="85" y="921" width="76" height="32"></rect>
+            <rect x="83" y="919" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="93" y="939">IS_FROM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NOT_FROM" xlink:title="NOT_FROM">
+            <rect x="85" y="965" width="88" height="32"></rect>
+            <rect x="83" y="963" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="93" y="983">NOT_FROM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_unary_expression" xlink:title="dm_unary_expression">
+            <rect x="439" y="801" width="160" height="32"></rect>
+            <rect x="437" y="799" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="447" y="819">dm_unary_expression</text></a><rect x="439" y="757" width="28" height="32" rx="10"></rect>
+         <rect x="437" y="755" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="447" y="775">*</text>
+         <rect x="439" y="713" width="28" height="32" rx="10"></rect>
+         <rect x="437" y="711" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="447" y="731">/</text>
+         <rect x="439" y="669" width="30" height="32" rx="10"></rect>
+         <rect x="437" y="667" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="447" y="687">+</text>
+         <rect x="439" y="625" width="26" height="32" rx="10"></rect>
+         <rect x="437" y="623" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="447" y="643">-</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CONCAT" xlink:title="CONCAT">
+            <rect x="439" y="581" width="72" height="32"></rect>
+            <rect x="437" y="579" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="447" y="599">CONCAT</text></a><rect x="639" y="801" width="38" height="32" rx="10"></rect>
+         <rect x="637" y="799" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="647" y="819">TO</text>
+         <rect x="85" y="1251" width="90" height="32" rx="10"></rect>
+         <rect x="83" y="1249" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1269">INCLUDES</text>
+         <rect x="85" y="1295" width="90" height="32" rx="10"></rect>
+         <rect x="83" y="1293" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1313">EXCLUDES</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_unary_expression" xlink:title="dm_unary_expression">
+            <rect x="275" y="1251" width="160" height="32"></rect>
+            <rect x="273" y="1249" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="283" y="1269">dm_unary_expression</text></a><rect x="275" y="1207" width="28" height="32" rx="10"></rect>
+         <rect x="273" y="1205" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="283" y="1225">*</text>
+         <rect x="275" y="1163" width="28" height="32" rx="10"></rect>
+         <rect x="273" y="1161" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="283" y="1181">/</text>
+         <rect x="275" y="1119" width="30" height="32" rx="10"></rect>
+         <rect x="273" y="1117" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="283" y="1137">+</text>
+         <rect x="275" y="1075" width="26" height="32" rx="10"></rect>
+         <rect x="273" y="1073" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="283" y="1093">-</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CONCAT" xlink:title="CONCAT">
+            <rect x="275" y="1031" width="72" height="32"></rect>
+            <rect x="273" y="1029" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="283" y="1049">CONCAT</text></a><rect x="475" y="1251" width="48" height="32" rx="10"></rect>
+         <rect x="473" y="1249" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="483" y="1269">AND</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_relational_op" xlink:title="dm_relational_op">
+            <rect x="65" y="1581" width="132" height="32"></rect>
+            <rect x="63" y="1579" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="73" y="1599">dm_relational_op</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_unary_expression" xlink:title="dm_unary_expression">
+            <rect x="277" y="1581" width="160" height="32"></rect>
+            <rect x="275" y="1579" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="285" y="1599">dm_unary_expression</text></a><rect x="277" y="1537" width="28" height="32" rx="10"></rect>
+         <rect x="275" y="1535" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="285" y="1555">*</text>
+         <rect x="277" y="1493" width="28" height="32" rx="10"></rect>
+         <rect x="275" y="1491" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="285" y="1511">/</text>
+         <rect x="277" y="1449" width="30" height="32" rx="10"></rect>
+         <rect x="275" y="1447" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="285" y="1467">+</text>
+         <rect x="277" y="1405" width="26" height="32" rx="10"></rect>
+         <rect x="275" y="1403" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="285" y="1423">-</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CONCAT" xlink:title="CONCAT">
+            <rect x="277" y="1361" width="72" height="32"></rect>
+            <rect x="275" y="1359" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="285" y="1379">CONCAT</text></a><rect x="477" y="1581" width="40" height="32" rx="10"></rect>
+         <rect x="475" y="1579" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="485" y="1599">OR</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_unary_expression" xlink:title="dm_unary_expression">
+            <rect x="737" y="801" width="160" height="32"></rect>
+            <rect x="735" y="799" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="745" y="819">dm_unary_expression</text></a><rect x="737" y="757" width="28" height="32" rx="10"></rect>
+         <rect x="735" y="755" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="745" y="775">*</text>
+         <rect x="737" y="713" width="28" height="32" rx="10"></rect>
+         <rect x="735" y="711" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="745" y="731">/</text>
+         <rect x="737" y="669" width="30" height="32" rx="10"></rect>
+         <rect x="735" y="667" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="745" y="687">+</text>
+         <rect x="737" y="625" width="26" height="32" rx="10"></rect>
+         <rect x="735" y="623" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="745" y="643">-</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CONCAT" xlink:title="CONCAT">
+            <rect x="737" y="581" width="72" height="32"></rect>
+            <rect x="735" y="579" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="745" y="599">CONCAT</text></a><rect x="45" y="1647" width="36" height="32" rx="10"></rect>
+         <rect x="43" y="1645" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="1665">IN</text>
+         <rect x="121" y="1647" width="50" height="32" rx="10"></rect>
+         <rect x="119" y="1645" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="129" y="1665">FILE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="191" y="1647" width="118" height="32"></rect>
+            <rect x="189" y="1645" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="199" y="1665">qualified_name</text></a><rect x="121" y="1955" width="26" height="32" rx="10"></rect>
+         <rect x="119" y="1953" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="129" y="1973">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_unary_expression" xlink:title="dm_unary_expression">
+            <rect x="187" y="1955" width="160" height="32"></rect>
+            <rect x="185" y="1953" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="195" y="1973">dm_unary_expression</text></a><rect x="187" y="1911" width="28" height="32" rx="10"></rect>
+         <rect x="185" y="1909" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="195" y="1929">*</text>
+         <rect x="187" y="1867" width="28" height="32" rx="10"></rect>
+         <rect x="185" y="1865" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="195" y="1885">/</text>
+         <rect x="187" y="1823" width="30" height="32" rx="10"></rect>
+         <rect x="185" y="1821" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="195" y="1841">+</text>
+         <rect x="187" y="1779" width="26" height="32" rx="10"></rect>
+         <rect x="185" y="1777" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="195" y="1797">-</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CONCAT" xlink:title="CONCAT">
+            <rect x="187" y="1735" width="72" height="32"></rect>
+            <rect x="185" y="1733" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="195" y="1753">CONCAT</text></a><rect x="187" y="1691" width="24" height="32" rx="10"></rect>
+         <rect x="185" y="1689" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="195" y="1709">,</text>
+         <rect x="387" y="1955" width="26" height="32" rx="10"></rect>
+         <rect x="385" y="1953" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="395" y="1973">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m19 237 h2 m20 0 h10 m160 0 h10 m-200 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m180 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-180 0 h10 m28 0 h10 m0 0 h132 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m28 0 h10 m0 0 h132 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m30 0 h10 m0 0 h130 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m26 0 h10 m0 0 h134 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m72 0 h10 m0 0 h88 m22 220 l2 0 m2 0 l2 0 m2 0 l2 0 m-252 54 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h882 m-912 0 h20 m892 0 h20 m-932 0 q10 0 10 10 m912 0 q0 -10 10 -10 m-922 10 v12 m912 0 v-12 m-912 12 q0 10 10 10 m892 0 q10 0 10 -10 m-882 10 h10 m0 0 h240 m-270 0 h20 m250 0 h20 m-290 0 q10 0 10 10 m270 0 q0 -10 10 -10 m-280 10 v12 m270 0 v-12 m-270 12 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m36 0 h10 m20 0 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-144 10 h10 m0 0 h36 m-66 0 h20 m46 0 h20 m-86 0 q10 0 10 10 m66 0 q0 -10 10 -10 m-76 10 v12 m66 0 v-12 m-66 12 q0 10 10 10 m46 0 q10 0 10 -10 m-56 10 h10 m26 0 h10 m20 -32 h10 m48 0 h10 m-240 -42 v20 m270 0 v-20 m-270 20 v88 m270 0 v-88 m-270 88 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m36 0 h10 m0 0 h194 m-260 -10 v20 m270 0 v-20 m-270 20 v24 m270 0 v-24 m-270 24 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m36 0 h10 m0 0 h194 m-260 -10 v20 m270 0 v-20 m-270 20 v24 m270 0 v-24 m-270 24 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m66 0 h10 m0 0 h164 m20 -228 h10 m82 0 h10 m0 0 h500 m-902 -10 v20 m912 0 v-20 m-912 20 v472 m912 0 v-472 m-912 472 q0 10 10 10 m892 0 q10 0 10 -10 m-842 10 h10 m0 0 h184 m-214 0 h20 m194 0 h20 m-234 0 q10 0 10 10 m214 0 q0 -10 10 -10 m-224 10 v12 m214 0 v-12 m-214 12 q0 10 10 10 m194 0 q10 0 10 -10 m-184 10 h10 m36 0 h10 m0 0 h12 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v24 m88 0 v-24 m-88 24 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m40 -44 h10 m0 0 h36 m-66 0 h20 m46 0 h20 m-86 0 q10 0 10 10 m66 0 q0 -10 10 -10 m-76 10 v12 m66 0 v-12 m-66 12 q0 10 10 10 m46 0 q10 0 10 -10 m-56 10 h10 m26 0 h10 m40 -64 h10 m60 0 h10 m-334 0 h20 m314 0 h20 m-354 0 q10 0 10 10 m334 0 q0 -10 10 -10 m-344 10 v100 m334 0 v-100 m-334 100 q0 10 10 10 m314 0 q10 0 10 -10 m-324 10 h10 m76 0 h10 m0 0 h218 m-324 -10 v20 m334 0 v-20 m-334 20 v24 m334 0 v-24 m-334 24 q0 10 10 10 m314 0 q10 0 10 -10 m-324 10 h10 m88 0 h10 m0 0 h206 m40 -164 h10 m160 0 h10 m-200 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m180 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-180 0 h10 m28 0 h10 m0 0 h132 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m28 0 h10 m0 0 h132 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m30 0 h10 m0 0 h130 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m26 0 h10 m0 0 h134 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m72 0 h10 m0 0 h88 m20 220 h10 m38 0 h10 m-652 0 h20 m632 0 h20 m-672 0 q10 0 10 10 m652 0 q0 -10 10 -10 m-662 10 v430 m652 0 v-430 m-652 430 q0 10 10 10 m632 0 q10 0 10 -10 m-622 10 h10 m90 0 h10 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m80 -44 h10 m160 0 h10 m-200 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m180 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-180 0 h10 m28 0 h10 m0 0 h132 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m28 0 h10 m0 0 h132 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m30 0 h10 m0 0 h130 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m26 0 h10 m0 0 h134 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m72 0 h10 m0 0 h88 m20 220 h10 m48 0 h10 m-308 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -232 q0 -10 10 -10 m288 252 l20 0 m-20 0 q10 0 10 -10 l0 -232 q0 -10 -10 -10 m-288 0 h10 m0 0 h278 m-328 252 h20 m328 0 h20 m-368 0 q10 0 10 10 m348 0 q0 -10 10 -10 m-358 10 v14 m348 0 v-14 m-348 14 q0 10 10 10 m328 0 q10 0 10 -10 m-338 10 h10 m0 0 h318 m20 -34 h114 m-642 -10 v20 m652 0 v-20 m-652 20 v310 m652 0 v-310 m-652 310 q0 10 10 10 m632 0 q10 0 10 -10 m-642 10 h10 m132 0 h10 m60 0 h10 m160 0 h10 m-200 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m180 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-180 0 h10 m28 0 h10 m0 0 h132 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m28 0 h10 m0 0 h132 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m30 0 h10 m0 0 h130 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m26 0 h10 m0 0 h134 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m72 0 h10 m0 0 h88 m20 220 h10 m40 0 h10 m-300 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -232 q0 -10 10 -10 m280 252 l20 0 m-20 0 q10 0 10 -10 l0 -232 q0 -10 -10 -10 m-280 0 h10 m0 0 h270 m-320 252 h20 m320 0 h20 m-360 0 q10 0 10 10 m340 0 q0 -10 10 -10 m-350 10 v14 m340 0 v-14 m-340 14 q0 10 10 10 m320 0 q10 0 10 -10 m-330 10 h10 m0 0 h310 m20 -34 h120 m40 -780 h10 m160 0 h10 m-200 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m180 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-180 0 h10 m28 0 h10 m0 0 h132 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m28 0 h10 m0 0 h132 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m30 0 h10 m0 0 h130 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m26 0 h10 m0 0 h134 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m72 0 h10 m0 0 h88 m-882 210 v20 m912 0 v-20 m-912 20 v826 m912 0 v-826 m-912 826 q0 10 10 10 m892 0 q10 0 10 -10 m-902 10 h10 m36 0 h10 m20 0 h10 m50 0 h10 m0 0 h10 m118 0 h10 m0 0 h104 m-332 0 h20 m312 0 h20 m-352 0 q10 0 10 10 m332 0 q0 -10 10 -10 m-342 10 v288 m332 0 v-288 m-332 288 q0 10 10 10 m312 0 q10 0 10 -10 m-322 10 h10 m26 0 h10 m20 0 h10 m160 0 h10 m-200 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m180 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-180 0 h10 m28 0 h10 m0 0 h132 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m28 0 h10 m0 0 h132 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m30 0 h10 m0 0 h130 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m26 0 h10 m0 0 h134 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m72 0 h10 m0 0 h88 m-190 10 l0 -44 q0 -10 10 -10 m190 54 l0 -44 q0 -10 -10 -10 m-180 0 h10 m24 0 h10 m0 0 h136 m20 264 h10 m26 0 h10 m20 -308 h484 m23 -1370 h-3"></svg:path>
+         <polygon points="955 291 963 287 963 295"></polygon>
+         <polygon points="955 291 947 287 947 295"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_relational_expression" title="dm_relational_expression">dm_relational_expression</a></div>
+               <div>         ::= <a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a> ( ( '*' | '/' | '+' | '-' | <a href="#CONCAT" title="CONCAT">CONCAT</a> ) <a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a> )* ( ( 'IS' ( '-'? 'NOT' )? | <a href="#EQ" title="EQ">EQ</a> | <a href="#NE" title="NE">NE</a> | <a href="#IS_NOT" title="IS_NOT">IS_NOT</a> )? 'MISSING' | ( ( ( ( 'IS' | 'NOT' ) '-'? )? 'FROM' | <a href="#IS_FROM" title="IS_FROM">IS_FROM</a> | <a href="#NOT_FROM" title="NOT_FROM">NOT_FROM</a> ) <a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a> ( ( '*' | '/' | '+' | '-' | <a href="#CONCAT" title="CONCAT">CONCAT</a> ) <a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a> )* 'TO' | ( 'INCLUDES' | 'EXCLUDES' ) ( <a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a> ( ( '*' | '/' | '+' | '-' | <a href="#CONCAT" title="CONCAT">CONCAT</a> ) <a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a> )* 'AND' )* | <a href="#dm_relational_op" title="dm_relational_op">dm_relational_op</a> ( <a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a> ( ( '*' | '/' | '+' | '-' | <a href="#CONCAT" title="CONCAT">CONCAT</a> ) <a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a> )* 'OR' )* ) <a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a> ( ( '*' | '/' | '+' | '-' | <a href="#CONCAT" title="CONCAT">CONCAT</a> ) <a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a> )* | 'IN' ( 'FILE' <a href="#qualified_name" title="qualified_name">qualified_name</a> | '(' <a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a> ( ( '*' | '/' | '+' | '-' | <a href="#CONCAT" title="CONCAT">CONCAT</a> | ',' ) <a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a> )* ')' ) )?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_logical_expression" title="dm_logical_expression">dm_logical_expression</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_relational_op" data-rule="dm_relational_op" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_expression" class="used-by-link">dm_relational_expression</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_relational_op">dm_relational_op:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="521" height="881">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="51" y="3" width="36" height="32"></rect>
+            <rect x="49" y="1" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NE" xlink:title="NE">
+            <rect x="51" y="47" width="36" height="32"></rect>
+            <rect x="49" y="45" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">NE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#LE" xlink:title="LE">
+            <rect x="51" y="91" width="34" height="32"></rect>
+            <rect x="49" y="89" width="34" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">LE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#GE" xlink:title="GE">
+            <rect x="51" y="135" width="36" height="32"></rect>
+            <rect x="49" y="133" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">GE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#LT" xlink:title="LT">
+            <rect x="51" y="179" width="34" height="32"></rect>
+            <rect x="49" y="177" width="34" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">LT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#GT" xlink:title="GT">
+            <rect x="51" y="223" width="36" height="32"></rect>
+            <rect x="49" y="221" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="241">GT</text></a><rect x="51" y="267" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">CONTAINS</text>
+         <rect x="51" y="311" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">OMITS</text>
+         <rect x="71" y="387" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="385" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="405">NOT</text>
+         <rect x="159" y="419" width="26" height="32" rx="10"></rect>
+         <rect x="157" y="417" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="437">-</text>
+         <rect x="245" y="355" width="52" height="32" rx="10"></rect>
+         <rect x="243" y="353" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="253" y="373">LIKE</text>
+         <rect x="51" y="463" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="461" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="481">EXCEEDS</text>
+         <rect x="51" y="507" width="36" height="32" rx="10"></rect>
+         <rect x="49" y="505" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="525">IS</text>
+         <rect x="147" y="571" width="26" height="32" rx="10"></rect>
+         <rect x="145" y="569" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="155" y="589">-</text>
+         <rect x="233" y="539" width="48" height="32" rx="10"></rect>
+         <rect x="231" y="537" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="241" y="557">NOT</text>
+         <rect x="253" y="583" width="54" height="32" rx="10"></rect>
+         <rect x="251" y="581" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="601">LESS</text>
+         <rect x="253" y="627" width="60" height="32" rx="10"></rect>
+         <rect x="251" y="625" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="645">MORE</text>
+         <rect x="253" y="671" width="82" height="32" rx="10"></rect>
+         <rect x="251" y="669" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="689">GREATER</text>
+         <rect x="375" y="583" width="58" height="32" rx="10"></rect>
+         <rect x="373" y="581" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="383" y="601">THAN</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IS_NOT" xlink:title="IS_NOT">
+            <rect x="51" y="715" width="66" height="32"></rect>
+            <rect x="49" y="713" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="733">IS_NOT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IS_LESS_THAN" xlink:title="IS_LESS_THAN">
+            <rect x="51" y="759" width="114" height="32"></rect>
+            <rect x="49" y="757" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="777">IS_LESS_THAN</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IS_MORE_THAN" xlink:title="IS_MORE_THAN">
+            <rect x="51" y="803" width="118" height="32"></rect>
+            <rect x="49" y="801" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="821">IS_MORE_THAN</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IS_GREATER_THAN" xlink:title="IS_GREATER_THAN">
+            <rect x="51" y="847" width="138" height="32"></rect>
+            <rect x="49" y="845" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="865">IS_GREATER_THAN</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m36 0 h10 m0 0 h386 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m36 0 h10 m0 0 h386 m-452 -10 v20 m462 0 v-20 m-462 20 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m34 0 h10 m0 0 h388 m-452 -10 v20 m462 0 v-20 m-462 20 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m36 0 h10 m0 0 h386 m-452 -10 v20 m462 0 v-20 m-462 20 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m34 0 h10 m0 0 h388 m-452 -10 v20 m462 0 v-20 m-462 20 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m36 0 h10 m0 0 h386 m-452 -10 v20 m462 0 v-20 m-462 20 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m92 0 h10 m0 0 h330 m-452 -10 v20 m462 0 v-20 m-462 20 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m66 0 h10 m0 0 h356 m-452 -10 v20 m462 0 v-20 m-462 20 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-432 10 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m48 0 h10 m20 0 h10 m0 0 h36 m-66 0 h20 m46 0 h20 m-86 0 q10 0 10 10 m66 0 q0 -10 10 -10 m-76 10 v12 m66 0 v-12 m-66 12 q0 10 10 10 m46 0 q10 0 10 -10 m-56 10 h10 m26 0 h10 m40 -64 h10 m52 0 h10 m0 0 h176 m-452 -10 v20 m462 0 v-20 m-462 20 v88 m462 0 v-88 m-462 88 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m82 0 h10 m0 0 h340 m-452 -10 v20 m462 0 v-20 m-462 20 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m36 0 h10 m20 0 h10 m0 0 h336 m-366 0 h20 m346 0 h20 m-386 0 q10 0 10 10 m366 0 q0 -10 10 -10 m-376 10 v12 m366 0 v-12 m-366 12 q0 10 10 10 m346 0 q10 0 10 -10 m-336 10 h10 m0 0 h36 m-66 0 h20 m46 0 h20 m-86 0 q10 0 10 10 m66 0 q0 -10 10 -10 m-76 10 v12 m66 0 v-12 m-66 12 q0 10 10 10 m46 0 q10 0 10 -10 m-56 10 h10 m26 0 h10 m40 -32 h10 m48 0 h10 m0 0 h152 m-240 0 h20 m220 0 h20 m-260 0 q10 0 10 10 m240 0 q0 -10 10 -10 m-250 10 v24 m240 0 v-24 m-240 24 q0 10 10 10 m220 0 q10 0 10 -10 m-210 10 h10 m54 0 h10 m0 0 h28 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m60 0 h10 m0 0 h22 m-112 -10 v20 m122 0 v-20 m-122 20 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m20 -88 h10 m58 0 h10 m-412 -86 v20 m462 0 v-20 m-462 20 v188 m462 0 v-188 m-462 188 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m66 0 h10 m0 0 h356 m-452 -10 v20 m462 0 v-20 m-462 20 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m114 0 h10 m0 0 h308 m-452 -10 v20 m462 0 v-20 m-462 20 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m118 0 h10 m0 0 h304 m-452 -10 v20 m462 0 v-20 m-462 20 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m138 0 h10 m0 0 h284 m23 -844 h-3"></svg:path>
+         <polygon points="511 17 519 13 519 21"></polygon>
+         <polygon points="511 17 503 13 503 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_relational_op" title="dm_relational_op">dm_relational_op</a></div>
+               <div>         ::= <a href="#EQ" title="EQ">EQ</a></div>
+               <div>           | <a href="#NE" title="NE">NE</a></div>
+               <div>           | <a href="#LE" title="LE">LE</a></div>
+               <div>           | <a href="#GE" title="GE">GE</a></div>
+               <div>           | <a href="#LT" title="LT">LT</a></div>
+               <div>           | <a href="#GT" title="GT">GT</a></div>
+               <div>           | 'CONTAINS'</div>
+               <div>           | 'OMITS'</div>
+               <div>           | ( 'NOT' '-'? )? 'LIKE'</div>
+               <div>           | 'EXCEEDS'</div>
+               <div>           | 'IS' ( '-'? ( 'NOT' | ( 'LESS' | 'MORE' | 'GREATER' ) 'THAN' ) )?</div>
+               <div>           | <a href="#IS_NOT" title="IS_NOT">IS_NOT</a></div>
+               <div>           | <a href="#IS_LESS_THAN" title="IS_LESS_THAN">IS_LESS_THAN</a></div>
+               <div>           | <a href="#IS_MORE_THAN" title="IS_MORE_THAN">IS_MORE_THAN</a></div>
+               <div>           | <a href="#IS_GREATER_THAN" title="IS_GREATER_THAN">IS_GREATER_THAN</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_expression" title="dm_relational_expression">dm_relational_expression</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_unary_expression" data-rule="dm_unary_expression" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_expression" class="used-by-link">dm_relational_expression</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_unary_expression">dm_unary_expression:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="655" height="449">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 95 1 91 1 99"></polygon>
+         <polygon points="17 95 9 91 9 99"></polygon>
+         <rect x="51" y="47" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">+</text>
+         <rect x="51" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">-</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="141" y="81" width="72" height="32"></rect>
+            <rect x="139" y="79" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="149" y="99">NUMBER</text></a><rect x="253" y="113" width="24" height="32" rx="10"></rect>
+         <rect x="251" y="111" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="131">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="297" y="113" width="72" height="32"></rect>
+            <rect x="295" y="111" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="305" y="131">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="141" y="157" width="144" height="32"></rect>
+            <rect x="139" y="155" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="149" y="175">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="141" y="245" width="118" height="32"></rect>
+            <rect x="139" y="243" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="149" y="263">qualified_name</text></a><rect x="299" y="245" width="26" height="32" rx="10"></rect>
+         <rect x="297" y="243" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="307" y="263">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="385" y="245" width="116" height="32"></rect>
+            <rect x="383" y="243" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="393" y="263">dm_expression</text></a><rect x="385" y="201" width="24" height="32" rx="10"></rect>
+         <rect x="383" y="199" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="393" y="219">,</text>
+         <rect x="561" y="245" width="26" height="32" rx="10"></rect>
+         <rect x="559" y="243" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="569" y="263">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="141" y="327" width="94" height="32"></rect>
+            <rect x="139" y="325" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="149" y="345">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="141" y="371" width="66" height="32"></rect>
+            <rect x="139" y="369" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="149" y="389">STRING</text></a><rect x="141" y="415" width="26" height="32" rx="10"></rect>
+         <rect x="139" y="413" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="149" y="433">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="187" y="415" width="116" height="32"></rect>
+            <rect x="185" y="413" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="195" y="433">dm_expression</text></a><rect x="323" y="415" width="26" height="32" rx="10"></rect>
+         <rect x="321" y="413" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="331" y="433">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 95 h2 m20 0 h10 m0 0 h40 m-70 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m50 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-50 0 h10 m30 0 h10 m-60 10 l0 -44 q0 -10 10 -10 m60 54 l0 -44 q0 -10 -10 -10 m-50 0 h10 m26 0 h10 m0 0 h4 m40 78 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m23 -334 h-3"></svg:path>
+         <polygon points="645 95 653 91 653 99"></polygon>
+         <polygon points="645 95 637 91 637 99"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</a></div>
+               <div>         ::= ( '+' | '-' )* ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' )</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_expression" title="dm_relational_expression">dm_relational_expression</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="decode_expression" data-rule="decode_expression" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_repeat" class="used-by-link">dm_repeat</a>
+          <a href="#dm_type" class="used-by-link">dm_type</a>
+          <a href="#dm_unary_expression" class="used-by-link">dm_unary_expression</a>
+          <a href="#dm_write" class="used-by-link">dm_write</a>
+          <a href="#show_command" class="used-by-link">show_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="decode_expression">decode_expression:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="1159" height="1219">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">DECODE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="147" y="3" width="72" height="32"></rect>
+            <rect x="145" y="1" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="155" y="21">NUMBER</text></a><rect x="259" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="257" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="267" y="53">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="303" y="35" width="72" height="32"></rect>
+            <rect x="301" y="33" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="311" y="53">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="147" y="79" width="144" height="32"></rect>
+            <rect x="145" y="77" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="155" y="97">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="147" y="167" width="118" height="32"></rect>
+            <rect x="145" y="165" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="155" y="185">qualified_name</text></a><rect x="305" y="167" width="26" height="32" rx="10"></rect>
+         <rect x="303" y="165" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="313" y="185">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="391" y="167" width="116" height="32"></rect>
+            <rect x="389" y="165" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="399" y="185">dm_expression</text></a><rect x="391" y="123" width="24" height="32" rx="10"></rect>
+         <rect x="389" y="121" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="399" y="141">,</text>
+         <rect x="567" y="167" width="26" height="32" rx="10"></rect>
+         <rect x="565" y="165" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="575" y="185">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="147" y="249" width="94" height="32"></rect>
+            <rect x="145" y="247" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="155" y="267">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="147" y="293" width="66" height="32"></rect>
+            <rect x="145" y="291" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="155" y="311">STRING</text></a><rect x="147" y="337" width="26" height="32" rx="10"></rect>
+         <rect x="145" y="335" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="155" y="355">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="193" y="337" width="116" height="32"></rect>
+            <rect x="191" y="335" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="201" y="355">dm_expression</text></a><rect x="329" y="337" width="26" height="32" rx="10"></rect>
+         <rect x="327" y="335" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="337" y="355">)</text>
+         <rect x="653" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="651" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="661" y="21">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="85" y="419" width="72" height="32"></rect>
+            <rect x="83" y="417" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="93" y="437">NUMBER</text></a><rect x="197" y="451" width="24" height="32" rx="10"></rect>
+         <rect x="195" y="449" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="205" y="469">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="241" y="451" width="72" height="32"></rect>
+            <rect x="239" y="449" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="249" y="469">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="85" y="495" width="144" height="32"></rect>
+            <rect x="83" y="493" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="93" y="513">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="85" y="583" width="118" height="32"></rect>
+            <rect x="83" y="581" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="93" y="601">qualified_name</text></a><rect x="243" y="583" width="26" height="32" rx="10"></rect>
+         <rect x="241" y="581" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="251" y="601">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="329" y="583" width="116" height="32"></rect>
+            <rect x="327" y="581" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="337" y="601">dm_expression</text></a><rect x="329" y="539" width="24" height="32" rx="10"></rect>
+         <rect x="327" y="537" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="337" y="557">,</text>
+         <rect x="505" y="583" width="26" height="32" rx="10"></rect>
+         <rect x="503" y="581" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="513" y="601">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="85" y="665" width="94" height="32"></rect>
+            <rect x="83" y="663" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="93" y="683">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="85" y="709" width="66" height="32"></rect>
+            <rect x="83" y="707" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="93" y="727">STRING</text></a><rect x="85" y="753" width="26" height="32" rx="10"></rect>
+         <rect x="83" y="751" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="771">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="131" y="753" width="116" height="32"></rect>
+            <rect x="129" y="751" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="139" y="771">dm_expression</text></a><rect x="267" y="753" width="26" height="32" rx="10"></rect>
+         <rect x="265" y="751" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="275" y="771">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="611" y="419" width="72" height="32"></rect>
+            <rect x="609" y="417" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="619" y="437">NUMBER</text></a><rect x="723" y="451" width="24" height="32" rx="10"></rect>
+         <rect x="721" y="449" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="731" y="469">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="767" y="451" width="72" height="32"></rect>
+            <rect x="765" y="449" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="775" y="469">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="611" y="495" width="144" height="32"></rect>
+            <rect x="609" y="493" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="619" y="513">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="611" y="583" width="118" height="32"></rect>
+            <rect x="609" y="581" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="619" y="601">qualified_name</text></a><rect x="769" y="583" width="26" height="32" rx="10"></rect>
+         <rect x="767" y="581" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="777" y="601">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="855" y="583" width="116" height="32"></rect>
+            <rect x="853" y="581" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="863" y="601">dm_expression</text></a><rect x="855" y="539" width="24" height="32" rx="10"></rect>
+         <rect x="853" y="537" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="863" y="557">,</text>
+         <rect x="1031" y="583" width="26" height="32" rx="10"></rect>
+         <rect x="1029" y="581" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1039" y="601">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="611" y="665" width="94" height="32"></rect>
+            <rect x="609" y="663" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="619" y="683">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="611" y="709" width="66" height="32"></rect>
+            <rect x="609" y="707" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="619" y="727">STRING</text></a><rect x="611" y="753" width="26" height="32" rx="10"></rect>
+         <rect x="609" y="751" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="619" y="771">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="657" y="753" width="116" height="32"></rect>
+            <rect x="655" y="751" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="665" y="771">dm_expression</text></a><rect x="793" y="753" width="26" height="32" rx="10"></rect>
+         <rect x="791" y="751" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="801" y="771">)</text>
+         <rect x="487" y="835" width="52" height="32" rx="10"></rect>
+         <rect x="485" y="833" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="495" y="853">ELSE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="579" y="835" width="72" height="32"></rect>
+            <rect x="577" y="833" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="587" y="853">NUMBER</text></a><rect x="691" y="867" width="24" height="32" rx="10"></rect>
+         <rect x="689" y="865" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="699" y="885">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="735" y="867" width="72" height="32"></rect>
+            <rect x="733" y="865" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="743" y="885">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="579" y="911" width="144" height="32"></rect>
+            <rect x="577" y="909" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="587" y="929">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="579" y="999" width="118" height="32"></rect>
+            <rect x="577" y="997" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="587" y="1017">qualified_name</text></a><rect x="737" y="999" width="26" height="32" rx="10"></rect>
+         <rect x="735" y="997" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="745" y="1017">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="823" y="999" width="116" height="32"></rect>
+            <rect x="821" y="997" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="831" y="1017">dm_expression</text></a><rect x="823" y="955" width="24" height="32" rx="10"></rect>
+         <rect x="821" y="953" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="831" y="973">,</text>
+         <rect x="999" y="999" width="26" height="32" rx="10"></rect>
+         <rect x="997" y="997" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1007" y="1017">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="579" y="1081" width="94" height="32"></rect>
+            <rect x="577" y="1079" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="587" y="1099">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="579" y="1125" width="66" height="32"></rect>
+            <rect x="577" y="1123" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="587" y="1143">STRING</text></a><rect x="579" y="1169" width="26" height="32" rx="10"></rect>
+         <rect x="577" y="1167" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="587" y="1187">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="625" y="1169" width="116" height="32"></rect>
+            <rect x="623" y="1167" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="633" y="1187">dm_expression</text></a><rect x="761" y="1169" width="26" height="32" rx="10"></rect>
+         <rect x="759" y="1167" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="769" y="1187">)</text>
+         <rect x="1105" y="835" width="26" height="32" rx="10"></rect>
+         <rect x="1103" y="833" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1113" y="853">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m20 0 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m20 -334 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-698 416 l2 0 m2 0 l2 0 m2 0 l2 0 m62 0 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m40 -334 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m-1052 -334 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m1052 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-1052 0 h10 m0 0 h1042 m-1092 32 h20 m1092 0 h20 m-1132 0 q10 0 10 10 m1112 0 q0 -10 10 -10 m-1122 10 v348 m1112 0 v-348 m-1112 348 q0 10 10 10 m1092 0 q10 0 10 -10 m-1102 10 h10 m0 0 h1082 m22 -368 l2 0 m2 0 l2 0 m2 0 l2 0 m-714 416 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m52 0 h10 m20 0 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m-598 -334 h20 m598 0 h20 m-638 0 q10 0 10 10 m618 0 q0 -10 10 -10 m-628 10 v348 m618 0 v-348 m-618 348 q0 10 10 10 m598 0 q10 0 10 -10 m-608 10 h10 m0 0 h588 m20 -368 h10 m26 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="1149 849 1157 845 1157 853"></polygon>
+         <polygon points="1149 849 1141 845 1141 853"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#decode_expression" title="decode_expression">decode_expression</a></div>
+               <div>         ::= 'DECODE' ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' ) '(' ( ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' ) ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' ) )* ( 'ELSE' ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' ) )? ')'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#decode_expression" title="decode_expression">decode_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_repeat" title="dm_repeat">dm_repeat</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_type" title="dm_type">dm_type</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_write" title="dm_write">dm_write</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#show_command" title="show_command">show_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="field_list" data-rule="field_list" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#verb_command" class="used-by-link">verb_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="field_list">field_list:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="333" height="135">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 83 1 79 1 87"></polygon>
+         <polygon points="17 83 9 79 9 87"></polygon>
+         <rect x="51" y="101" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="99" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="119">THE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#field_or_prefixed" xlink:title="field_or_prefixed">
+            <rect x="157" y="69" width="128" height="32"></rect>
+            <rect x="155" y="67" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="165" y="87">field_or_prefixed</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#field_separator" xlink:title="field_separator">
+            <rect x="157" y="3" width="116" height="32"></rect>
+            <rect x="155" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="165" y="21">field_separator</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 83 h2 m20 0 h10 m0 0 h56 m-86 0 h20 m66 0 h20 m-106 0 q10 0 10 10 m86 0 q0 -10 10 -10 m-96 10 v12 m86 0 v-12 m-86 12 q0 10 10 10 m66 0 q10 0 10 -10 m-76 10 h10 m46 0 h10 m40 -32 h10 m128 0 h10 m-168 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m148 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-148 0 h10 m0 0 h138 m-158 10 l0 -34 q0 -10 10 -10 m158 44 l0 -34 q0 -10 -10 -10 m-148 0 h10 m116 0 h10 m0 0 h12 m23 66 h-3"></svg:path>
+         <polygon points="323 83 331 79 331 87"></polygon>
+         <polygon points="323 83 315 79 315 87"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#field_list" title="field_list">field_list</a></div>
+               <div>         ::= 'THE'? <a href="#field_or_prefixed" title="field_or_prefixed">field_or_prefixed</a> ( <a href="#field_separator" title="field_separator">field_separator</a>? <a href="#field_or_prefixed" title="field_or_prefixed">field_or_prefixed</a> )*</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#verb_command" title="verb_command">verb_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="field_separator" data-rule="field_separator" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#field_list" class="used-by-link">field_list</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="field_separator">field_separator:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="253" height="157">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <rect x="51" y="47" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">AND</text>
+         <rect x="139" y="79" width="46" height="32" rx="10"></rect>
+         <rect x="137" y="77" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="97">THE</text>
+         <rect x="51" y="123" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="121" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="141">THE</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m24 0 h10 m0 0 h130 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m48 0 h10 m20 0 h10 m0 0 h56 m-86 0 h20 m66 0 h20 m-106 0 q10 0 10 10 m86 0 q0 -10 10 -10 m-96 10 v12 m86 0 v-12 m-86 12 q0 10 10 10 m66 0 q10 0 10 -10 m-76 10 h10 m46 0 h10 m-164 -42 v20 m194 0 v-20 m-194 20 v56 m194 0 v-56 m-194 56 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m46 0 h10 m0 0 h108 m23 -120 h-3"></svg:path>
+         <polygon points="243 17 251 13 251 21"></polygon>
+         <polygon points="243 17 235 13 235 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#field_separator" title="field_separator">field_separator</a></div>
+               <div>         ::= ','</div>
+               <div>           | 'AND' 'THE'?</div>
+               <div>           | 'THE'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#field_list" title="field_list">field_list</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="field_or_prefixed" data-rule="field_or_prefixed" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#field_list" class="used-by-link">field_list</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="field_or_prefixed">field_or_prefixed:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="345" height="729">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <rect x="91" y="19" width="46" height="32" rx="10"></rect>
+         <rect x="89" y="17" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="37">AVE</text>
+         <rect x="91" y="63" width="48" height="32" rx="10"></rect>
+         <rect x="89" y="61" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="81">MIN</text>
+         <rect x="91" y="107" width="50" height="32" rx="10"></rect>
+         <rect x="89" y="105" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="125">MAX</text>
+         <rect x="91" y="151" width="46" height="32" rx="10"></rect>
+         <rect x="89" y="149" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="169">CNT</text>
+         <rect x="91" y="195" width="44" height="32" rx="10"></rect>
+         <rect x="89" y="193" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="213">FST</text>
+         <rect x="91" y="239" width="44" height="32" rx="10"></rect>
+         <rect x="89" y="237" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="257">LST</text>
+         <rect x="91" y="283" width="48" height="32" rx="10"></rect>
+         <rect x="89" y="281" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="301">ASQ</text>
+         <rect x="91" y="327" width="50" height="32" rx="10"></rect>
+         <rect x="89" y="325" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="345">MDN</text>
+         <rect x="91" y="371" width="50" height="32" rx="10"></rect>
+         <rect x="89" y="369" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="389">MDE</text>
+         <rect x="91" y="415" width="46" height="32" rx="10"></rect>
+         <rect x="89" y="413" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="433">PCT</text>
+         <rect x="91" y="459" width="56" height="32" rx="10"></rect>
+         <rect x="89" y="457" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="477">RPCT</text>
+         <rect x="91" y="503" width="48" height="32" rx="10"></rect>
+         <rect x="89" y="501" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="521">RNK</text>
+         <rect x="91" y="547" width="46" height="32" rx="10"></rect>
+         <rect x="89" y="545" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="565">DST</text>
+         <rect x="91" y="591" width="46" height="32" rx="10"></rect>
+         <rect x="89" y="589" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="609">TOT</text>
+         <rect x="91" y="635" width="50" height="32" rx="10"></rect>
+         <rect x="89" y="633" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="653">SUM</text>
+         <rect x="91" y="679" width="36" height="32" rx="10"></rect>
+         <rect x="89" y="677" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="697">CT</text>
+         <rect x="187" y="19" width="24" height="32" rx="10"></rect>
+         <rect x="185" y="17" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="195" y="37">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#field" xlink:title="field">
+            <rect x="271" y="19" width="46" height="32"></rect>
+            <rect x="269" y="17" width="46" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="279" y="37">field</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m60 0 h10 m46 0 h10 m0 0 h10 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m48 0 h10 m0 0 h8 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m50 0 h10 m0 0 h6 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m44 0 h10 m0 0 h12 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m44 0 h10 m0 0 h12 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m48 0 h10 m0 0 h8 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m50 0 h10 m0 0 h6 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m50 0 h10 m0 0 h6 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m48 0 h10 m0 0 h8 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m50 0 h10 m0 0 h6 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m36 0 h10 m0 0 h20 m20 -660 h10 m24 0 h10 m-180 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m160 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-160 0 h10 m0 0 h150 m-200 32 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v674 m220 0 v-674 m-220 674 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m0 0 h190 m20 -694 h10 m46 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="335 33 343 29 343 37"></polygon>
+         <polygon points="335 33 327 29 327 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#field_or_prefixed" title="field_or_prefixed">field_or_prefixed</a></div>
+               <div>         ::= ( ( 'AVE' | 'MIN' | 'MAX' | 'CNT' | 'FST' | 'LST' | 'ASQ' | 'MDN' | 'MDE'
+                  | 'PCT' | 'RPCT' | 'RNK' | 'DST' | 'TOT' | 'SUM' | 'CT' ) '.' )* <a href="#field" title="field">field</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#field_list" title="field_list">field_list</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="field" data-rule="field" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#across_command" class="used-by-link">across_command</a>
+          <a href="#by_command" class="used-by-link">by_command</a>
+          <a href="#field_or_prefixed" class="used-by-link">field_or_prefixed</a>
+          <a href="#summarize_command" class="used-by-link">summarize_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="field">field:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="537" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="31" y="3" width="118" height="32"></rect>
+            <rect x="29" y="1" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">qualified_name</text></a><rect x="189" y="35" width="28" height="32" rx="10"></rect>
+         <rect x="187" y="33" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="197" y="53">/</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#format_name" xlink:title="format_name">
+            <rect x="237" y="35" width="106" height="32"></rect>
+            <rect x="235" y="33" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="245" y="53">format_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#as_phrase" xlink:title="as_phrase">
+            <rect x="403" y="35" width="86" height="32"></rect>
+            <rect x="401" y="33" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="411" y="53">as_phrase</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m28 0 h10 m0 0 h10 m106 0 h10 m40 -32 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="527 17 535 13 535 21"></polygon>
+         <polygon points="527 17 519 13 519 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#field" title="field">field</a>    ::= <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '/' <a href="#format_name" title="format_name">format_name</a> )? <a href="#as_phrase" title="as_phrase">as_phrase</a>?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#across_command" title="across_command">across_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#by_command" title="by_command">by_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#field_or_prefixed" title="field_or_prefixed">field_or_prefixed</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#summarize_command" title="summarize_command">summarize_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="as_phrase" data-rule="as_phrase" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#across_command" class="used-by-link">across_command</a>
+          <a href="#compute_command" class="used-by-link">compute_command</a>
+          <a href="#field" class="used-by-link">field</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#recap_option" class="used-by-link">recap_option</a>
+          <a href="#summarize_command" class="used-by-link">summarize_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="as_phrase">as_phrase:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="183" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">AS</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="89" y="3" width="66" height="32"></rect>
+            <rect x="87" y="1" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="97" y="21">STRING</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m38 0 h10 m0 0 h10 m66 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="173 17 181 13 181 21"></polygon>
+         <polygon points="173 17 165 13 165 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#as_phrase" title="as_phrase">as_phrase</a></div>
+               <div>         ::= 'AS' <a href="#STRING" title="STRING">STRING</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#across_command" title="across_command">across_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#compute_command" title="compute_command">compute_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#field" title="field">field</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#recap_option" title="recap_option">recap_option</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#summarize_command" title="summarize_command">summarize_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="across_command" data-rule="across_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#request" class="used-by-link">request</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="across_command">across_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="829" height="101">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ACROSS</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#sort_options" xlink:title="sort_options">
+            <rect x="147" y="35" width="100" height="32"></rect>
+            <rect x="145" y="33" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="155" y="53">sort_options</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#field" xlink:title="field">
+            <rect x="287" y="3" width="46" height="32"></rect>
+            <rect x="285" y="1" width="46" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="295" y="21">field</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ACROSS_TOTAL" xlink:title="ACROSS_TOTAL">
+            <rect x="373" y="35" width="118" height="32"></rect>
+            <rect x="371" y="33" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="381" y="53">ACROSS_TOTAL</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#as_phrase" xlink:title="as_phrase">
+            <rect x="531" y="67" width="86" height="32"></rect>
+            <rect x="529" y="65" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="539" y="85">as_phrase</text></a><rect x="697" y="35" width="84" height="32" rx="10"></rect>
+         <rect x="695" y="33" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="705" y="53">NOPRINT</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h110 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v12 m140 0 v-12 m-140 12 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m100 0 h10 m20 -32 h10 m46 0 h10 m20 0 h10 m0 0 h274 m-304 0 h20 m284 0 h20 m-324 0 q10 0 10 10 m304 0 q0 -10 10 -10 m-314 10 v12 m304 0 v-12 m-304 12 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m118 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m60 -64 h10 m0 0 h94 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v12 m124 0 v-12 m-124 12 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m84 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="819 17 827 13 827 21"></polygon>
+         <polygon points="819 17 811 13 811 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#across_command" title="across_command">across_command</a></div>
+               <div>         ::= 'ACROSS' <a href="#sort_options" title="sort_options">sort_options</a>? <a href="#field" title="field">field</a> ( <a href="#ACROSS_TOTAL" title="ACROSS_TOTAL">ACROSS_TOTAL</a> <a href="#as_phrase" title="as_phrase">as_phrase</a>? )? 'NOPRINT'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="when_command" data-rule="when_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#request" class="used-by-link">request</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="when_command">when_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="389" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">WHEN</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_logical_expression" xlink:title="dm_logical_expression">
+            <rect x="113" y="3" width="164" height="32"></rect>
+            <rect x="111" y="1" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="121" y="21">dm_logical_expression</text></a><rect x="317" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="315" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="325" y="53">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m164 0 h10 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="379 17 387 13 387 21"></polygon>
+         <polygon points="379 17 371 13 371 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#when_command" title="when_command">when_command</a></div>
+               <div>         ::= 'WHEN' <a href="#dm_logical_expression" title="dm_logical_expression">dm_logical_expression</a> ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="show_command" data-rule="show_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#request" class="used-by-link">request</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="show_command">show_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="949" height="771">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SHOW</text>
+         <rect x="135" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="133" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="21">UP</text>
+         <rect x="135" y="47" width="64" height="32" rx="10"></rect>
+         <rect x="133" y="45" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="65">DOWN</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="259" y="3" width="72" height="32"></rect>
+            <rect x="257" y="1" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="267" y="21">NUMBER</text></a><rect x="371" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="369" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="379" y="53">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="415" y="35" width="72" height="32"></rect>
+            <rect x="413" y="33" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="423" y="53">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="259" y="79" width="144" height="32"></rect>
+            <rect x="257" y="77" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="267" y="97">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="259" y="167" width="118" height="32"></rect>
+            <rect x="257" y="165" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="267" y="185">qualified_name</text></a><rect x="417" y="167" width="26" height="32" rx="10"></rect>
+         <rect x="415" y="165" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="425" y="185">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="503" y="167" width="116" height="32"></rect>
+            <rect x="501" y="165" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="511" y="185">dm_expression</text></a><rect x="503" y="123" width="24" height="32" rx="10"></rect>
+         <rect x="501" y="121" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="511" y="141">,</text>
+         <rect x="679" y="167" width="26" height="32" rx="10"></rect>
+         <rect x="677" y="165" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="687" y="185">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="259" y="249" width="94" height="32"></rect>
+            <rect x="257" y="247" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="267" y="267">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="259" y="293" width="66" height="32"></rect>
+            <rect x="257" y="291" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="267" y="311">STRING</text></a><rect x="259" y="337" width="26" height="32" rx="10"></rect>
+         <rect x="257" y="335" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="267" y="355">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="305" y="337" width="116" height="32"></rect>
+            <rect x="303" y="335" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="313" y="355">dm_expression</text></a><rect x="441" y="337" width="26" height="32" rx="10"></rect>
+         <rect x="439" y="335" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="449" y="355">)</text>
+         <rect x="765" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="763" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="773" y="21">TO</text>
+         <rect x="843" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="841" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="851" y="21">UP</text>
+         <rect x="843" y="47" width="64" height="32" rx="10"></rect>
+         <rect x="841" y="45" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="851" y="65">DOWN</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="435" y="403" width="72" height="32"></rect>
+            <rect x="433" y="401" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="443" y="421">NUMBER</text></a><rect x="547" y="435" width="24" height="32" rx="10"></rect>
+         <rect x="545" y="433" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="555" y="453">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="591" y="435" width="72" height="32"></rect>
+            <rect x="589" y="433" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="599" y="453">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#decode_expression" xlink:title="decode_expression">
+            <rect x="435" y="479" width="144" height="32"></rect>
+            <rect x="433" y="477" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="443" y="497">decode_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="435" y="567" width="118" height="32"></rect>
+            <rect x="433" y="565" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="443" y="585">qualified_name</text></a><rect x="593" y="567" width="26" height="32" rx="10"></rect>
+         <rect x="591" y="565" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="601" y="585">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="679" y="567" width="116" height="32"></rect>
+            <rect x="677" y="565" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="687" y="585">dm_expression</text></a><rect x="679" y="523" width="24" height="32" rx="10"></rect>
+         <rect x="677" y="521" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="687" y="541">,</text>
+         <rect x="855" y="567" width="26" height="32" rx="10"></rect>
+         <rect x="853" y="565" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="863" y="585">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AMPER_VAR" xlink:title="AMPER_VAR">
+            <rect x="435" y="649" width="94" height="32"></rect>
+            <rect x="433" y="647" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="443" y="667">AMPER_VAR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="435" y="693" width="66" height="32"></rect>
+            <rect x="433" y="691" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="443" y="711">STRING</text></a><rect x="435" y="737" width="26" height="32" rx="10"></rect>
+         <rect x="433" y="735" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="443" y="755">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="481" y="737" width="116" height="32"></rect>
+            <rect x="479" y="735" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="489" y="755">dm_expression</text></a><rect x="617" y="737" width="26" height="32" rx="10"></rect>
+         <rect x="615" y="735" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="625" y="755">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m38 0 h10 m0 0 h26 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -44 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m20 -334 h10 m38 0 h10 m20 0 h10 m38 0 h10 m0 0 h26 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-556 400 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m72 0 h10 m20 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m24 0 h10 m0 0 h10 m72 0 h10 m20 -32 h218 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m144 0 h10 m0 0 h322 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m118 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m-176 44 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v14 m196 0 v-14 m-196 14 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m0 0 h166 m20 -34 h10 m26 0 h10 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v30 m328 0 v-30 m-328 30 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m-476 -60 v20 m506 0 v-20 m-506 20 v62 m506 0 v-62 m-506 62 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m94 0 h10 m0 0 h372 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h400 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m0 0 h258 m23 -334 h-3"></svg:path>
+         <polygon points="939 417 947 413 947 421"></polygon>
+         <polygon points="939 417 931 413 931 421"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#show_command" title="show_command">show_command</a></div>
+               <div>         ::= 'SHOW' ( 'UP' | 'DOWN' ) ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' ) 'TO' ( 'UP' | 'DOWN' ) ( <a href="#NUMBER" title="NUMBER">NUMBER</a> ( '.' <a href="#NUMBER" title="NUMBER">NUMBER</a> )? | <a href="#decode_expression" title="decode_expression">decode_expression</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> ( '(' ( <a href="#dm_expression" title="dm_expression">dm_expression</a> ( ',' <a href="#dm_expression" title="dm_expression">dm_expression</a> )* )? ')' )? | <a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a> | <a href="#STRING" title="STRING">STRING</a> | '(' <a href="#dm_expression" title="dm_expression">dm_expression</a> ')' )</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="sort_options" data-rule="sort_options" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#across_command" class="used-by-link">across_command</a>
+          <a href="#by_command" class="used-by-link">by_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="sort_options">sort_options:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="353" height="213">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="71" y="3" width="82" height="32" rx="10"></rect>
+         <rect x="69" y="1" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="21">HIGHEST</text>
+         <rect x="71" y="47" width="78" height="32" rx="10"></rect>
+         <rect x="69" y="45" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="65">LOWEST</text>
+         <rect x="71" y="91" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="89" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="109">TOP</text>
+         <rect x="71" y="135" width="78" height="32" rx="10"></rect>
+         <rect x="69" y="133" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="153">BOTTOM</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="213" y="35" width="72" height="32"></rect>
+            <rect x="211" y="33" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="221" y="53">NUMBER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMBER" xlink:title="NUMBER">
+            <rect x="51" y="179" width="72" height="32"></rect>
+            <rect x="49" y="177" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">NUMBER</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m40 0 h10 m82 0 h10 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m78 0 h10 m0 0 h4 m-112 -10 v20 m122 0 v-20 m-122 20 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m48 0 h10 m0 0 h34 m-112 -10 v20 m122 0 v-20 m-122 20 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m78 0 h10 m0 0 h4 m40 -132 h10 m0 0 h82 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v12 m112 0 v-12 m-112 12 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m72 0 h10 m-274 -32 h20 m274 0 h20 m-314 0 q10 0 10 10 m294 0 q0 -10 10 -10 m-304 10 v156 m294 0 v-156 m-294 156 q0 10 10 10 m274 0 q10 0 10 -10 m-284 10 h10 m72 0 h10 m0 0 h182 m23 -176 h-3"></svg:path>
+         <polygon points="343 17 351 13 351 21"></polygon>
+         <polygon points="343 17 335 13 335 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#sort_options" title="sort_options">sort_options</a></div>
+               <div>         ::= ( 'HIGHEST' | 'LOWEST' | 'TOP' | 'BOTTOM' ) <a href="#NUMBER" title="NUMBER">NUMBER</a>?</div>
+               <div>           | <a href="#NUMBER" title="NUMBER">NUMBER</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#across_command" title="across_command">across_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#by_command" title="by_command">by_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="footing_command" data-rule="footing_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#request" class="used-by-link">request</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="footing_command">footing_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="401" height="85">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <rect x="31" y="19" width="84" height="32" rx="10"></rect>
+         <rect x="29" y="17" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="37">FOOTING</text>
+         <rect x="155" y="51" width="72" height="32" rx="10"></rect>
+         <rect x="153" y="49" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="163" y="69">CENTER</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="287" y="19" width="66" height="32"></rect>
+            <rect x="285" y="17" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="295" y="37">STRING</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m0 0 h10 m84 0 h10 m20 0 h10 m0 0 h82 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v12 m112 0 v-12 m-112 12 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m72 0 h10 m40 -32 h10 m66 0 h10 m-106 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m86 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-86 0 h10 m0 0 h76 m23 32 h-3"></svg:path>
+         <polygon points="391 33 399 29 399 37"></polygon>
+         <polygon points="391 33 383 29 383 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#footing_command" title="footing_command">footing_command</a></div>
+               <div>         ::= 'FOOTING' 'CENTER'? <a href="#STRING" title="STRING">STRING</a>+</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="on_command" data-rule="on_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#request" class="used-by-link">request</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="on_command">on_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="423" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="40" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ON</text>
+         <rect x="111" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="109" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="119" y="21">TABLE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#on_table_options" xlink:title="on_table_options">
+            <rect x="193" y="3" width="132" height="32"></rect>
+            <rect x="191" y="1" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="201" y="21">on_table_options</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="111" y="47" width="118" height="32"></rect>
+            <rect x="109" y="45" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="119" y="65">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#on_field_options" xlink:title="on_field_options">
+            <rect x="249" y="47" width="126" height="32"></rect>
+            <rect x="247" y="45" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="257" y="65">on_field_options</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m40 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m132 0 h10 m0 0 h50 m-304 0 h20 m284 0 h20 m-324 0 q10 0 10 10 m304 0 q0 -10 10 -10 m-314 10 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m118 0 h10 m0 0 h10 m126 0 h10 m23 -44 h-3"></svg:path>
+         <polygon points="413 17 421 13 421 21"></polygon>
+         <polygon points="413 17 405 13 405 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#on_command" title="on_command">on_command</a></div>
+               <div>         ::= 'ON' ( 'TABLE' <a href="#on_table_options" title="on_table_options">on_table_options</a> | <a href="#qualified_name" title="qualified_name">qualified_name</a> <a href="#on_field_options" title="on_field_options">on_field_options</a> )</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="on_table_options" data-rule="on_table_options" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#on_command" class="used-by-link">on_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="on_table_options">on_table_options:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="1101" height="4875">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <rect x="71" y="19" width="84" height="32" rx="10"></rect>
+         <rect x="69" y="17" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="37">SUBHEAD</text>
+         <rect x="71" y="63" width="86" height="32" rx="10"></rect>
+         <rect x="69" y="61" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="81">SUBFOOT</text>
+         <rect x="217" y="51" width="72" height="32" rx="10"></rect>
+         <rect x="215" y="49" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="225" y="69">CENTER</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="349" y="19" width="66" height="32"></rect>
+            <rect x="347" y="17" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="357" y="37">STRING</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#COLUMN_TOTAL_KW" xlink:title="COLUMN_TOTAL_KW">
+            <rect x="51" y="107" width="148" height="32"></rect>
+            <rect x="49" y="105" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="125">COLUMN_TOTAL_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ROW_TOTAL_KW" xlink:title="ROW_TOTAL_KW">
+            <rect x="51" y="151" width="126" height="32"></rect>
+            <rect x="49" y="149" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="169">ROW_TOTAL_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ACROSS_TOTAL" xlink:title="ACROSS_TOTAL">
+            <rect x="51" y="195" width="118" height="32"></rect>
+            <rect x="49" y="193" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="213">ACROSS_TOTAL</text></a><rect x="209" y="227" width="28" height="32" rx="10"></rect>
+         <rect x="207" y="225" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="217" y="245">/</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#format_name" xlink:title="format_name">
+            <rect x="257" y="227" width="106" height="32"></rect>
+            <rect x="255" y="225" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="265" y="245">format_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#as_phrase" xlink:title="as_phrase">
+            <rect x="423" y="227" width="86" height="32"></rect>
+            <rect x="421" y="225" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="431" y="245">as_phrase</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="569" y="227" width="118" height="32"></rect>
+            <rect x="567" y="225" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="577" y="245">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#output_command" xlink:title="output_command">
+            <rect x="51" y="271" width="130" height="32"></rect>
+            <rect x="49" y="269" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="289">output_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#summarize_command" xlink:title="summarize_command">
+            <rect x="51" y="315" width="158" height="32"></rect>
+            <rect x="49" y="313" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="333">summarize_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#recap_command" xlink:title="recap_command">
+            <rect x="51" y="359" width="124" height="32"></rect>
+            <rect x="49" y="357" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="377">recap_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#merge_command" xlink:title="merge_command">
+            <rect x="51" y="403" width="130" height="32"></rect>
+            <rect x="49" y="401" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="421">merge_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#set_command" xlink:title="set_command">
+            <rect x="51" y="447" width="108" height="32"></rect>
+            <rect x="49" y="445" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="465">set_command</text></a><rect x="51" y="557" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="555" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="575">SET</text>
+         <rect x="115" y="557" width="62" height="32" rx="10"></rect>
+         <rect x="113" y="555" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="123" y="575">STYLE</text>
+         <rect x="197" y="557" width="28" height="32" rx="10"></rect>
+         <rect x="195" y="555" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="205" y="575">*</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="325" y="557" width="54" height="32"></rect>
+            <rect x="323" y="555" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="333" y="575">NAME</text></a><rect x="325" y="601" width="46" height="32" rx="10"></rect>
+         <rect x="323" y="599" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="619">AVE</text>
+         <rect x="325" y="645" width="48" height="32" rx="10"></rect>
+         <rect x="323" y="643" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="663">MIN</text>
+         <rect x="325" y="689" width="50" height="32" rx="10"></rect>
+         <rect x="323" y="687" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="707">MAX</text>
+         <rect x="325" y="733" width="46" height="32" rx="10"></rect>
+         <rect x="323" y="731" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="751">CNT</text>
+         <rect x="325" y="777" width="44" height="32" rx="10"></rect>
+         <rect x="323" y="775" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="795">FST</text>
+         <rect x="325" y="821" width="44" height="32" rx="10"></rect>
+         <rect x="323" y="819" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="839">LST</text>
+         <rect x="325" y="865" width="48" height="32" rx="10"></rect>
+         <rect x="323" y="863" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="883">ASQ</text>
+         <rect x="325" y="909" width="50" height="32" rx="10"></rect>
+         <rect x="323" y="907" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="927">MDN</text>
+         <rect x="325" y="953" width="50" height="32" rx="10"></rect>
+         <rect x="323" y="951" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="971">MDE</text>
+         <rect x="325" y="997" width="46" height="32" rx="10"></rect>
+         <rect x="323" y="995" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1015">PCT</text>
+         <rect x="325" y="1041" width="56" height="32" rx="10"></rect>
+         <rect x="323" y="1039" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1059">RPCT</text>
+         <rect x="325" y="1085" width="48" height="32" rx="10"></rect>
+         <rect x="323" y="1083" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1103">RNK</text>
+         <rect x="325" y="1129" width="46" height="32" rx="10"></rect>
+         <rect x="323" y="1127" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1147">DST</text>
+         <rect x="325" y="1173" width="46" height="32" rx="10"></rect>
+         <rect x="323" y="1171" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1191">TOT</text>
+         <rect x="325" y="1217" width="50" height="32" rx="10"></rect>
+         <rect x="323" y="1215" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1235">SUM</text>
+         <rect x="325" y="1261" width="36" height="32" rx="10"></rect>
+         <rect x="323" y="1259" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1279">CT</text>
+         <rect x="325" y="1305" width="36" height="32" rx="10"></rect>
+         <rect x="323" y="1303" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1323">IS</text>
+         <rect x="325" y="1349" width="92" height="32" rx="10"></rect>
+         <rect x="323" y="1347" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1367">CONTAINS</text>
+         <rect x="325" y="1393" width="66" height="32" rx="10"></rect>
+         <rect x="323" y="1391" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1411">OMITS</text>
+         <rect x="325" y="1437" width="52" height="32" rx="10"></rect>
+         <rect x="323" y="1435" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1455">LIKE</text>
+         <rect x="325" y="1481" width="64" height="32" rx="10"></rect>
+         <rect x="323" y="1479" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1499">TOTAL</text>
+         <rect x="325" y="1525" width="82" height="32" rx="10"></rect>
+         <rect x="323" y="1523" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1543">MISSING</text>
+         <rect x="325" y="1569" width="90" height="32" rx="10"></rect>
+         <rect x="323" y="1567" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1587">INCLUDES</text>
+         <rect x="325" y="1613" width="90" height="32" rx="10"></rect>
+         <rect x="323" y="1611" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1631">EXCLUDES</text>
+         <rect x="325" y="1657" width="82" height="32" rx="10"></rect>
+         <rect x="323" y="1655" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1675">EXCEEDS</text>
+         <rect x="325" y="1701" width="44" height="32" rx="10"></rect>
+         <rect x="323" y="1699" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1719">ALL</text>
+         <rect x="325" y="1745" width="54" height="32" rx="10"></rect>
+         <rect x="323" y="1743" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1763">LESS</text>
+         <rect x="325" y="1789" width="58" height="32" rx="10"></rect>
+         <rect x="323" y="1787" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1807">THAN</text>
+         <rect x="325" y="1833" width="60" height="32" rx="10"></rect>
+         <rect x="323" y="1831" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1851">MORE</text>
+         <rect x="325" y="1877" width="82" height="32" rx="10"></rect>
+         <rect x="323" y="1875" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1895">GREATER</text>
+         <rect x="325" y="1921" width="46" height="32" rx="10"></rect>
+         <rect x="323" y="1919" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1939">OFF</text>
+         <rect x="325" y="1965" width="40" height="32" rx="10"></rect>
+         <rect x="323" y="1963" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1983">ON</text>
+         <rect x="325" y="2009" width="64" height="32" rx="10"></rect>
+         <rect x="323" y="2007" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2027">RECAP</text>
+         <rect x="325" y="2053" width="72" height="32" rx="10"></rect>
+         <rect x="323" y="2051" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2071">INDENT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ACROSS_TOTAL" xlink:title="ACROSS_TOTAL">
+            <rect x="325" y="2097" width="118" height="32"></rect>
+            <rect x="323" y="2095" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="333" y="2115">ACROSS_TOTAL</text></a><rect x="325" y="2141" width="100" height="32" rx="10"></rect>
+         <rect x="323" y="2139" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2159">COMPOUND</text>
+         <rect x="325" y="2185" width="74" height="32" rx="10"></rect>
+         <rect x="323" y="2183" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2203">LAYOUT</text>
+         <rect x="325" y="2229" width="82" height="32" rx="10"></rect>
+         <rect x="323" y="2227" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2247">SECTION</text>
+         <rect x="325" y="2273" width="110" height="32" rx="10"></rect>
+         <rect x="323" y="2271" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2291">PAGELAYOUT</text>
+         <rect x="325" y="2317" width="108" height="32" rx="10"></rect>
+         <rect x="323" y="2315" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2335">COMPONENT</text>
+         <rect x="325" y="2361" width="66" height="32" rx="10"></rect>
+         <rect x="323" y="2359" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2379">MERGE</text>
+         <rect x="325" y="2405" width="118" height="32" rx="10"></rect>
+         <rect x="323" y="2403" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2423">ORIENTATION</text>
+         <rect x="325" y="2449" width="102" height="32" rx="10"></rect>
+         <rect x="323" y="2447" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2467">LANDSCAPE</text>
+         <rect x="325" y="2493" width="90" height="32" rx="10"></rect>
+         <rect x="323" y="2491" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2511">PORTRAIT</text>
+         <rect x="325" y="2537" width="54" height="32" rx="10"></rect>
+         <rect x="323" y="2535" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2555">TYPE</text>
+         <rect x="325" y="2581" width="90" height="32" rx="10"></rect>
+         <rect x="323" y="2579" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2599">POSITION</text>
+         <rect x="325" y="2625" width="102" height="32" rx="10"></rect>
+         <rect x="323" y="2623" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2643">DIMENSION</text>
+         <rect x="325" y="2669" width="62" height="32" rx="10"></rect>
+         <rect x="323" y="2667" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2687">STYLE</text>
+         <rect x="325" y="2713" width="90" height="32" rx="10"></rect>
+         <rect x="323" y="2711" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2731">ENDSTYLE</text>
+         <rect x="325" y="2757" width="68" height="32" rx="10"></rect>
+         <rect x="323" y="2755" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2775">MATCH</text>
+         <rect x="325" y="2801" width="62" height="32" rx="10"></rect>
+         <rect x="323" y="2799" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2819">AFTER</text>
+         <rect x="325" y="2845" width="48" height="32" rx="10"></rect>
+         <rect x="323" y="2843" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2863">RUN</text>
+         <rect x="325" y="2889" width="48" height="32" rx="10"></rect>
+         <rect x="323" y="2887" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2907">OLD</text>
+         <rect x="325" y="2933" width="52" height="32" rx="10"></rect>
+         <rect x="323" y="2931" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2951">NEW</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_OR_NEW_KW" xlink:title="OLD_OR_NEW_KW">
+            <rect x="325" y="2977" width="138" height="32"></rect>
+            <rect x="323" y="2975" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="333" y="2995">OLD_OR_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_AND_NEW_KW" xlink:title="OLD_AND_NEW_KW">
+            <rect x="325" y="3021" width="146" height="32"></rect>
+            <rect x="323" y="3019" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="333" y="3039">OLD_AND_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_NOT_NEW_KW" xlink:title="OLD_NOT_NEW_KW">
+            <rect x="325" y="3065" width="146" height="32"></rect>
+            <rect x="323" y="3063" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="333" y="3083">OLD_NOT_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NEW_NOT_OLD_KW" xlink:title="NEW_NOT_OLD_KW">
+            <rect x="325" y="3109" width="146" height="32"></rect>
+            <rect x="323" y="3107" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="333" y="3127">NEW_NOT_OLD_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_NOR_NEW_KW" xlink:title="OLD_NOR_NEW_KW">
+            <rect x="325" y="3153" width="148" height="32"></rect>
+            <rect x="323" y="3151" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="333" y="3171">OLD_NOR_NEW_KW</text></a><rect x="325" y="3197" width="94" height="32" rx="10"></rect>
+         <rect x="323" y="3195" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3215">MATCHING</text>
+         <rect x="325" y="3241" width="86" height="32" rx="10"></rect>
+         <rect x="323" y="3239" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3259">MATCHED</text>
+         <rect x="325" y="3285" width="74" height="32" rx="10"></rect>
+         <rect x="323" y="3283" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3303">UPDATE</text>
+         <rect x="325" y="3329" width="70" height="32" rx="10"></rect>
+         <rect x="323" y="3327" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3347">INSERT</text>
+         <rect x="325" y="3373" width="56" height="32" rx="10"></rect>
+         <rect x="323" y="3371" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3391">INTO</text>
+         <rect x="325" y="3417" width="84" height="32" rx="10"></rect>
+         <rect x="323" y="3415" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3435">HEADING</text>
+         <rect x="325" y="3461" width="84" height="32" rx="10"></rect>
+         <rect x="323" y="3459" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3479">FOOTING</text>
+         <rect x="325" y="3505" width="84" height="32" rx="10"></rect>
+         <rect x="323" y="3503" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3523">SUBHEAD</text>
+         <rect x="325" y="3549" width="86" height="32" rx="10"></rect>
+         <rect x="323" y="3547" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3567">SUBFOOT</text>
+         <rect x="325" y="3593" width="76" height="32" rx="10"></rect>
+         <rect x="323" y="3591" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3611">FORMAT</text>
+         <rect x="325" y="3637" width="62" height="32" rx="10"></rect>
+         <rect x="323" y="3635" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3655">TIMES</text>
+         <rect x="325" y="3681" width="66" height="32" rx="10"></rect>
+         <rect x="323" y="3679" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3699">WHILE</text>
+         <rect x="325" y="3725" width="62" height="32" rx="10"></rect>
+         <rect x="323" y="3723" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3743">UNTIL</text>
+         <rect x="325" y="3769" width="48" height="32" rx="10"></rect>
+         <rect x="323" y="3767" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3787">FOR</text>
+         <rect x="325" y="3813" width="54" height="32" rx="10"></rect>
+         <rect x="323" y="3811" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3831">STEP</text>
+         <rect x="325" y="3857" width="48" height="32" rx="10"></rect>
+         <rect x="323" y="3855" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3875">TOP</text>
+         <rect x="325" y="3901" width="78" height="32" rx="10"></rect>
+         <rect x="323" y="3899" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3919">BOTTOM</text>
+         <rect x="325" y="3945" width="76" height="32" rx="10"></rect>
+         <rect x="323" y="3943" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="3963">RANKED</text>
+         <rect x="325" y="3989" width="84" height="32" rx="10"></rect>
+         <rect x="323" y="3987" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4007">NOPRINT</text>
+         <rect x="325" y="4033" width="38" height="32" rx="10"></rect>
+         <rect x="323" y="4031" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4051">AS</text>
+         <rect x="325" y="4077" width="36" height="32" rx="10"></rect>
+         <rect x="323" y="4075" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4095">IN</text>
+         <rect x="325" y="4121" width="100" height="32" rx="10"></rect>
+         <rect x="323" y="4119" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4139">HIERARCHY</text>
+         <rect x="325" y="4165" width="62" height="32" rx="10"></rect>
+         <rect x="323" y="4163" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4183">WHEN</text>
+         <rect x="325" y="4209" width="64" height="32" rx="10"></rect>
+         <rect x="323" y="4207" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4227">SHOW</text>
+         <rect x="325" y="4253" width="38" height="32" rx="10"></rect>
+         <rect x="323" y="4251" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4271">UP</text>
+         <rect x="325" y="4297" width="64" height="32" rx="10"></rect>
+         <rect x="323" y="4295" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4315">DOWN</text>
+         <rect x="325" y="4341" width="58" height="32" rx="10"></rect>
+         <rect x="323" y="4339" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4359">OPEN</text>
+         <rect x="325" y="4385" width="64" height="32" rx="10"></rect>
+         <rect x="323" y="4383" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4403">CLOSE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#PAGE_BREAK" xlink:title="PAGE_BREAK">
+            <rect x="325" y="4429" width="102" height="32"></rect>
+            <rect x="323" y="4427" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="333" y="4447">PAGE_BREAK</text></a><rect x="325" y="4473" width="130" height="32" rx="10"></rect>
+         <rect x="323" y="4471" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4491">DRILLTHROUGH</text>
+         <rect x="325" y="4517" width="78" height="32" rx="10"></rect>
+         <rect x="323" y="4515" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4535">COLUMN</text>
+         <rect x="325" y="4561" width="52" height="32" rx="10"></rect>
+         <rect x="323" y="4559" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4579">LINE</text>
+         <rect x="325" y="4605" width="54" height="32" rx="10"></rect>
+         <rect x="323" y="4603" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4623">ITEM</text>
+         <rect x="325" y="4649" width="68" height="32" rx="10"></rect>
+         <rect x="323" y="4647" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4667">COLOR</text>
+         <rect x="325" y="4693" width="80" height="32" rx="10"></rect>
+         <rect x="323" y="4691" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4711">DEFAULT</text>
+         <rect x="325" y="4737" width="56" height="32" rx="10"></rect>
+         <rect x="323" y="4735" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4755">READ</text>
+         <rect x="325" y="4781" width="66" height="32" rx="10"></rect>
+         <rect x="323" y="4779" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4799">WRITE</text>
+         <rect x="325" y="4825" width="54" height="32" rx="10"></rect>
+         <rect x="323" y="4823" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="4843">TYPE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="513" y="557" width="36" height="32"></rect>
+            <rect x="511" y="555" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="521" y="575">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#layout_value" xlink:title="layout_value">
+            <rect x="569" y="557" width="102" height="32"></rect>
+            <rect x="567" y="555" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="577" y="575">layout_value</text></a><rect x="305" y="513" width="24" height="32" rx="10"></rect>
+         <rect x="303" y="511" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="313" y="531">,</text>
+         <rect x="751" y="621" width="24" height="32" rx="10"></rect>
+         <rect x="749" y="619" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="759" y="639">,</text>
+         <rect x="815" y="589" width="28" height="32" rx="10"></rect>
+         <rect x="813" y="587" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="823" y="607">$</text>
+         <rect x="943" y="589" width="90" height="32" rx="10"></rect>
+         <rect x="941" y="587" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="951" y="607">ENDSTYLE</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m40 0 h10 m84 0 h10 m0 0 h2 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m40 -44 h10 m0 0 h82 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v12 m112 0 v-12 m-112 12 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m72 0 h10 m40 -32 h10 m66 0 h10 m-106 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m86 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-86 0 h10 m0 0 h76 m20 32 h618 m-1042 0 h20 m1022 0 h20 m-1062 0 q10 0 10 10 m1042 0 q0 -10 10 -10 m-1052 10 v68 m1042 0 v-68 m-1042 68 q0 10 10 10 m1022 0 q10 0 10 -10 m-1032 10 h10 m148 0 h10 m0 0 h854 m-1032 -10 v20 m1042 0 v-20 m-1042 20 v24 m1042 0 v-24 m-1042 24 q0 10 10 10 m1022 0 q10 0 10 -10 m-1032 10 h10 m126 0 h10 m0 0 h876 m-1032 -10 v20 m1042 0 v-20 m-1042 20 v24 m1042 0 v-24 m-1042 24 q0 10 10 10 m1022 0 q10 0 10 -10 m-1032 10 h10 m118 0 h10 m20 0 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m28 0 h10 m0 0 h10 m106 0 h10 m40 -32 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m40 -32 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h346 m-1032 -10 v20 m1042 0 v-20 m-1042 20 v56 m1042 0 v-56 m-1042 56 q0 10 10 10 m1022 0 q10 0 10 -10 m-1032 10 h10 m130 0 h10 m0 0 h872 m-1032 -10 v20 m1042 0 v-20 m-1042 20 v24 m1042 0 v-24 m-1042 24 q0 10 10 10 m1022 0 q10 0 10 -10 m-1032 10 h10 m158 0 h10 m0 0 h844 m-1032 -10 v20 m1042 0 v-20 m-1042 20 v24 m1042 0 v-24 m-1042 24 q0 10 10 10 m1022 0 q10 0 10 -10 m-1032 10 h10 m124 0 h10 m0 0 h878 m-1032 -10 v20 m1042 0 v-20 m-1042 20 v24 m1042 0 v-24 m-1042 24 q0 10 10 10 m1022 0 q10 0 10 -10 m-1032 10 h10 m130 0 h10 m0 0 h872 m-1032 -10 v20 m1042 0 v-20 m-1042 20 v24 m1042 0 v-24 m-1042 24 q0 10 10 10 m1022 0 q10 0 10 -10 m-1032 10 h10 m108 0 h10 m0 0 h894 m-1032 -10 v20 m1042 0 v-20 m-1042 20 v90 m1042 0 v-90 m-1042 90 q0 10 10 10 m1022 0 q10 0 10 -10 m-1032 10 h10 m44 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m28 0 h10 m80 0 h10 m54 0 h10 m0 0 h94 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m92 0 h10 m0 0 h56 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m58 0 h10 m0 0 h90 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m60 0 h10 m0 0 h88 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m40 0 h10 m0 0 h108 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m72 0 h10 m0 0 h76 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m118 0 h10 m0 0 h30 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m100 0 h10 m0 0 h48 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m74 0 h10 m0 0 h74 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m110 0 h10 m0 0 h38 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m108 0 h10 m0 0 h40 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m118 0 h10 m0 0 h30 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m68 0 h10 m0 0 h80 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m138 0 h10 m0 0 h10 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m148 0 h10 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m94 0 h10 m0 0 h54 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m86 0 h10 m0 0 h62 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m74 0 h10 m0 0 h74 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m70 0 h10 m0 0 h78 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m86 0 h10 m0 0 h62 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m76 0 h10 m0 0 h72 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m78 0 h10 m0 0 h70 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m76 0 h10 m0 0 h72 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m38 0 h10 m0 0 h110 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m100 0 h10 m0 0 h48 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m38 0 h10 m0 0 h110 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m58 0 h10 m0 0 h90 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m130 0 h10 m0 0 h18 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m78 0 h10 m0 0 h70 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m68 0 h10 m0 0 h80 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m80 0 h10 m0 0 h68 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m20 -4268 h10 m36 0 h10 m0 0 h10 m102 0 h10 m-406 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m386 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-386 0 h10 m24 0 h10 m0 0 h342 m40 44 h10 m0 0 h122 m-152 0 h20 m132 0 h20 m-172 0 q10 0 10 10 m152 0 q0 -10 10 -10 m-162 10 v12 m152 0 v-12 m-152 12 q0 10 10 10 m132 0 q10 0 10 -10 m-122 10 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m20 -32 h10 m28 0 h10 m-598 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -56 q0 -10 10 -10 m598 76 l20 0 m-20 0 q10 0 10 -10 l0 -56 q0 -10 -10 -10 m-598 0 h10 m0 0 h588 m-638 76 h20 m638 0 h20 m-678 0 q10 0 10 10 m658 0 q0 -10 10 -10 m-668 10 v4282 m658 0 v-4282 m-658 4282 q0 10 10 10 m638 0 q10 0 10 -10 m-648 10 h10 m0 0 h628 m40 -4302 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m43 -570 h-3"></svg:path>
+         <polygon points="1091 33 1099 29 1099 37"></polygon>
+         <polygon points="1091 33 1083 29 1083 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#on_table_options" title="on_table_options">on_table_options</a></div>
+               <div>         ::= ( 'SUBHEAD' | 'SUBFOOT' ) 'CENTER'? <a href="#STRING" title="STRING">STRING</a>+</div>
+               <div>           | <a href="#COLUMN_TOTAL_KW" title="COLUMN_TOTAL_KW">COLUMN_TOTAL_KW</a></div>
+               <div>           | <a href="#ROW_TOTAL_KW" title="ROW_TOTAL_KW">ROW_TOTAL_KW</a></div>
+               <div>           | <a href="#ACROSS_TOTAL" title="ACROSS_TOTAL">ACROSS_TOTAL</a> ( '/' <a href="#format_name" title="format_name">format_name</a> )? <a href="#as_phrase" title="as_phrase">as_phrase</a>? <a href="#qualified_name" title="qualified_name">qualified_name</a>?</div>
+               <div>           | <a href="#output_command" title="output_command">output_command</a></div>
+               <div>           | <a href="#summarize_command" title="summarize_command">summarize_command</a></div>
+               <div>           | <a href="#recap_command" title="recap_command">recap_command</a></div>
+               <div>           | <a href="#merge_command" title="merge_command">merge_command</a></div>
+               <div>           | <a href="#set_command" title="set_command">set_command</a></div>
+               <div>           | 'SET' 'STYLE' '*' ( ( <a href="#NAME" title="NAME">NAME</a> | 'AVE' | 'MIN' | 'MAX' | 'CNT' | 'FST' | 'LST' | 'ASQ' | 'MDN' | 'MDE' | 'PCT' |
+                  'RPCT' | 'RNK' | 'DST' | 'TOT' | 'SUM' | 'CT' | 'IS' | 'CONTAINS' | 'OMITS' | 'LIKE'
+                  | 'TOTAL' | 'MISSING' | 'INCLUDES' | 'EXCLUDES' | 'EXCEEDS' | 'ALL' | 'LESS' | 'THAN'
+                  | 'MORE' | 'GREATER' | 'OFF' | 'ON' | 'RECAP' | 'INDENT' | <a href="#ACROSS_TOTAL" title="ACROSS_TOTAL">ACROSS_TOTAL</a> | 'COMPOUND' | 'LAYOUT' | 'SECTION' | 'PAGELAYOUT' | 'COMPONENT' | 'MERGE' | 'ORIENTATION'
+                  | 'LANDSCAPE' | 'PORTRAIT' | 'TYPE' | 'POSITION' | 'DIMENSION' | 'STYLE' | 'ENDSTYLE'
+                  | 'MATCH' | 'AFTER' | 'RUN' | 'OLD' | 'NEW' | <a href="#OLD_OR_NEW_KW" title="OLD_OR_NEW_KW">OLD_OR_NEW_KW</a> | <a href="#OLD_AND_NEW_KW" title="OLD_AND_NEW_KW">OLD_AND_NEW_KW</a> | <a href="#OLD_NOT_NEW_KW" title="OLD_NOT_NEW_KW">OLD_NOT_NEW_KW</a> | <a href="#NEW_NOT_OLD_KW" title="NEW_NOT_OLD_KW">NEW_NOT_OLD_KW</a> | <a href="#OLD_NOR_NEW_KW" title="OLD_NOR_NEW_KW">OLD_NOR_NEW_KW</a> | 'MATCHING' | 'MATCHED' | 'UPDATE' | 'INSERT' | 'INTO' | 'HEADING' | 'FOOTING' |
+                  'SUBHEAD' | 'SUBFOOT' | 'FORMAT' | 'TIMES' | 'WHILE' | 'UNTIL' | 'FOR' | 'STEP' |
+                  'TOP' | 'BOTTOM' | 'RANKED' | 'NOPRINT' | 'AS' | 'IN' | 'HIERARCHY' | 'WHEN' | 'SHOW'
+                  | 'UP' | 'DOWN' | 'OPEN' | 'CLOSE' | <a href="#PAGE_BREAK" title="PAGE_BREAK">PAGE_BREAK</a> | 'DRILLTHROUGH' | 'COLUMN' | 'LINE' | 'ITEM' | 'COLOR' | 'DEFAULT' | 'READ' | 'WRITE'
+                  | 'TYPE' ) <a href="#EQ" title="EQ">EQ</a> <a href="#layout_value" title="layout_value">layout_value</a> ( ',' ( <a href="#NAME" title="NAME">NAME</a> | 'AVE' | 'MIN' | 'MAX' | 'CNT' | 'FST' | 'LST' | 'ASQ' | 'MDN' | 'MDE' | 'PCT' |
+                  'RPCT' | 'RNK' | 'DST' | 'TOT' | 'SUM' | 'CT' | 'IS' | 'CONTAINS' | 'OMITS' | 'LIKE'
+                  | 'TOTAL' | 'MISSING' | 'INCLUDES' | 'EXCLUDES' | 'EXCEEDS' | 'ALL' | 'LESS' | 'THAN'
+                  | 'MORE' | 'GREATER' | 'OFF' | 'ON' | 'RECAP' | 'INDENT' | <a href="#ACROSS_TOTAL" title="ACROSS_TOTAL">ACROSS_TOTAL</a> | 'COMPOUND' | 'LAYOUT' | 'SECTION' | 'PAGELAYOUT' | 'COMPONENT' | 'MERGE' | 'ORIENTATION'
+                  | 'LANDSCAPE' | 'PORTRAIT' | 'TYPE' | 'POSITION' | 'DIMENSION' | 'STYLE' | 'ENDSTYLE'
+                  | 'MATCH' | 'AFTER' | 'RUN' | 'OLD' | 'NEW' | <a href="#OLD_OR_NEW_KW" title="OLD_OR_NEW_KW">OLD_OR_NEW_KW</a> | <a href="#OLD_AND_NEW_KW" title="OLD_AND_NEW_KW">OLD_AND_NEW_KW</a> | <a href="#OLD_NOT_NEW_KW" title="OLD_NOT_NEW_KW">OLD_NOT_NEW_KW</a> | <a href="#NEW_NOT_OLD_KW" title="NEW_NOT_OLD_KW">NEW_NOT_OLD_KW</a> | <a href="#OLD_NOR_NEW_KW" title="OLD_NOR_NEW_KW">OLD_NOR_NEW_KW</a> | 'MATCHING' | 'MATCHED' | 'UPDATE' | 'INSERT' | 'INTO' | 'HEADING' | 'FOOTING' |
+                  'SUBHEAD' | 'SUBFOOT' | 'FORMAT' | 'TIMES' | 'WHILE' | 'UNTIL' | 'FOR' | 'STEP' |
+                  'TOP' | 'BOTTOM' | 'RANKED' | 'NOPRINT' | 'AS' | 'IN' | 'HIERARCHY' | 'WHEN' | 'SHOW'
+                  | 'UP' | 'DOWN' | 'OPEN' | 'CLOSE' | <a href="#PAGE_BREAK" title="PAGE_BREAK">PAGE_BREAK</a> | 'DRILLTHROUGH' | 'COLUMN' | 'LINE' | 'ITEM' | 'COLOR' | 'DEFAULT' | 'READ' | 'WRITE'
+                  | 'TYPE' ) <a href="#EQ" title="EQ">EQ</a> <a href="#layout_value" title="layout_value">layout_value</a> )* ( ','? '$' )? )* 'ENDSTYLE'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#on_command" title="on_command">on_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="on_field_options" data-rule="on_field_options" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#on_command" class="used-by-link">on_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="on_field_options">on_field_options:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="483" height="229">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <rect x="71" y="19" width="84" height="32" rx="10"></rect>
+         <rect x="69" y="17" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="37">SUBHEAD</text>
+         <rect x="71" y="63" width="86" height="32" rx="10"></rect>
+         <rect x="69" y="61" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="81">SUBFOOT</text>
+         <rect x="217" y="51" width="72" height="32" rx="10"></rect>
+         <rect x="215" y="49" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="225" y="69">CENTER</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="349" y="19" width="66" height="32"></rect>
+            <rect x="347" y="17" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="357" y="37">STRING</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#summarize_command" xlink:title="summarize_command">
+            <rect x="51" y="107" width="158" height="32"></rect>
+            <rect x="49" y="105" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="125">summarize_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#recap_command" xlink:title="recap_command">
+            <rect x="51" y="151" width="124" height="32"></rect>
+            <rect x="49" y="149" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="169">recap_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#PAGE_BREAK" xlink:title="PAGE_BREAK">
+            <rect x="51" y="195" width="102" height="32"></rect>
+            <rect x="49" y="193" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="213">PAGE_BREAK</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m40 0 h10 m84 0 h10 m0 0 h2 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m40 -44 h10 m0 0 h82 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v12 m112 0 v-12 m-112 12 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m72 0 h10 m40 -32 h10 m66 0 h10 m-106 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m86 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-86 0 h10 m0 0 h76 m-404 32 h20 m404 0 h20 m-444 0 q10 0 10 10 m424 0 q0 -10 10 -10 m-434 10 v68 m424 0 v-68 m-424 68 q0 10 10 10 m404 0 q10 0 10 -10 m-414 10 h10 m158 0 h10 m0 0 h226 m-414 -10 v20 m424 0 v-20 m-424 20 v24 m424 0 v-24 m-424 24 q0 10 10 10 m404 0 q10 0 10 -10 m-414 10 h10 m124 0 h10 m0 0 h260 m-414 -10 v20 m424 0 v-20 m-424 20 v24 m424 0 v-24 m-424 24 q0 10 10 10 m404 0 q10 0 10 -10 m-414 10 h10 m102 0 h10 m0 0 h282 m23 -176 h-3"></svg:path>
+         <polygon points="473 33 481 29 481 37"></polygon>
+         <polygon points="473 33 465 29 465 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#on_field_options" title="on_field_options">on_field_options</a></div>
+               <div>         ::= ( 'SUBHEAD' | 'SUBFOOT' ) 'CENTER'? <a href="#STRING" title="STRING">STRING</a>+</div>
+               <div>           | <a href="#summarize_command" title="summarize_command">summarize_command</a></div>
+               <div>           | <a href="#recap_command" title="recap_command">recap_command</a></div>
+               <div>           | <a href="#PAGE_BREAK" title="PAGE_BREAK">PAGE_BREAK</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#on_command" title="on_command">on_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="summarize_command" data-rule="summarize_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#by_command" class="used-by-link">by_command</a>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#on_field_options" class="used-by-link">on_field_options</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#request" class="used-by-link">request</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="summarize_command">summarize_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="659" height="169">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">SUBTOTAL</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#SUB_TOTAL" xlink:title="SUB_TOTAL">
+            <rect x="51" y="47" width="92" height="32"></rect>
+            <rect x="49" y="45" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">SUB_TOTAL</text></a><rect x="51" y="91" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">SUMMARIZE</text>
+         <rect x="51" y="135" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">RECOMPUTE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#summarize_options" xlink:title="summarize_options">
+            <rect x="215" y="35" width="144" height="32"></rect>
+            <rect x="213" y="33" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="223" y="53">summarize_options</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#field" xlink:title="field">
+            <rect x="419" y="35" width="46" height="32"></rect>
+            <rect x="417" y="33" width="46" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="427" y="53">field</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#as_phrase" xlink:title="as_phrase">
+            <rect x="525" y="35" width="86" height="32"></rect>
+            <rect x="523" y="33" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="533" y="53">as_phrase</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m92 0 h10 m0 0 h12 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m92 0 h10 m0 0 h12 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m102 0 h10 m0 0 h2 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m104 0 h10 m40 -132 h10 m0 0 h154 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v12 m184 0 v-12 m-184 12 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m144 0 h10 m40 -32 h10 m0 0 h56 m-86 0 h20 m66 0 h20 m-106 0 q10 0 10 10 m86 0 q0 -10 10 -10 m-96 10 v12 m86 0 v-12 m-86 12 q0 10 10 10 m66 0 q10 0 10 -10 m-76 10 h10 m46 0 h10 m40 -32 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="649 17 657 13 657 21"></polygon>
+         <polygon points="649 17 641 13 641 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#summarize_command" title="summarize_command">summarize_command</a></div>
+               <div>         ::= ( 'SUBTOTAL' | <a href="#SUB_TOTAL" title="SUB_TOTAL">SUB_TOTAL</a> | 'SUMMARIZE' | 'RECOMPUTE' ) <a href="#summarize_options" title="summarize_options">summarize_options</a>? <a href="#field" title="field">field</a>? <a href="#as_phrase" title="as_phrase">as_phrase</a>?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#by_command" title="by_command">by_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_field_options" title="on_field_options">on_field_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="summarize_options" data-rule="summarize_options" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#summarize_command" class="used-by-link">summarize_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="summarize_options">summarize_options:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="479" height="757">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ROLL_DOT" xlink:title="ROLL_DOT">
+            <rect x="51" y="19" width="84" height="32"></rect>
+            <rect x="49" y="17" width="84" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="37">ROLL_DOT</text></a><rect x="71" y="63" width="46" height="32" rx="10"></rect>
+         <rect x="69" y="61" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="81">AVE</text>
+         <rect x="71" y="107" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="105" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="125">MIN</text>
+         <rect x="71" y="151" width="50" height="32" rx="10"></rect>
+         <rect x="69" y="149" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="169">MAX</text>
+         <rect x="71" y="195" width="46" height="32" rx="10"></rect>
+         <rect x="69" y="193" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="213">CNT</text>
+         <rect x="71" y="239" width="44" height="32" rx="10"></rect>
+         <rect x="69" y="237" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="257">FST</text>
+         <rect x="71" y="283" width="44" height="32" rx="10"></rect>
+         <rect x="69" y="281" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="301">LST</text>
+         <rect x="71" y="327" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="325" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="345">ASQ</text>
+         <rect x="71" y="371" width="50" height="32" rx="10"></rect>
+         <rect x="69" y="369" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="389">MDN</text>
+         <rect x="71" y="415" width="50" height="32" rx="10"></rect>
+         <rect x="69" y="413" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="433">MDE</text>
+         <rect x="71" y="459" width="46" height="32" rx="10"></rect>
+         <rect x="69" y="457" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="477">PCT</text>
+         <rect x="71" y="503" width="56" height="32" rx="10"></rect>
+         <rect x="69" y="501" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="521">RPCT</text>
+         <rect x="71" y="547" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="545" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="565">RNK</text>
+         <rect x="71" y="591" width="46" height="32" rx="10"></rect>
+         <rect x="69" y="589" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="609">DST</text>
+         <rect x="71" y="635" width="46" height="32" rx="10"></rect>
+         <rect x="69" y="633" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="653">TOT</text>
+         <rect x="71" y="679" width="50" height="32" rx="10"></rect>
+         <rect x="69" y="677" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="697">SUM</text>
+         <rect x="71" y="723" width="36" height="32" rx="10"></rect>
+         <rect x="69" y="721" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="741">CT</text>
+         <rect x="167" y="63" width="24" height="32" rx="10"></rect>
+         <rect x="165" y="61" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="175" y="81">.</text>
+         <rect x="291" y="19" width="46" height="32" rx="10"></rect>
+         <rect x="289" y="17" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="37">AVE</text>
+         <rect x="291" y="63" width="48" height="32" rx="10"></rect>
+         <rect x="289" y="61" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="81">MIN</text>
+         <rect x="291" y="107" width="50" height="32" rx="10"></rect>
+         <rect x="289" y="105" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="125">MAX</text>
+         <rect x="291" y="151" width="46" height="32" rx="10"></rect>
+         <rect x="289" y="149" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="169">CNT</text>
+         <rect x="291" y="195" width="44" height="32" rx="10"></rect>
+         <rect x="289" y="193" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="213">FST</text>
+         <rect x="291" y="239" width="44" height="32" rx="10"></rect>
+         <rect x="289" y="237" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="257">LST</text>
+         <rect x="291" y="283" width="48" height="32" rx="10"></rect>
+         <rect x="289" y="281" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="301">ASQ</text>
+         <rect x="291" y="327" width="50" height="32" rx="10"></rect>
+         <rect x="289" y="325" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="345">MDN</text>
+         <rect x="291" y="371" width="50" height="32" rx="10"></rect>
+         <rect x="289" y="369" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="389">MDE</text>
+         <rect x="291" y="415" width="46" height="32" rx="10"></rect>
+         <rect x="289" y="413" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="433">PCT</text>
+         <rect x="291" y="459" width="56" height="32" rx="10"></rect>
+         <rect x="289" y="457" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="477">RPCT</text>
+         <rect x="291" y="503" width="48" height="32" rx="10"></rect>
+         <rect x="289" y="501" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="521">RNK</text>
+         <rect x="291" y="547" width="46" height="32" rx="10"></rect>
+         <rect x="289" y="545" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="565">DST</text>
+         <rect x="291" y="591" width="46" height="32" rx="10"></rect>
+         <rect x="289" y="589" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="609">TOT</text>
+         <rect x="291" y="635" width="50" height="32" rx="10"></rect>
+         <rect x="289" y="633" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="653">SUM</text>
+         <rect x="291" y="679" width="36" height="32" rx="10"></rect>
+         <rect x="289" y="677" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="697">CT</text>
+         <rect x="387" y="19" width="24" height="32" rx="10"></rect>
+         <rect x="385" y="17" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="395" y="37">.</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m20 0 h10 m84 0 h10 m0 0 h56 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-150 10 h10 m46 0 h10 m0 0 h10 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m48 0 h10 m0 0 h8 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m50 0 h10 m0 0 h6 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m44 0 h10 m0 0 h12 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m44 0 h10 m0 0 h12 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m48 0 h10 m0 0 h8 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m50 0 h10 m0 0 h6 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m50 0 h10 m0 0 h6 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m48 0 h10 m0 0 h8 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m50 0 h10 m0 0 h6 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m36 0 h10 m0 0 h20 m20 -660 h10 m24 0 h10 m80 -44 h10 m46 0 h10 m0 0 h10 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m48 0 h10 m0 0 h8 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m50 0 h10 m0 0 h6 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m44 0 h10 m0 0 h12 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m44 0 h10 m0 0 h12 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m48 0 h10 m0 0 h8 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m50 0 h10 m0 0 h6 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m50 0 h10 m0 0 h6 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m48 0 h10 m0 0 h8 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m50 0 h10 m0 0 h6 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m36 0 h10 m0 0 h20 m20 -660 h10 m24 0 h10 m-180 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m160 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-160 0 h10 m0 0 h150 m-200 32 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v674 m220 0 v-674 m-220 674 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m0 0 h190 m23 -694 h-3"></svg:path>
+         <polygon points="469 33 477 29 477 37"></polygon>
+         <polygon points="469 33 461 29 461 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#summarize_options" title="summarize_options">summarize_options</a></div>
+               <div>         ::= ( <a href="#ROLL_DOT" title="ROLL_DOT">ROLL_DOT</a> | ( 'AVE' | 'MIN' | 'MAX' | 'CNT' | 'FST' | 'LST' | 'ASQ' | 'MDN' | 'MDE' | 'PCT'
+                  | 'RPCT' | 'RNK' | 'DST' | 'TOT' | 'SUM' | 'CT' ) '.' ) ( ( 'AVE' | 'MIN' | 'MAX'
+                  | 'CNT' | 'FST' | 'LST' | 'ASQ' | 'MDN' | 'MDE' | 'PCT' | 'RPCT' | 'RNK' | 'DST' |
+                  'TOT' | 'SUM' | 'CT' ) '.' )*</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#summarize_command" title="summarize_command">summarize_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="output_command" data-rule="output_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="output_command">output_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="785" height="169">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">HOLD</text>
+         <rect x="51" y="47" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">PCHOLD</text>
+         <rect x="51" y="91" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">SAVE</text>
+         <rect x="51" y="135" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">SAVB</text>
+         <rect x="187" y="35" width="38" height="32" rx="10"></rect>
+         <rect x="185" y="33" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="195" y="53">AS</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="245" y="35" width="118" height="32"></rect>
+            <rect x="243" y="33" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="253" y="53">qualified_name</text></a><rect x="423" y="35" width="76" height="32" rx="10"></rect>
+         <rect x="421" y="33" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="431" y="53">FORMAT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="539" y="35" width="54" height="32"></rect>
+            <rect x="537" y="33" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="547" y="53">NAME</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#verb" xlink:title="verb">
+            <rect x="539" y="79" width="48" height="32"></rect>
+            <rect x="537" y="77" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="547" y="97">verb</text></a><rect x="673" y="35" width="58" height="32" rx="10"></rect>
+         <rect x="671" y="33" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="681" y="53">OPEN</text>
+         <rect x="673" y="79" width="64" height="32" rx="10"></rect>
+         <rect x="671" y="77" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="681" y="97">CLOSE</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m58 0 h10 m0 0 h18 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m56 0 h10 m0 0 h20 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m56 0 h10 m0 0 h20 m40 -132 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m38 0 h10 m0 0 h10 m118 0 h10 m40 -32 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m76 0 h10 m20 0 h10 m54 0 h10 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v24 m94 0 v-24 m-94 24 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m48 0 h10 m0 0 h6 m60 -76 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m58 0 h10 m0 0 h6 m-94 -10 v20 m104 0 v-20 m-104 20 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m23 -76 h-3"></svg:path>
+         <polygon points="775 17 783 13 783 21"></polygon>
+         <polygon points="775 17 767 13 767 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#output_command" title="output_command">output_command</a></div>
+               <div>         ::= ( 'HOLD' | 'PCHOLD' | 'SAVE' | 'SAVB' ) ( 'AS' <a href="#qualified_name" title="qualified_name">qualified_name</a> )? ( 'FORMAT' ( <a href="#NAME" title="NAME">NAME</a> | <a href="#verb" title="verb">verb</a> ) )? ( 'OPEN' | 'CLOSE' )?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="merge_command" data-rule="merge_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="merge_command">merge_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="773" height="155">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="66" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">MERGE</text>
+         <rect x="117" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="115" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="125" y="21">INTO</text>
+         <rect x="193" y="3" width="50" height="32" rx="10"></rect>
+         <rect x="191" y="1" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="201" y="21">FILE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="263" y="3" width="118" height="32"></rect>
+            <rect x="261" y="1" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="271" y="21">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#matching_clause" xlink:title="matching_clause">
+            <rect x="401" y="3" width="126" height="32"></rect>
+            <rect x="399" y="1" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="409" y="21">matching_clause</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#when_matched_clause" xlink:title="when_matched_clause">
+            <rect x="567" y="35" width="164" height="32"></rect>
+            <rect x="565" y="33" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="575" y="53">when_matched_clause</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#when_not_matched_clause" xlink:title="when_not_matched_clause">
+            <rect x="531" y="121" width="194" height="32"></rect>
+            <rect x="529" y="119" width="194" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="539" y="139">when_not_matched_clause</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m164 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-284 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m194 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="763 103 771 99 771 107"></polygon>
+         <polygon points="763 103 755 99 755 107"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#merge_command" title="merge_command">merge_command</a></div>
+               <div>         ::= 'MERGE' 'INTO' 'FILE' <a href="#qualified_name" title="qualified_name">qualified_name</a> <a href="#matching_clause" title="matching_clause">matching_clause</a> <a href="#when_matched_clause" title="when_matched_clause">when_matched_clause</a>? <a href="#when_not_matched_clause" title="when_not_matched_clause">when_not_matched_clause</a>?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="matching_clause" data-rule="matching_clause" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#merge_command" class="used-by-link">merge_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="matching_clause">matching_clause:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="609" height="113">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <rect x="31" y="47" width="94" height="32" rx="10"></rect>
+         <rect x="29" y="45" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="65">MATCHING</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="165" y="47" width="118" height="32"></rect>
+            <rect x="163" y="45" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="173" y="65">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="303" y="47" width="36" height="32"></rect>
+            <rect x="301" y="45" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="311" y="65">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="359" y="47" width="118" height="32"></rect>
+            <rect x="357" y="45" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="367" y="65">qualified_name</text></a><rect x="165" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="163" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="173" y="21">AND</text>
+         <rect x="537" y="79" width="24" height="32" rx="10"></rect>
+         <rect x="535" y="77" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="545" y="97">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m0 0 h10 m94 0 h10 m20 0 h10 m118 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m118 0 h10 m-352 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m332 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-332 0 h10 m48 0 h10 m0 0 h264 m40 44 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="599 61 607 57 607 65"></polygon>
+         <polygon points="599 61 591 57 591 65"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#matching_clause" title="matching_clause">matching_clause</a></div>
+               <div>         ::= 'MATCHING' <a href="#qualified_name" title="qualified_name">qualified_name</a> <a href="#EQ" title="EQ">EQ</a> <a href="#qualified_name" title="qualified_name">qualified_name</a> ( 'AND' <a href="#qualified_name" title="qualified_name">qualified_name</a> <a href="#EQ" title="EQ">EQ</a> <a href="#qualified_name" title="qualified_name">qualified_name</a> )* ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#merge_command" title="merge_command">merge_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="when_matched_clause" data-rule="when_matched_clause" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#merge_command" class="used-by-link">merge_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="when_matched_clause">when_matched_clause:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="775" height="85">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <rect x="31" y="19" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="17" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="37">WHEN</text>
+         <rect x="113" y="19" width="86" height="32" rx="10"></rect>
+         <rect x="111" y="17" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="37">MATCHED</text>
+         <rect x="219" y="19" width="74" height="32" rx="10"></rect>
+         <rect x="217" y="17" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="227" y="37">UPDATE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="333" y="19" width="118" height="32"></rect>
+            <rect x="331" y="17" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="341" y="37">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="471" y="19" width="36" height="32"></rect>
+            <rect x="469" y="17" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="479" y="37">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="527" y="19" width="116" height="32"></rect>
+            <rect x="525" y="17" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="535" y="37">dm_expression</text></a><rect x="683" y="51" width="24" height="32" rx="10"></rect>
+         <rect x="681" y="49" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="691" y="69">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m0 0 h10 m62 0 h10 m0 0 h10 m86 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m118 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m116 0 h10 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m-414 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m414 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-414 0 h10 m0 0 h404 m23 32 h-3"></svg:path>
+         <polygon points="765 33 773 29 773 37"></polygon>
+         <polygon points="765 33 757 29 757 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#when_matched_clause" title="when_matched_clause">when_matched_clause</a></div>
+               <div>         ::= 'WHEN' 'MATCHED' 'UPDATE' ( <a href="#qualified_name" title="qualified_name">qualified_name</a> <a href="#EQ" title="EQ">EQ</a> <a href="#dm_expression" title="dm_expression">dm_expression</a> ';'? )+</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#merge_command" title="merge_command">merge_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="when_not_matched_clause" data-rule="when_not_matched_clause" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#merge_command" class="used-by-link">merge_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="when_not_matched_clause">when_not_matched_clause:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="839" height="85">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <rect x="31" y="19" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="17" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="37">WHEN</text>
+         <rect x="113" y="19" width="48" height="32" rx="10"></rect>
+         <rect x="111" y="17" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="37">NOT</text>
+         <rect x="181" y="19" width="86" height="32" rx="10"></rect>
+         <rect x="179" y="17" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="189" y="37">MATCHED</text>
+         <rect x="287" y="19" width="70" height="32" rx="10"></rect>
+         <rect x="285" y="17" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="295" y="37">INSERT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="397" y="19" width="118" height="32"></rect>
+            <rect x="395" y="17" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="405" y="37">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="535" y="19" width="36" height="32"></rect>
+            <rect x="533" y="17" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="543" y="37">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="591" y="19" width="116" height="32"></rect>
+            <rect x="589" y="17" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="599" y="37">dm_expression</text></a><rect x="747" y="51" width="24" height="32" rx="10"></rect>
+         <rect x="745" y="49" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="755" y="69">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m0 0 h10 m62 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m86 0 h10 m0 0 h10 m70 0 h10 m20 0 h10 m118 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m116 0 h10 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m-414 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m414 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-414 0 h10 m0 0 h404 m23 32 h-3"></svg:path>
+         <polygon points="829 33 837 29 837 37"></polygon>
+         <polygon points="829 33 821 29 821 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#when_not_matched_clause" title="when_not_matched_clause">when_not_matched_clause</a></div>
+               <div>         ::= 'WHEN' 'NOT' 'MATCHED' 'INSERT' ( <a href="#qualified_name" title="qualified_name">qualified_name</a> <a href="#EQ" title="EQ">EQ</a> <a href="#dm_expression" title="dm_expression">dm_expression</a> ';'? )+</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#merge_command" title="merge_command">merge_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="qualified_name" data-rule="qualified_name" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compute_command" class="used-by-link">compute_command</a>
+          <a href="#decode_expression" class="used-by-link">decode_expression</a>
+          <a href="#define_assignment" class="used-by-link">define_assignment</a>
+          <a href="#define_file" class="used-by-link">define_file</a>
+          <a href="#dm_htmlform" class="used-by-link">dm_htmlform</a>
+          <a href="#dm_include" class="used-by-link">dm_include</a>
+          <a href="#dm_read" class="used-by-link">dm_read</a>
+          <a href="#dm_relational_expression" class="used-by-link">dm_relational_expression</a>
+          <a href="#dm_repeat" class="used-by-link">dm_repeat</a>
+          <a href="#dm_type" class="used-by-link">dm_type</a>
+          <a href="#dm_unary_expression" class="used-by-link">dm_unary_expression</a>
+          <a href="#dm_write" class="used-by-link">dm_write</a>
+          <a href="#field" class="used-by-link">field</a>
+          <a href="#join_command" class="used-by-link">join_command</a>
+          <a href="#layout_value" class="used-by-link">layout_value</a>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#matching_clause" class="used-by-link">matching_clause</a>
+          <a href="#merge_command" class="used-by-link">merge_command</a>
+          <a href="#on_command" class="used-by-link">on_command</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#output_command" class="used-by-link">output_command</a>
+          <a href="#recap_assignment" class="used-by-link">recap_assignment</a>
+          <a href="#request" class="used-by-link">request</a>
+          <a href="#show_command" class="used-by-link">show_command</a>
+          <a href="#when_matched_clause" class="used-by-link">when_matched_clause</a>
+          <a href="#when_not_matched_clause" class="used-by-link">when_not_matched_clause</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="qualified_name">qualified_name:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="287" height="4305">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="71" y="47" width="54" height="32"></rect>
+            <rect x="69" y="45" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="65">NAME</text></a><rect x="71" y="91" width="46" height="32" rx="10"></rect>
+         <rect x="69" y="89" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="109">AVE</text>
+         <rect x="71" y="135" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="133" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="153">MIN</text>
+         <rect x="71" y="179" width="50" height="32" rx="10"></rect>
+         <rect x="69" y="177" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="197">MAX</text>
+         <rect x="71" y="223" width="46" height="32" rx="10"></rect>
+         <rect x="69" y="221" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="241">CNT</text>
+         <rect x="71" y="267" width="44" height="32" rx="10"></rect>
+         <rect x="69" y="265" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="285">FST</text>
+         <rect x="71" y="311" width="44" height="32" rx="10"></rect>
+         <rect x="69" y="309" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="329">LST</text>
+         <rect x="71" y="355" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="353" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="373">ASQ</text>
+         <rect x="71" y="399" width="50" height="32" rx="10"></rect>
+         <rect x="69" y="397" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="417">MDN</text>
+         <rect x="71" y="443" width="50" height="32" rx="10"></rect>
+         <rect x="69" y="441" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="461">MDE</text>
+         <rect x="71" y="487" width="46" height="32" rx="10"></rect>
+         <rect x="69" y="485" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="505">PCT</text>
+         <rect x="71" y="531" width="56" height="32" rx="10"></rect>
+         <rect x="69" y="529" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="549">RPCT</text>
+         <rect x="71" y="575" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="573" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="593">RNK</text>
+         <rect x="71" y="619" width="46" height="32" rx="10"></rect>
+         <rect x="69" y="617" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="637">DST</text>
+         <rect x="71" y="663" width="46" height="32" rx="10"></rect>
+         <rect x="69" y="661" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="681">TOT</text>
+         <rect x="71" y="707" width="50" height="32" rx="10"></rect>
+         <rect x="69" y="705" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="725">SUM</text>
+         <rect x="71" y="751" width="36" height="32" rx="10"></rect>
+         <rect x="69" y="749" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="769">CT</text>
+         <rect x="71" y="795" width="36" height="32" rx="10"></rect>
+         <rect x="69" y="793" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="813">IS</text>
+         <rect x="71" y="839" width="92" height="32" rx="10"></rect>
+         <rect x="69" y="837" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="857">CONTAINS</text>
+         <rect x="71" y="883" width="66" height="32" rx="10"></rect>
+         <rect x="69" y="881" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="901">OMITS</text>
+         <rect x="71" y="927" width="52" height="32" rx="10"></rect>
+         <rect x="69" y="925" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="945">LIKE</text>
+         <rect x="71" y="971" width="64" height="32" rx="10"></rect>
+         <rect x="69" y="969" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="989">TOTAL</text>
+         <rect x="71" y="1015" width="82" height="32" rx="10"></rect>
+         <rect x="69" y="1013" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1033">MISSING</text>
+         <rect x="71" y="1059" width="90" height="32" rx="10"></rect>
+         <rect x="69" y="1057" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1077">INCLUDES</text>
+         <rect x="71" y="1103" width="90" height="32" rx="10"></rect>
+         <rect x="69" y="1101" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1121">EXCLUDES</text>
+         <rect x="71" y="1147" width="82" height="32" rx="10"></rect>
+         <rect x="69" y="1145" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1165">EXCEEDS</text>
+         <rect x="71" y="1191" width="44" height="32" rx="10"></rect>
+         <rect x="69" y="1189" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1209">ALL</text>
+         <rect x="71" y="1235" width="54" height="32" rx="10"></rect>
+         <rect x="69" y="1233" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1253">LESS</text>
+         <rect x="71" y="1279" width="58" height="32" rx="10"></rect>
+         <rect x="69" y="1277" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1297">THAN</text>
+         <rect x="71" y="1323" width="60" height="32" rx="10"></rect>
+         <rect x="69" y="1321" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1341">MORE</text>
+         <rect x="71" y="1367" width="82" height="32" rx="10"></rect>
+         <rect x="69" y="1365" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1385">GREATER</text>
+         <rect x="71" y="1411" width="46" height="32" rx="10"></rect>
+         <rect x="69" y="1409" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1429">OFF</text>
+         <rect x="71" y="1455" width="40" height="32" rx="10"></rect>
+         <rect x="69" y="1453" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1473">ON</text>
+         <rect x="71" y="1499" width="64" height="32" rx="10"></rect>
+         <rect x="69" y="1497" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1517">RECAP</text>
+         <rect x="71" y="1543" width="72" height="32" rx="10"></rect>
+         <rect x="69" y="1541" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1561">INDENT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ACROSS_TOTAL" xlink:title="ACROSS_TOTAL">
+            <rect x="71" y="1587" width="118" height="32"></rect>
+            <rect x="69" y="1585" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="1605">ACROSS_TOTAL</text></a><rect x="71" y="1631" width="100" height="32" rx="10"></rect>
+         <rect x="69" y="1629" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1649">COMPOUND</text>
+         <rect x="71" y="1675" width="74" height="32" rx="10"></rect>
+         <rect x="69" y="1673" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1693">LAYOUT</text>
+         <rect x="71" y="1719" width="82" height="32" rx="10"></rect>
+         <rect x="69" y="1717" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1737">SECTION</text>
+         <rect x="71" y="1763" width="110" height="32" rx="10"></rect>
+         <rect x="69" y="1761" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1781">PAGELAYOUT</text>
+         <rect x="71" y="1807" width="108" height="32" rx="10"></rect>
+         <rect x="69" y="1805" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1825">COMPONENT</text>
+         <rect x="71" y="1851" width="66" height="32" rx="10"></rect>
+         <rect x="69" y="1849" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1869">MERGE</text>
+         <rect x="71" y="1895" width="118" height="32" rx="10"></rect>
+         <rect x="69" y="1893" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1913">ORIENTATION</text>
+         <rect x="71" y="1939" width="102" height="32" rx="10"></rect>
+         <rect x="69" y="1937" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1957">LANDSCAPE</text>
+         <rect x="71" y="1983" width="90" height="32" rx="10"></rect>
+         <rect x="69" y="1981" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2001">PORTRAIT</text>
+         <rect x="71" y="2027" width="54" height="32" rx="10"></rect>
+         <rect x="69" y="2025" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2045">TYPE</text>
+         <rect x="71" y="2071" width="90" height="32" rx="10"></rect>
+         <rect x="69" y="2069" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2089">POSITION</text>
+         <rect x="71" y="2115" width="102" height="32" rx="10"></rect>
+         <rect x="69" y="2113" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2133">DIMENSION</text>
+         <rect x="71" y="2159" width="62" height="32" rx="10"></rect>
+         <rect x="69" y="2157" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2177">STYLE</text>
+         <rect x="71" y="2203" width="90" height="32" rx="10"></rect>
+         <rect x="69" y="2201" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2221">ENDSTYLE</text>
+         <rect x="71" y="2247" width="68" height="32" rx="10"></rect>
+         <rect x="69" y="2245" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2265">MATCH</text>
+         <rect x="71" y="2291" width="62" height="32" rx="10"></rect>
+         <rect x="69" y="2289" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2309">AFTER</text>
+         <rect x="71" y="2335" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="2333" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2353">RUN</text>
+         <rect x="71" y="2379" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="2377" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2397">OLD</text>
+         <rect x="71" y="2423" width="52" height="32" rx="10"></rect>
+         <rect x="69" y="2421" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2441">NEW</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_OR_NEW_KW" xlink:title="OLD_OR_NEW_KW">
+            <rect x="71" y="2467" width="138" height="32"></rect>
+            <rect x="69" y="2465" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="2485">OLD_OR_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_AND_NEW_KW" xlink:title="OLD_AND_NEW_KW">
+            <rect x="71" y="2511" width="146" height="32"></rect>
+            <rect x="69" y="2509" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="2529">OLD_AND_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_NOT_NEW_KW" xlink:title="OLD_NOT_NEW_KW">
+            <rect x="71" y="2555" width="146" height="32"></rect>
+            <rect x="69" y="2553" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="2573">OLD_NOT_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NEW_NOT_OLD_KW" xlink:title="NEW_NOT_OLD_KW">
+            <rect x="71" y="2599" width="146" height="32"></rect>
+            <rect x="69" y="2597" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="2617">NEW_NOT_OLD_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_NOR_NEW_KW" xlink:title="OLD_NOR_NEW_KW">
+            <rect x="71" y="2643" width="148" height="32"></rect>
+            <rect x="69" y="2641" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="2661">OLD_NOR_NEW_KW</text></a><rect x="71" y="2687" width="94" height="32" rx="10"></rect>
+         <rect x="69" y="2685" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2705">MATCHING</text>
+         <rect x="71" y="2731" width="86" height="32" rx="10"></rect>
+         <rect x="69" y="2729" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2749">MATCHED</text>
+         <rect x="71" y="2775" width="74" height="32" rx="10"></rect>
+         <rect x="69" y="2773" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2793">UPDATE</text>
+         <rect x="71" y="2819" width="70" height="32" rx="10"></rect>
+         <rect x="69" y="2817" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2837">INSERT</text>
+         <rect x="71" y="2863" width="56" height="32" rx="10"></rect>
+         <rect x="69" y="2861" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2881">INTO</text>
+         <rect x="71" y="2907" width="84" height="32" rx="10"></rect>
+         <rect x="69" y="2905" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2925">HEADING</text>
+         <rect x="71" y="2951" width="84" height="32" rx="10"></rect>
+         <rect x="69" y="2949" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="2969">FOOTING</text>
+         <rect x="71" y="2995" width="84" height="32" rx="10"></rect>
+         <rect x="69" y="2993" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3013">SUBHEAD</text>
+         <rect x="71" y="3039" width="86" height="32" rx="10"></rect>
+         <rect x="69" y="3037" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3057">SUBFOOT</text>
+         <rect x="71" y="3083" width="76" height="32" rx="10"></rect>
+         <rect x="69" y="3081" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3101">FORMAT</text>
+         <rect x="71" y="3127" width="62" height="32" rx="10"></rect>
+         <rect x="69" y="3125" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3145">TIMES</text>
+         <rect x="71" y="3171" width="66" height="32" rx="10"></rect>
+         <rect x="69" y="3169" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3189">WHILE</text>
+         <rect x="71" y="3215" width="62" height="32" rx="10"></rect>
+         <rect x="69" y="3213" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3233">UNTIL</text>
+         <rect x="71" y="3259" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="3257" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3277">FOR</text>
+         <rect x="71" y="3303" width="54" height="32" rx="10"></rect>
+         <rect x="69" y="3301" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3321">STEP</text>
+         <rect x="71" y="3347" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="3345" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3365">TOP</text>
+         <rect x="71" y="3391" width="78" height="32" rx="10"></rect>
+         <rect x="69" y="3389" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3409">BOTTOM</text>
+         <rect x="71" y="3435" width="76" height="32" rx="10"></rect>
+         <rect x="69" y="3433" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3453">RANKED</text>
+         <rect x="71" y="3479" width="84" height="32" rx="10"></rect>
+         <rect x="69" y="3477" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3497">NOPRINT</text>
+         <rect x="71" y="3523" width="38" height="32" rx="10"></rect>
+         <rect x="69" y="3521" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3541">AS</text>
+         <rect x="71" y="3567" width="36" height="32" rx="10"></rect>
+         <rect x="69" y="3565" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3585">IN</text>
+         <rect x="71" y="3611" width="100" height="32" rx="10"></rect>
+         <rect x="69" y="3609" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3629">HIERARCHY</text>
+         <rect x="71" y="3655" width="62" height="32" rx="10"></rect>
+         <rect x="69" y="3653" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3673">WHEN</text>
+         <rect x="71" y="3699" width="64" height="32" rx="10"></rect>
+         <rect x="69" y="3697" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3717">SHOW</text>
+         <rect x="71" y="3743" width="38" height="32" rx="10"></rect>
+         <rect x="69" y="3741" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3761">UP</text>
+         <rect x="71" y="3787" width="64" height="32" rx="10"></rect>
+         <rect x="69" y="3785" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3805">DOWN</text>
+         <rect x="71" y="3831" width="58" height="32" rx="10"></rect>
+         <rect x="69" y="3829" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3849">OPEN</text>
+         <rect x="71" y="3875" width="64" height="32" rx="10"></rect>
+         <rect x="69" y="3873" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3893">CLOSE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#PAGE_BREAK" xlink:title="PAGE_BREAK">
+            <rect x="71" y="3919" width="102" height="32"></rect>
+            <rect x="69" y="3917" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="3937">PAGE_BREAK</text></a><rect x="71" y="3963" width="130" height="32" rx="10"></rect>
+         <rect x="69" y="3961" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="3981">DRILLTHROUGH</text>
+         <rect x="71" y="4007" width="78" height="32" rx="10"></rect>
+         <rect x="69" y="4005" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="4025">COLUMN</text>
+         <rect x="71" y="4051" width="52" height="32" rx="10"></rect>
+         <rect x="69" y="4049" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="4069">LINE</text>
+         <rect x="71" y="4095" width="54" height="32" rx="10"></rect>
+         <rect x="69" y="4093" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="4113">ITEM</text>
+         <rect x="71" y="4139" width="68" height="32" rx="10"></rect>
+         <rect x="69" y="4137" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="4157">COLOR</text>
+         <rect x="71" y="4183" width="80" height="32" rx="10"></rect>
+         <rect x="69" y="4181" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="4201">DEFAULT</text>
+         <rect x="71" y="4227" width="56" height="32" rx="10"></rect>
+         <rect x="69" y="4225" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="4245">READ</text>
+         <rect x="71" y="4271" width="66" height="32" rx="10"></rect>
+         <rect x="69" y="4269" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="4289">WRITE</text>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">.</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m40 0 h10 m54 0 h10 m0 0 h94 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m92 0 h10 m0 0 h56 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m58 0 h10 m0 0 h90 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m60 0 h10 m0 0 h88 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m40 0 h10 m0 0 h108 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m72 0 h10 m0 0 h76 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m118 0 h10 m0 0 h30 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m100 0 h10 m0 0 h48 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m74 0 h10 m0 0 h74 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m110 0 h10 m0 0 h38 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m108 0 h10 m0 0 h40 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m118 0 h10 m0 0 h30 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m68 0 h10 m0 0 h80 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m138 0 h10 m0 0 h10 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m148 0 h10 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m94 0 h10 m0 0 h54 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m86 0 h10 m0 0 h62 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m74 0 h10 m0 0 h74 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m70 0 h10 m0 0 h78 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m86 0 h10 m0 0 h62 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m76 0 h10 m0 0 h72 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m78 0 h10 m0 0 h70 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m76 0 h10 m0 0 h72 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m38 0 h10 m0 0 h110 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m100 0 h10 m0 0 h48 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m38 0 h10 m0 0 h110 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m58 0 h10 m0 0 h90 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m130 0 h10 m0 0 h18 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m78 0 h10 m0 0 h70 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m68 0 h10 m0 0 h80 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m80 0 h10 m0 0 h68 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-208 -4224 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m208 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-208 0 h10 m24 0 h10 m0 0 h164 m23 44 h-3"></svg:path>
+         <polygon points="277 61 285 57 285 65"></polygon>
+         <polygon points="277 61 269 57 269 65"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#qualified_name" title="qualified_name">qualified_name</a></div>
+               <div>         ::= ( <a href="#NAME" title="NAME">NAME</a> | 'AVE' | 'MIN' | 'MAX' | 'CNT' | 'FST' | 'LST' | 'ASQ' | 'MDN' | 'MDE' | 'PCT' |
+                  'RPCT' | 'RNK' | 'DST' | 'TOT' | 'SUM' | 'CT' | 'IS' | 'CONTAINS' | 'OMITS' | 'LIKE'
+                  | 'TOTAL' | 'MISSING' | 'INCLUDES' | 'EXCLUDES' | 'EXCEEDS' | 'ALL' | 'LESS' | 'THAN'
+                  | 'MORE' | 'GREATER' | 'OFF' | 'ON' | 'RECAP' | 'INDENT' | <a href="#ACROSS_TOTAL" title="ACROSS_TOTAL">ACROSS_TOTAL</a> | 'COMPOUND' | 'LAYOUT' | 'SECTION' | 'PAGELAYOUT' | 'COMPONENT' | 'MERGE' | 'ORIENTATION'
+                  | 'LANDSCAPE' | 'PORTRAIT' | 'TYPE' | 'POSITION' | 'DIMENSION' | 'STYLE' | 'ENDSTYLE'
+                  | 'MATCH' | 'AFTER' | 'RUN' | 'OLD' | 'NEW' | <a href="#OLD_OR_NEW_KW" title="OLD_OR_NEW_KW">OLD_OR_NEW_KW</a> | <a href="#OLD_AND_NEW_KW" title="OLD_AND_NEW_KW">OLD_AND_NEW_KW</a> | <a href="#OLD_NOT_NEW_KW" title="OLD_NOT_NEW_KW">OLD_NOT_NEW_KW</a> | <a href="#NEW_NOT_OLD_KW" title="NEW_NOT_OLD_KW">NEW_NOT_OLD_KW</a> | <a href="#OLD_NOR_NEW_KW" title="OLD_NOR_NEW_KW">OLD_NOR_NEW_KW</a> | 'MATCHING' | 'MATCHED' | 'UPDATE' | 'INSERT' | 'INTO' | 'HEADING' | 'FOOTING' |
+                  'SUBHEAD' | 'SUBFOOT' | 'FORMAT' | 'TIMES' | 'WHILE' | 'UNTIL' | 'FOR' | 'STEP' |
+                  'TOP' | 'BOTTOM' | 'RANKED' | 'NOPRINT' | 'AS' | 'IN' | 'HIERARCHY' | 'WHEN' | 'SHOW'
+                  | 'UP' | 'DOWN' | 'OPEN' | 'CLOSE' | <a href="#PAGE_BREAK" title="PAGE_BREAK">PAGE_BREAK</a> | 'DRILLTHROUGH' | 'COLUMN' | 'LINE' | 'ITEM' | 'COLOR' | 'DEFAULT' | 'READ' | 'WRITE'
+                  ) ( '.' ( <a href="#NAME" title="NAME">NAME</a> | 'AVE' | 'MIN' | 'MAX' | 'CNT' | 'FST' | 'LST' | 'ASQ' | 'MDN' | 'MDE' | 'PCT' |
+                  'RPCT' | 'RNK' | 'DST' | 'TOT' | 'SUM' | 'CT' | 'IS' | 'CONTAINS' | 'OMITS' | 'LIKE'
+                  | 'TOTAL' | 'MISSING' | 'INCLUDES' | 'EXCLUDES' | 'EXCEEDS' | 'ALL' | 'LESS' | 'THAN'
+                  | 'MORE' | 'GREATER' | 'OFF' | 'ON' | 'RECAP' | 'INDENT' | <a href="#ACROSS_TOTAL" title="ACROSS_TOTAL">ACROSS_TOTAL</a> | 'COMPOUND' | 'LAYOUT' | 'SECTION' | 'PAGELAYOUT' | 'COMPONENT' | 'MERGE' | 'ORIENTATION'
+                  | 'LANDSCAPE' | 'PORTRAIT' | 'TYPE' | 'POSITION' | 'DIMENSION' | 'STYLE' | 'ENDSTYLE'
+                  | 'MATCH' | 'AFTER' | 'RUN' | 'OLD' | 'NEW' | <a href="#OLD_OR_NEW_KW" title="OLD_OR_NEW_KW">OLD_OR_NEW_KW</a> | <a href="#OLD_AND_NEW_KW" title="OLD_AND_NEW_KW">OLD_AND_NEW_KW</a> | <a href="#OLD_NOT_NEW_KW" title="OLD_NOT_NEW_KW">OLD_NOT_NEW_KW</a> | <a href="#NEW_NOT_OLD_KW" title="NEW_NOT_OLD_KW">NEW_NOT_OLD_KW</a> | <a href="#OLD_NOR_NEW_KW" title="OLD_NOR_NEW_KW">OLD_NOR_NEW_KW</a> | 'MATCHING' | 'MATCHED' | 'UPDATE' | 'INSERT' | 'INTO' | 'HEADING' | 'FOOTING' |
+                  'SUBHEAD' | 'SUBFOOT' | 'FORMAT' | 'TIMES' | 'WHILE' | 'UNTIL' | 'FOR' | 'STEP' |
+                  'TOP' | 'BOTTOM' | 'RANKED' | 'NOPRINT' | 'AS' | 'IN' | 'HIERARCHY' | 'WHEN' | 'SHOW'
+                  | 'UP' | 'DOWN' | 'OPEN' | 'CLOSE' | <a href="#PAGE_BREAK" title="PAGE_BREAK">PAGE_BREAK</a> | 'DRILLTHROUGH' | 'COLUMN' | 'LINE' | 'ITEM' | 'COLOR' | 'DEFAULT' | 'READ' | 'WRITE'
+                  ) )*</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compute_command" title="compute_command">compute_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#decode_expression" title="decode_expression">decode_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#define_assignment" title="define_assignment">define_assignment</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#define_file" title="define_file">define_file</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_htmlform" title="dm_htmlform">dm_htmlform</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_include" title="dm_include">dm_include</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_read" title="dm_read">dm_read</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_relational_expression" title="dm_relational_expression">dm_relational_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_repeat" title="dm_repeat">dm_repeat</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_type" title="dm_type">dm_type</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_write" title="dm_write">dm_write</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#field" title="field">field</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#join_command" title="join_command">join_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#layout_value" title="layout_value">layout_value</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#matching_clause" title="matching_clause">matching_clause</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#merge_command" title="merge_command">merge_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_command" title="on_command">on_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#output_command" title="output_command">output_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#recap_assignment" title="recap_assignment">recap_assignment</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#show_command" title="show_command">show_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#when_matched_clause" title="when_matched_clause">when_matched_clause</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#when_not_matched_clause" title="when_not_matched_clause">when_not_matched_clause</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="SET_DM" data-rule="SET_DM" data-description="Keywords
+-SET command">
+      <div class="rule-description">Keywords<br/>-SET command</div>
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_set" class="used-by-link">dm_set</a>
+          <a href="#dm_token" class="used-by-link">dm_token</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="SET_DM">SET_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="149" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="44" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">SET</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m44 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="139 17 147 13 147 21"></polygon>
+         <polygon points="139 17 131 13 131 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#SET_DM" title="SET_DM">SET_DM</a>   ::= '-' 'SET'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_set" title="dm_set">dm_set</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_token" title="dm_token">dm_token</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="GOTO_DM" data-rule="GOTO_DM" data-description="-GOTO command">
+      <div class="rule-description">-GOTO command</div>
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_goto" class="used-by-link">dm_goto</a>
+          <a href="#dm_token" class="used-by-link">dm_token</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="GOTO_DM">GOTO_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="165" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="60" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">GOTO</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m60 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="155 17 163 13 163 21"></polygon>
+         <polygon points="155 17 147 13 147 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#GOTO_DM" title="GOTO_DM">GOTO_DM</a>  ::= '-' 'GOTO'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_goto" title="dm_goto">dm_goto</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_token" title="dm_token">dm_token</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="REPEAT_DM" data-rule="REPEAT_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_repeat" class="used-by-link">dm_repeat</a>
+          <a href="#dm_token" class="used-by-link">dm_token</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="REPEAT_DM">REPEAT_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="177" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">REPEAT</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m72 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="167 17 175 13 175 21"></polygon>
+         <polygon points="167 17 159 13 159 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#REPEAT_DM" title="REPEAT_DM">REPEAT_DM</a></div>
+               <div>         ::= '-' 'REPEAT'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_repeat" title="dm_repeat">dm_repeat</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_token" title="dm_token">dm_token</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="IF_DM" data-rule="IF_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_if" class="used-by-link">dm_if</a>
+          <a href="#dm_token" class="used-by-link">dm_token</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="IF_DM">IF_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="139" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="34" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">IF</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m34 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="129 17 137 13 137 21"></polygon>
+         <polygon points="129 17 121 13 121 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#IF_DM" title="IF_DM">IF_DM</a>    ::= '-' 'IF'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_if" title="dm_if">dm_if</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_token" title="dm_token">dm_token</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="TYPE_DM" data-rule="TYPE_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_token" class="used-by-link">dm_token</a>
+          <a href="#dm_type" class="used-by-link">dm_type</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="TYPE_DM">TYPE_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="159" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">TYPE</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m54 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="149 17 157 13 157 21"></polygon>
+         <polygon points="149 17 141 13 141 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#TYPE_DM" title="TYPE_DM">TYPE_DM</a>  ::= '-' 'TYPE'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_token" title="dm_token">dm_token</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_type" title="dm_type">dm_type</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="INCLUDE_DM" data-rule="INCLUDE_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_include" class="used-by-link">dm_include</a>
+          <a href="#dm_token" class="used-by-link">dm_token</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="INCLUDE_DM">INCLUDE_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="185" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="80" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">INCLUDE</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="175 17 183 13 183 21"></polygon>
+         <polygon points="175 17 167 13 167 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#INCLUDE_DM" title="INCLUDE_DM">INCLUDE_DM</a></div>
+               <div>         ::= '-' 'INCLUDE'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_include" title="dm_include">dm_include</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_token" title="dm_token">dm_token</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="HTMLFORM_DM" data-rule="HTMLFORM_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_htmlform" class="used-by-link">dm_htmlform</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="HTMLFORM_DM">HTMLFORM_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="201" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="96" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">HTMLFORM</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m96 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="191 17 199 13 199 21"></polygon>
+         <polygon points="191 17 183 13 183 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#HTMLFORM_DM" title="HTMLFORM_DM">HTMLFORM_DM</a></div>
+               <div>         ::= '-' 'HTMLFORM'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_htmlform" title="dm_htmlform">dm_htmlform</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="HTMLFORM_BLOCK" data-rule="HTMLFORM_BLOCK" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_htmlform" class="used-by-link">dm_htmlform</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="HTMLFORM_BLOCK">HTMLFORM_BLOCK:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="865" height="159">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 51 1 47 1 55"></polygon>
+         <polygon points="17 51 9 47 9 55"></polygon>
+         <rect x="31" y="37" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="35" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="55">-</text>
+         <rect x="77" y="37" width="96" height="32" rx="10"></rect>
+         <rect x="75" y="35" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="55">HTMLFORM</text>
+         <rect x="233" y="37" width="24" height="32" rx="10"></rect>
+         <rect x="231" y="35" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="241" y="55"></text>
+         <rect x="233" y="81" width="28" height="32" rx="10"></rect>
+         <rect x="231" y="79" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="241" y="99">\</text>
+         <rect x="233" y="125" width="24" height="32" rx="10"></rect>
+         <rect x="231" y="123" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="241" y="143">t</text>
+         <rect x="321" y="37" width="64" height="32" rx="10"></rect>
+         <rect x="319" y="35" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="329" y="55">BEGIN</text>
+         <polygon points="425 19 432 3 452 3 459 19 452 35 432 35"></polygon>
+         <polygon points="423 17 430 1 450 1 457 17 450 33 430 33" class="regexp"></polygon>
+         <text class="regexp" x="438" y="21">.</text>
+         <rect x="499" y="37" width="26" height="32" rx="10"></rect>
+         <rect x="497" y="35" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="507" y="55">-</text>
+         <rect x="545" y="37" width="96" height="32" rx="10"></rect>
+         <rect x="543" y="35" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="553" y="55">HTMLFORM</text>
+         <rect x="701" y="37" width="24" height="32" rx="10"></rect>
+         <rect x="699" y="35" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="709" y="55"></text>
+         <rect x="701" y="81" width="28" height="32" rx="10"></rect>
+         <rect x="699" y="79" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="709" y="99">\</text>
+         <rect x="701" y="125" width="24" height="32" rx="10"></rect>
+         <rect x="699" y="123" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="709" y="143">t</text>
+         <rect x="789" y="37" width="48" height="32" rx="10"></rect>
+         <rect x="787" y="35" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="797" y="55">END</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 51 h2 m0 0 h10 m26 0 h10 m0 0 h10 m96 0 h10 m40 0 h10 m24 0 h10 m0 0 h4 m-68 0 h20 m48 0 h20 m-88 0 q10 0 10 10 m68 0 q0 -10 10 -10 m-78 10 v24 m68 0 v-24 m-68 24 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m28 0 h10 m-58 -10 v20 m68 0 v-20 m-68 20 v24 m68 0 v-24 m-68 24 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m24 0 h10 m0 0 h4 m-88 -88 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m88 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-88 0 h10 m0 0 h78 m20 32 h10 m64 0 h10 m20 0 h10 m0 0 h44 m-74 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m54 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-54 0 h10 m34 0 h10 m20 34 h10 m26 0 h10 m0 0 h10 m96 0 h10 m40 0 h10 m24 0 h10 m0 0 h4 m-68 0 h20 m48 0 h20 m-88 0 q10 0 10 10 m68 0 q0 -10 10 -10 m-78 10 v24 m68 0 v-24 m-68 24 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m28 0 h10 m-58 -10 v20 m68 0 v-20 m-68 20 v24 m68 0 v-24 m-68 24 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m24 0 h10 m0 0 h4 m-88 -88 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m88 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-88 0 h10 m0 0 h78 m20 32 h10 m48 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="855 51 863 47 863 55"></polygon>
+         <polygon points="855 51 847 47 847 55"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#HTMLFORM_BLOCK" title="HTMLFORM_BLOCK">HTMLFORM_BLOCK</a></div>
+               <div>         ::= '-' 'HTMLFORM' [ \t]+ 'BEGIN' <a href="#." title=".">.</a>* '-' 'HTMLFORM' [ \t]+ 'END'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_htmlform" title="dm_htmlform">dm_htmlform</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="READ_DM" data-rule="READ_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_read" class="used-by-link">dm_read</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="READ_DM">READ_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="161" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">READ</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m56 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="151 17 159 13 159 21"></polygon>
+         <polygon points="151 17 143 13 143 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#READ_DM" title="READ_DM">READ_DM</a>  ::= '-' 'READ'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_read" title="dm_read">dm_read</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="WRITE_DM" data-rule="WRITE_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_write" class="used-by-link">dm_write</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="WRITE_DM">WRITE_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="171" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="66" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">WRITE</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m66 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="161 17 169 13 169 21"></polygon>
+         <polygon points="161 17 153 13 153 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#WRITE_DM" title="WRITE_DM">WRITE_DM</a> ::= '-' 'WRITE'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_write" title="dm_write">dm_write</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="DEFAULT_DM" data-rule="DEFAULT_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_default" class="used-by-link">dm_default</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="DEFAULT_DM">DEFAULT_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="185" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="80" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">DEFAULT</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="175 17 183 13 183 21"></polygon>
+         <polygon points="175 17 167 13 167 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#DEFAULT_DM" title="DEFAULT_DM">DEFAULT_DM</a></div>
+               <div>         ::= '-' 'DEFAULT'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_default" title="dm_default">dm_default</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="DEFAULTS_DM" data-rule="DEFAULTS_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_default" class="used-by-link">dm_default</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="DEFAULTS_DM">DEFAULTS_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="195" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="90" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">DEFAULTS</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="185 17 193 13 193 21"></polygon>
+         <polygon points="185 17 177 13 177 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#DEFAULTS_DM" title="DEFAULTS_DM">DEFAULTS_DM</a></div>
+               <div>         ::= '-' 'DEFAULTS'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_default" title="dm_default">dm_default</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="DEFAULTH_DM" data-rule="DEFAULTH_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_default" class="used-by-link">dm_default</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="DEFAULTH_DM">DEFAULTH_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="195" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="90" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">DEFAULTH</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="185 17 193 13 193 21"></polygon>
+         <polygon points="185 17 177 13 177 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#DEFAULTH_DM" title="DEFAULTH_DM">DEFAULTH_DM</a></div>
+               <div>         ::= '-' 'DEFAULTH'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_default" title="dm_default">dm_default</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="RUN_DM" data-rule="RUN_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_run" class="used-by-link">dm_run</a>
+          <a href="#dm_token" class="used-by-link">dm_token</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="RUN_DM">RUN_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="153" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">RUN</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="143 17 151 13 151 21"></polygon>
+         <polygon points="143 17 135 13 135 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#RUN_DM" title="RUN_DM">RUN_DM</a>   ::= '-' 'RUN'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_run" title="dm_run">dm_run</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_token" title="dm_token">dm_token</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="EXIT_DM" data-rule="EXIT_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_exit" class="used-by-link">dm_exit</a>
+          <a href="#dm_token" class="used-by-link">dm_token</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="EXIT_DM">EXIT_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="157" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">-</text>
+         <rect x="77" y="3" width="52" height="32" rx="10"></rect>
+         <rect x="75" y="1" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="85" y="21">EXIT</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m52 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="147 17 155 13 155 21"></polygon>
+         <polygon points="147 17 139 13 139 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#EXIT_DM" title="EXIT_DM">EXIT_DM</a>  ::= '-' 'EXIT'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_exit" title="dm_exit">dm_exit</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_token" title="dm_token">dm_token</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="SUB_TOTAL" data-rule="SUB_TOTAL" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#summarize_command" class="used-by-link">summarize_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="SUB_TOTAL">SUB_TOTAL:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="237" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SUB</text>
+         <rect x="99" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="97" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="107" y="21">-</text>
+         <rect x="145" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="143" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="21">TOTAL</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="227 17 235 13 235 21"></polygon>
+         <polygon points="227 17 219 13 219 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#SUB_TOTAL" title="SUB_TOTAL">SUB_TOTAL</a></div>
+               <div>         ::= 'SUB' '-' 'TOTAL'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#summarize_command" title="summarize_command">summarize_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="COLUMN_TOTAL_KW" data-rule="COLUMN_TOTAL_KW" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="COLUMN_TOTAL_KW">COLUMN_TOTAL_KW:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="267" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="78" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">COLUMN</text>
+         <rect x="129" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="127" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="137" y="21">-</text>
+         <rect x="175" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="173" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="183" y="21">TOTAL</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m78 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="257 17 265 13 265 21"></polygon>
+         <polygon points="257 17 249 13 249 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#COLUMN_TOTAL_KW" title="COLUMN_TOTAL_KW">COLUMN_TOTAL_KW</a></div>
+               <div>         ::= 'COLUMN' '-' 'TOTAL'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="ROW_TOTAL_KW" data-rule="ROW_TOTAL_KW" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="ROW_TOTAL_KW">ROW_TOTAL_KW:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="243" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ROW</text>
+         <rect x="105" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="103" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="21">-</text>
+         <rect x="151" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="149" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="159" y="21">TOTAL</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="233 17 241 13 241 21"></polygon>
+         <polygon points="233 17 225 13 225 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#ROW_TOTAL_KW" title="ROW_TOTAL_KW">ROW_TOTAL_KW</a></div>
+               <div>         ::= 'ROW' '-' 'TOTAL'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="ACROSS_TOTAL" data-rule="ACROSS_TOTAL" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#across_command" class="used-by-link">across_command</a>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#hyphenated_name" class="used-by-link">hyphenated_name</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#qualified_name" class="used-by-link">qualified_name</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="ACROSS_TOTAL">ACROSS_TOTAL:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="265" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ACROSS</text>
+         <rect x="127" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="125" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="135" y="21">-</text>
+         <rect x="173" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="171" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="181" y="21">TOTAL</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="255 17 263 13 263 21"></polygon>
+         <polygon points="255 17 247 13 247 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#ACROSS_TOTAL" title="ACROSS_TOTAL">ACROSS_TOTAL</a></div>
+               <div>         ::= 'ACROSS' '-' 'TOTAL'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#across_command" title="across_command">across_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#qualified_name" title="qualified_name">qualified_name</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="IS_NOT" data-rule="IS_NOT" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_expression" class="used-by-link">dm_relational_expression</a>
+          <a href="#dm_relational_op" class="used-by-link">dm_relational_op</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="IS_NOT">IS_NOT:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="209" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="36" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">IS</text>
+         <rect x="87" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="85" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="95" y="21">-</text>
+         <rect x="133" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="131" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="141" y="21">NOT</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m36 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="199 17 207 13 207 21"></polygon>
+         <polygon points="199 17 191 13 191 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#IS_NOT" title="IS_NOT">IS_NOT</a>   ::= 'IS' '-' 'NOT'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_expression" title="dm_relational_expression">dm_relational_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_relational_op" title="dm_relational_op">dm_relational_op</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="IS_FROM" data-rule="IS_FROM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_expression" class="used-by-link">dm_relational_expression</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="IS_FROM">IS_FROM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="221" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="36" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">IS</text>
+         <rect x="87" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="85" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="95" y="21">-</text>
+         <rect x="133" y="3" width="60" height="32" rx="10"></rect>
+         <rect x="131" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="141" y="21">FROM</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m36 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m60 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="211 17 219 13 219 21"></polygon>
+         <polygon points="211 17 203 13 203 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#IS_FROM" title="IS_FROM">IS_FROM</a>  ::= 'IS' '-' 'FROM'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_expression" title="dm_relational_expression">dm_relational_expression</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="NOT_FROM" data-rule="NOT_FROM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_expression" class="used-by-link">dm_relational_expression</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="NOT_FROM">NOT_FROM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="233" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">NOT</text>
+         <rect x="99" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="97" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="107" y="21">-</text>
+         <rect x="145" y="3" width="60" height="32" rx="10"></rect>
+         <rect x="143" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="21">FROM</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m60 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="223 17 231 13 231 21"></polygon>
+         <polygon points="223 17 215 13 215 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#NOT_FROM" title="NOT_FROM">NOT_FROM</a> ::= 'NOT' '-' 'FROM'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_expression" title="dm_relational_expression">dm_relational_expression</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="IS_LESS_THAN" data-rule="IS_LESS_THAN" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_op" class="used-by-link">dm_relational_op</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="IS_LESS_THAN">IS_LESS_THAN:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="339" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="36" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">IS</text>
+         <rect x="87" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="85" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="95" y="21">-</text>
+         <rect x="133" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="131" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="141" y="21">LESS</text>
+         <rect x="207" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="205" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="215" y="21">-</text>
+         <rect x="253" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="251" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="21">THAN</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m36 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m58 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="329 17 337 13 337 21"></polygon>
+         <polygon points="329 17 321 13 321 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#IS_LESS_THAN" title="IS_LESS_THAN">IS_LESS_THAN</a></div>
+               <div>         ::= 'IS' '-' 'LESS' '-' 'THAN'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_op" title="dm_relational_op">dm_relational_op</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="IS_MORE_THAN" data-rule="IS_MORE_THAN" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_op" class="used-by-link">dm_relational_op</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="IS_MORE_THAN">IS_MORE_THAN:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="345" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="36" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">IS</text>
+         <rect x="87" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="85" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="95" y="21">-</text>
+         <rect x="133" y="3" width="60" height="32" rx="10"></rect>
+         <rect x="131" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="141" y="21">MORE</text>
+         <rect x="213" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="211" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="221" y="21">-</text>
+         <rect x="259" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="257" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="267" y="21">THAN</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m36 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m58 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="335 17 343 13 343 21"></polygon>
+         <polygon points="335 17 327 13 327 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#IS_MORE_THAN" title="IS_MORE_THAN">IS_MORE_THAN</a></div>
+               <div>         ::= 'IS' '-' 'MORE' '-' 'THAN'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_op" title="dm_relational_op">dm_relational_op</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="IS_GREATER_THAN" data-rule="IS_GREATER_THAN" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_op" class="used-by-link">dm_relational_op</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="IS_GREATER_THAN">IS_GREATER_THAN:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="367" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="36" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">IS</text>
+         <rect x="87" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="85" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="95" y="21">-</text>
+         <rect x="133" y="3" width="82" height="32" rx="10"></rect>
+         <rect x="131" y="1" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="141" y="21">GREATER</text>
+         <rect x="235" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="233" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="243" y="21">-</text>
+         <rect x="281" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="279" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="289" y="21">THAN</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m36 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m58 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="357 17 365 13 365 21"></polygon>
+         <polygon points="357 17 349 13 349 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#IS_GREATER_THAN" title="IS_GREATER_THAN">IS_GREATER_THAN</a></div>
+               <div>         ::= 'IS' '-' 'GREATER' '-' 'THAN'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_op" title="dm_relational_op">dm_relational_op</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="OLD_OR_NEW_KW" data-rule="OLD_OR_NEW_KW" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#hyphenated_name" class="used-by-link">hyphenated_name</a>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#qualified_name" class="used-by-link">qualified_name</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="OLD_OR_NEW_KW">OLD_OR_NEW_KW:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="331" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">OLD</text>
+         <rect x="99" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="97" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="107" y="21">-</text>
+         <rect x="145" y="3" width="40" height="32" rx="10"></rect>
+         <rect x="143" y="1" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="21">OR</text>
+         <rect x="205" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="203" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="213" y="21">-</text>
+         <rect x="251" y="3" width="52" height="32" rx="10"></rect>
+         <rect x="249" y="1" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="259" y="21">NEW</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m52 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="321 17 329 13 329 21"></polygon>
+         <polygon points="321 17 313 13 313 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#OLD_OR_NEW_KW" title="OLD_OR_NEW_KW">OLD_OR_NEW_KW</a></div>
+               <div>         ::= 'OLD' '-' 'OR' '-' 'NEW'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#qualified_name" title="qualified_name">qualified_name</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="OLD_AND_NEW_KW" data-rule="OLD_AND_NEW_KW" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#hyphenated_name" class="used-by-link">hyphenated_name</a>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#qualified_name" class="used-by-link">qualified_name</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="OLD_AND_NEW_KW">OLD_AND_NEW_KW:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="339" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">OLD</text>
+         <rect x="99" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="97" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="107" y="21">-</text>
+         <rect x="145" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="143" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="21">AND</text>
+         <rect x="213" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="211" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="221" y="21">-</text>
+         <rect x="259" y="3" width="52" height="32" rx="10"></rect>
+         <rect x="257" y="1" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="267" y="21">NEW</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m52 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="329 17 337 13 337 21"></polygon>
+         <polygon points="329 17 321 13 321 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#OLD_AND_NEW_KW" title="OLD_AND_NEW_KW">OLD_AND_NEW_KW</a></div>
+               <div>         ::= 'OLD' '-' 'AND' '-' 'NEW'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#qualified_name" title="qualified_name">qualified_name</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="OLD_NOT_NEW_KW" data-rule="OLD_NOT_NEW_KW" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#hyphenated_name" class="used-by-link">hyphenated_name</a>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#qualified_name" class="used-by-link">qualified_name</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="OLD_NOT_NEW_KW">OLD_NOT_NEW_KW:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="339" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">OLD</text>
+         <rect x="99" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="97" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="107" y="21">-</text>
+         <rect x="145" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="143" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="21">NOT</text>
+         <rect x="213" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="211" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="221" y="21">-</text>
+         <rect x="259" y="3" width="52" height="32" rx="10"></rect>
+         <rect x="257" y="1" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="267" y="21">NEW</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m52 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="329 17 337 13 337 21"></polygon>
+         <polygon points="329 17 321 13 321 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#OLD_NOT_NEW_KW" title="OLD_NOT_NEW_KW">OLD_NOT_NEW_KW</a></div>
+               <div>         ::= 'OLD' '-' 'NOT' '-' 'NEW'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#qualified_name" title="qualified_name">qualified_name</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="NEW_NOT_OLD_KW" data-rule="NEW_NOT_OLD_KW" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#hyphenated_name" class="used-by-link">hyphenated_name</a>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#qualified_name" class="used-by-link">qualified_name</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="NEW_NOT_OLD_KW">NEW_NOT_OLD_KW:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="339" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="52" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">NEW</text>
+         <rect x="103" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="101" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="111" y="21">-</text>
+         <rect x="149" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="147" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="157" y="21">NOT</text>
+         <rect x="217" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="215" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="225" y="21">-</text>
+         <rect x="263" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="261" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="271" y="21">OLD</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m52 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="329 17 337 13 337 21"></polygon>
+         <polygon points="329 17 321 13 321 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#NEW_NOT_OLD_KW" title="NEW_NOT_OLD_KW">NEW_NOT_OLD_KW</a></div>
+               <div>         ::= 'NEW' '-' 'NOT' '-' 'OLD'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#qualified_name" title="qualified_name">qualified_name</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="OLD_NOR_NEW_KW" data-rule="OLD_NOR_NEW_KW" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#hyphenated_name" class="used-by-link">hyphenated_name</a>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#qualified_name" class="used-by-link">qualified_name</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="OLD_NOR_NEW_KW">OLD_NOR_NEW_KW:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="341" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">OLD</text>
+         <rect x="99" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="97" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="107" y="21">-</text>
+         <rect x="145" y="3" width="50" height="32" rx="10"></rect>
+         <rect x="143" y="1" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="21">NOR</text>
+         <rect x="215" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="213" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="223" y="21">-</text>
+         <rect x="261" y="3" width="52" height="32" rx="10"></rect>
+         <rect x="259" y="1" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="269" y="21">NEW</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m52 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="331 17 339 13 339 21"></polygon>
+         <polygon points="331 17 323 13 323 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#OLD_NOR_NEW_KW" title="OLD_NOR_NEW_KW">OLD_NOR_NEW_KW</a></div>
+               <div>         ::= 'OLD' '-' 'NOR' '-' 'NEW'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#qualified_name" title="qualified_name">qualified_name</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="LABEL_DM" data-rule="LABEL_DM" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_label" class="used-by-link">dm_label</a>
+          <a href="#dm_token" class="used-by-link">dm_token</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="LABEL_DM">LABEL_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="329" height="291">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 183 1 179 1 187"></polygon>
+         <polygon points="17 183 9 179 9 187"></polygon>
+         <rect x="31" y="169" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="167" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="187">-</text>
+         <polygon points="97 185 104 169 150 169 157 185 150 201 104 201"></polygon>
+         <polygon points="95 183 102 167 148 167 155 183 148 199 102 199" class="regexp"></polygon>
+         <text class="regexp" x="110" y="187">[a-z]</text>
+         <polygon points="97 229 104 213 152 213 159 229 152 245 104 245"></polygon>
+         <polygon points="95 227 102 211 150 211 157 227 150 243 102 243" class="regexp"></polygon>
+         <text class="regexp" x="110" y="231">[A-Z]</text>
+         <rect x="97" y="257" width="28" height="32" rx="10"></rect>
+         <rect x="95" y="255" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="105" y="275">_</text>
+         <polygon points="219 151 226 135 272 135 279 151 272 167 226 167"></polygon>
+         <polygon points="217 149 224 133 270 133 277 149 270 165 224 165" class="regexp"></polygon>
+         <text class="regexp" x="232" y="153">[a-z]</text>
+         <polygon points="219 107 226 91 274 91 281 107 274 123 226 123"></polygon>
+         <polygon points="217 105 224 89 272 89 279 105 272 121 224 121" class="regexp"></polygon>
+         <text class="regexp" x="232" y="109">[A-Z]</text>
+         <polygon points="219 63 226 47 274 47 281 63 274 79 226 79"></polygon>
+         <polygon points="217 61 224 45 272 45 279 61 272 77 224 77" class="regexp"></polygon>
+         <text class="regexp" x="232" y="65">[0-9]</text>
+         <rect x="219" y="3" width="28" height="32" rx="10"></rect>
+         <rect x="217" y="1" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="227" y="21">_</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 183 h2 m0 0 h10 m26 0 h10 m20 0 h10 m60 0 h10 m0 0 h2 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m-92 -10 v20 m102 0 v-20 m-102 20 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m28 0 h10 m0 0 h34 m40 -88 h10 m0 0 h72 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m82 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-82 0 h10 m60 0 h10 m0 0 h2 m-92 10 l0 -44 q0 -10 10 -10 m92 54 l0 -44 q0 -10 -10 -10 m-82 0 h10 m62 0 h10 m-92 10 l0 -44 q0 -10 10 -10 m92 54 l0 -44 q0 -10 -10 -10 m-82 0 h10 m62 0 h10 m-92 10 l0 -44 q0 -10 10 -10 m92 54 l0 -44 q0 -10 -10 -10 m-82 0 h10 m28 0 h10 m0 0 h34 m23 166 h-3"></svg:path>
+         <polygon points="319 183 327 179 327 187"></polygon>
+         <polygon points="319 183 311 179 311 187"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#LABEL_DM" title="LABEL_DM">LABEL_DM</a> ::= '-' [a-zA-Z_] [a-zA-Z0-9_]*</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_label" title="dm_label">dm_label</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_token" title="dm_token">dm_token</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="COMMENT_DM" data-rule="COMMENT_DM" data-description="">
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="COMMENT_DM">COMMENT_DM:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="335" height="71">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 51 1 47 1 55"></polygon>
+         <polygon points="17 51 9 47 9 55"></polygon>
+         <rect x="31" y="37" width="34" height="32" rx="10"></rect>
+         <rect x="29" y="35" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="55">-*</text>
+         <rect x="105" y="3" width="182" height="32" rx="10"></rect>
+         <rect x="103" y="1" width="182" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="21">ANY_CHAR_EXCEPT_NL</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 51 h2 m0 0 h10 m34 0 h10 m20 0 h10 m0 0 h192 m-222 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m202 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-202 0 h10 m182 0 h10 m23 34 h-3"></svg:path>
+         <polygon points="325 51 333 47 333 55"></polygon>
+         <polygon points="325 51 317 47 317 55"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#COMMENT_DM" title="COMMENT_DM">COMMENT_DM</a></div>
+               <div>         ::= '-*' 'ANY_CHAR_EXCEPT_NL'*</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">no references</xhtml:p>
+   </div>
+   <div class="rule-container" id="EQ" data-rule="EQ" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#compute_command" class="used-by-link">compute_command</a>
+          <a href="#define_assignment" class="used-by-link">define_assignment</a>
+          <a href="#dm_default" class="used-by-link">dm_default</a>
+          <a href="#dm_relational_expression" class="used-by-link">dm_relational_expression</a>
+          <a href="#dm_relational_op" class="used-by-link">dm_relational_op</a>
+          <a href="#dm_set" class="used-by-link">dm_set</a>
+          <a href="#matching_clause" class="used-by-link">matching_clause</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#recap_assignment" class="used-by-link">recap_assignment</a>
+          <a href="#set_command" class="used-by-link">set_command</a>
+          <a href="#when_matched_clause" class="used-by-link">when_matched_clause</a>
+          <a href="#when_not_matched_clause" class="used-by-link">when_not_matched_clause</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="EQ">EQ:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="137" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">EQ</text>
+         <rect x="51" y="47" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">=</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m38 0 h10 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v24 m78 0 v-24 m-78 24 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m30 0 h10 m0 0 h8 m23 -44 h-3"></svg:path>
+         <polygon points="127 17 135 13 135 21"></polygon>
+         <polygon points="127 17 119 13 119 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#EQ" title="EQ">EQ</a>       ::= 'EQ'</div>
+               <div>           | '='</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#compute_command" title="compute_command">compute_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#define_assignment" title="define_assignment">define_assignment</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_default" title="dm_default">dm_default</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_relational_expression" title="dm_relational_expression">dm_relational_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_relational_op" title="dm_relational_op">dm_relational_op</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_set" title="dm_set">dm_set</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#matching_clause" title="matching_clause">matching_clause</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#recap_assignment" title="recap_assignment">recap_assignment</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#set_command" title="set_command">set_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#when_matched_clause" title="when_matched_clause">when_matched_clause</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#when_not_matched_clause" title="when_not_matched_clause">when_not_matched_clause</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="NE" data-rule="NE" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_expression" class="used-by-link">dm_relational_expression</a>
+          <a href="#dm_relational_op" class="used-by-link">dm_relational_op</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="NE">NE:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="137" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">NE</text>
+         <rect x="51" y="47" width="34" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">!=</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m38 0 h10 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v24 m78 0 v-24 m-78 24 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m34 0 h10 m0 0 h4 m23 -44 h-3"></svg:path>
+         <polygon points="127 17 135 13 135 21"></polygon>
+         <polygon points="127 17 119 13 119 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#NE" title="NE">NE</a>       ::= 'NE'</div>
+               <div>           | '!='</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_expression" title="dm_relational_expression">dm_relational_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_relational_op" title="dm_relational_op">dm_relational_op</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="LT" data-rule="LT" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_op" class="used-by-link">dm_relational_op</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="LT">LT:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="135" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="36" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">LT</text>
+         <rect x="51" y="47" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">&lt;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m36 0 h10 m-76 0 h20 m56 0 h20 m-96 0 q10 0 10 10 m76 0 q0 -10 10 -10 m-86 10 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m30 0 h10 m0 0 h6 m23 -44 h-3"></svg:path>
+         <polygon points="125 17 133 13 133 21"></polygon>
+         <polygon points="125 17 117 13 117 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#LT" title="LT">LT</a>       ::= 'LT'</div>
+               <div>           | '&lt;'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_op" title="dm_relational_op">dm_relational_op</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="GT" data-rule="GT" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_op" class="used-by-link">dm_relational_op</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="GT">GT:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="137" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">GT</text>
+         <rect x="51" y="47" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">&gt;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m38 0 h10 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v24 m78 0 v-24 m-78 24 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m30 0 h10 m0 0 h8 m23 -44 h-3"></svg:path>
+         <polygon points="127 17 135 13 135 21"></polygon>
+         <polygon points="127 17 119 13 119 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#GT" title="GT">GT</a>       ::= 'GT'</div>
+               <div>           | '&gt;'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_op" title="dm_relational_op">dm_relational_op</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="LE" data-rule="LE" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_op" class="used-by-link">dm_relational_op</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="LE">LE:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="139" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="36" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">LE</text>
+         <rect x="51" y="47" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">&lt;=</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m36 0 h10 m0 0 h4 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v24 m80 0 v-24 m-80 24 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m40 0 h10 m23 -44 h-3"></svg:path>
+         <polygon points="129 17 137 13 137 21"></polygon>
+         <polygon points="129 17 121 13 121 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#LE" title="LE">LE</a>       ::= 'LE'</div>
+               <div>           | '&lt;='</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_op" title="dm_relational_op">dm_relational_op</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="GE" data-rule="GE" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_op" class="used-by-link">dm_relational_op</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="GE">GE:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="139" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">GE</text>
+         <rect x="51" y="47" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">&gt;=</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m38 0 h10 m0 0 h2 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v24 m80 0 v-24 m-80 24 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m40 0 h10 m23 -44 h-3"></svg:path>
+         <polygon points="129 17 137 13 137 21"></polygon>
+         <polygon points="129 17 121 13 121 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#GE" title="GE">GE</a>       ::= 'GE'</div>
+               <div>           | '&gt;='</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_op" title="dm_relational_op">dm_relational_op</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="PAGE_BREAK" data-rule="PAGE_BREAK" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#hyphenated_name" class="used-by-link">hyphenated_name</a>
+          <a href="#on_field_options" class="used-by-link">on_field_options</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#qualified_name" class="used-by-link">qualified_name</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="PAGE_BREAK">PAGE_BREAK:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="245" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">PAGE</text>
+         <rect x="107" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="105" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="115" y="21">-</text>
+         <rect x="153" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="151" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="161" y="21">BREAK</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m56 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="235 17 243 13 243 21"></polygon>
+         <polygon points="235 17 227 13 227 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#PAGE_BREAK" title="PAGE_BREAK">PAGE_BREAK</a></div>
+               <div>         ::= 'PAGE' '-' 'BREAK'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_field_options" title="on_field_options">on_field_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#qualified_name" title="qualified_name">qualified_name</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="ROLL_DOT" data-rule="ROLL_DOT" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#summarize_options" class="used-by-link">summarize_options</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="ROLL_DOT">ROLL_DOT:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="159" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ROLL</text>
+         <rect x="107" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="105" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="115" y="21">.</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="149 17 157 13 157 21"></polygon>
+         <polygon points="149 17 141 13 141 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#ROLL_DOT" title="ROLL_DOT">ROLL_DOT</a> ::= 'ROLL' '.'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#summarize_options" title="summarize_options">summarize_options</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="CONCAT" data-rule="CONCAT" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_relational_expression" class="used-by-link">dm_relational_expression</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="CONCAT">CONCAT:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="131" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="32" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="32" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">||</text>
+         <rect x="51" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">|</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m32 0 h10 m-72 0 h20 m52 0 h20 m-92 0 q10 0 10 10 m72 0 q0 -10 10 -10 m-82 10 v24 m72 0 v-24 m-72 24 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m26 0 h10 m0 0 h6 m23 -44 h-3"></svg:path>
+         <polygon points="121 17 129 13 129 21"></polygon>
+         <polygon points="121 17 113 13 113 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#CONCAT" title="CONCAT">CONCAT</a>   ::= '||'</div>
+               <div>           | '|'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_relational_expression" title="dm_relational_expression">dm_relational_expression</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="NUMBER" data-rule="NUMBER" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#decode_expression" class="used-by-link">decode_expression</a>
+          <a href="#dm_repeat" class="used-by-link">dm_repeat</a>
+          <a href="#dm_type" class="used-by-link">dm_type</a>
+          <a href="#dm_unary_expression" class="used-by-link">dm_unary_expression</a>
+          <a href="#dm_write" class="used-by-link">dm_write</a>
+          <a href="#format_name" class="used-by-link">format_name</a>
+          <a href="#hyphenated_name" class="used-by-link">hyphenated_name</a>
+          <a href="#layout_value" class="used-by-link">layout_value</a>
+          <a href="#recap_option" class="used-by-link">recap_option</a>
+          <a href="#show_command" class="used-by-link">show_command</a>
+          <a href="#sort_options" class="used-by-link">sort_options</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="NUMBER">NUMBER:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="161" height="53">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <polygon points="51 35 58 19 106 19 113 35 106 51 58 51"></polygon>
+         <polygon points="49 33 56 17 104 17 111 33 104 49 56 49" class="regexp"></polygon>
+         <text class="regexp" x="64" y="37">[0-9]</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m82 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-82 0 h10 m0 0 h72 m23 32 h-3"></svg:path>
+         <polygon points="151 33 159 29 159 37"></polygon>
+         <polygon points="151 33 143 29 143 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#NUMBER" title="NUMBER">NUMBER</a>   ::= [0-9]+</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#decode_expression" title="decode_expression">decode_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_repeat" title="dm_repeat">dm_repeat</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_type" title="dm_type">dm_type</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_write" title="dm_write">dm_write</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#format_name" title="format_name">format_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#layout_value" title="layout_value">layout_value</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#recap_option" title="recap_option">recap_option</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#show_command" title="show_command">show_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#sort_options" title="sort_options">sort_options</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="STRING" data-rule="STRING" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#as_phrase" class="used-by-link">as_phrase</a>
+          <a href="#decode_expression" class="used-by-link">decode_expression</a>
+          <a href="#dm_repeat" class="used-by-link">dm_repeat</a>
+          <a href="#dm_type" class="used-by-link">dm_type</a>
+          <a href="#dm_unary_expression" class="used-by-link">dm_unary_expression</a>
+          <a href="#dm_write" class="used-by-link">dm_write</a>
+          <a href="#footing_command" class="used-by-link">footing_command</a>
+          <a href="#heading_command" class="used-by-link">heading_command</a>
+          <a href="#layout_value" class="used-by-link">layout_value</a>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#on_field_options" class="used-by-link">on_field_options</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#request" class="used-by-link">request</a>
+          <a href="#set_value" class="used-by-link">set_value</a>
+          <a href="#show_command" class="used-by-link">show_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="STRING">STRING:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="511" height="149">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 51 1 47 1 55"></polygon>
+         <polygon points="17 51 9 47 9 55"></polygon>
+         <rect x="51" y="37" width="20" height="32" rx="10"></rect>
+         <rect x="49" y="35" width="20" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="55"></text>
+         <rect x="91" y="37" width="20" height="32" rx="10"></rect>
+         <rect x="89" y="35" width="20" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="55"></text>
+         <rect x="151" y="3" width="212" height="32" rx="10"></rect>
+         <rect x="149" y="1" width="212" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="159" y="21">ANY_CHAR_EXCEPT_QUOTE</text>
+         <rect x="403" y="37" width="20" height="32" rx="10"></rect>
+         <rect x="401" y="35" width="20" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="411" y="55"></text>
+         <rect x="443" y="37" width="20" height="32" rx="10"></rect>
+         <rect x="441" y="35" width="20" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="451" y="55"></text>
+         <rect x="51" y="115" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="113" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="133">"</text>
+         <rect x="117" y="81" width="278" height="32" rx="10"></rect>
+         <rect x="115" y="79" width="278" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="125" y="99">ANY_CHAR_EXCEPT_DOUBLE_QUOTE</text>
+         <rect x="435" y="115" width="26" height="32" rx="10"></rect>
+         <rect x="433" y="113" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="443" y="133">"</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 51 h2 m20 0 h10 m20 0 h10 m0 0 h10 m20 0 h10 m20 0 h10 m0 0 h222 m-252 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m232 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-232 0 h10 m212 0 h10 m20 34 h10 m20 0 h10 m0 0 h10 m20 0 h10 m-452 0 h20 m432 0 h20 m-472 0 q10 0 10 10 m452 0 q0 -10 10 -10 m-462 10 v58 m452 0 v-58 m-452 58 q0 10 10 10 m432 0 q10 0 10 -10 m-442 10 h10 m26 0 h10 m20 0 h10 m0 0 h288 m-318 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m298 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-298 0 h10 m278 0 h10 m20 34 h10 m26 0 h10 m0 0 h2 m23 -78 h-3"></svg:path>
+         <polygon points="501 51 509 47 509 55"></polygon>
+         <polygon points="501 51 493 47 493 55"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#STRING" title="STRING">STRING</a>   ::= '' '' 'ANY_CHAR_EXCEPT_QUOTE'* '' ''</div>
+               <div>           | '"' 'ANY_CHAR_EXCEPT_DOUBLE_QUOTE'* '"'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#as_phrase" title="as_phrase">as_phrase</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#decode_expression" title="decode_expression">decode_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_repeat" title="dm_repeat">dm_repeat</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_type" title="dm_type">dm_type</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_write" title="dm_write">dm_write</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#footing_command" title="footing_command">footing_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#heading_command" title="heading_command">heading_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#layout_value" title="layout_value">layout_value</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_field_options" title="on_field_options">on_field_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#set_value" title="set_value">set_value</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#show_command" title="show_command">show_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="AMPER_VAR" data-rule="AMPER_VAR" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#decode_expression" class="used-by-link">decode_expression</a>
+          <a href="#dm_default" class="used-by-link">dm_default</a>
+          <a href="#dm_read" class="used-by-link">dm_read</a>
+          <a href="#dm_repeat" class="used-by-link">dm_repeat</a>
+          <a href="#dm_set" class="used-by-link">dm_set</a>
+          <a href="#dm_type" class="used-by-link">dm_type</a>
+          <a href="#dm_unary_expression" class="used-by-link">dm_unary_expression</a>
+          <a href="#dm_write" class="used-by-link">dm_write</a>
+          <a href="#hyphenated_name" class="used-by-link">hyphenated_name</a>
+          <a href="#show_command" class="used-by-link">show_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="AMPER_VAR">AMPER_VAR:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="383" height="291">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 183 1 179 1 187"></polygon>
+         <polygon points="17 183 9 179 9 187"></polygon>
+         <rect x="51" y="169" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="167" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="187">&amp;&amp;</text>
+         <rect x="51" y="213" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="211" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="231">&amp;</text>
+         <polygon points="151 185 158 169 204 169 211 185 204 201 158 201"></polygon>
+         <polygon points="149 183 156 167 202 167 209 183 202 199 156 199" class="regexp"></polygon>
+         <text class="regexp" x="164" y="187">[a-z]</text>
+         <polygon points="151 229 158 213 206 213 213 229 206 245 158 245"></polygon>
+         <polygon points="149 227 156 211 204 211 211 227 204 243 156 243" class="regexp"></polygon>
+         <text class="regexp" x="164" y="231">[A-Z]</text>
+         <rect x="151" y="257" width="28" height="32" rx="10"></rect>
+         <rect x="149" y="255" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="159" y="275">_</text>
+         <polygon points="273 151 280 135 326 135 333 151 326 167 280 167"></polygon>
+         <polygon points="271 149 278 133 324 133 331 149 324 165 278 165" class="regexp"></polygon>
+         <text class="regexp" x="286" y="153">[a-z]</text>
+         <polygon points="273 107 280 91 328 91 335 107 328 123 280 123"></polygon>
+         <polygon points="271 105 278 89 326 89 333 105 326 121 278 121" class="regexp"></polygon>
+         <text class="regexp" x="286" y="109">[A-Z]</text>
+         <polygon points="273 63 280 47 328 47 335 63 328 79 280 79"></polygon>
+         <polygon points="271 61 278 45 326 45 333 61 326 77 278 77" class="regexp"></polygon>
+         <text class="regexp" x="286" y="65">[0-9]</text>
+         <rect x="273" y="3" width="28" height="32" rx="10"></rect>
+         <rect x="271" y="1" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="281" y="21">_</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 183 h2 m20 0 h10 m40 0 h10 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v24 m80 0 v-24 m-80 24 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m30 0 h10 m0 0 h10 m40 -44 h10 m60 0 h10 m0 0 h2 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m-92 -10 v20 m102 0 v-20 m-102 20 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m28 0 h10 m0 0 h34 m40 -88 h10 m0 0 h72 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m82 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-82 0 h10 m60 0 h10 m0 0 h2 m-92 10 l0 -44 q0 -10 10 -10 m92 54 l0 -44 q0 -10 -10 -10 m-82 0 h10 m62 0 h10 m-92 10 l0 -44 q0 -10 10 -10 m92 54 l0 -44 q0 -10 -10 -10 m-82 0 h10 m62 0 h10 m-92 10 l0 -44 q0 -10 10 -10 m92 54 l0 -44 q0 -10 -10 -10 m-82 0 h10 m28 0 h10 m0 0 h34 m23 166 h-3"></svg:path>
+         <polygon points="373 183 381 179 381 187"></polygon>
+         <polygon points="373 183 365 179 365 187"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#AMPER_VAR" title="AMPER_VAR">AMPER_VAR</a></div>
+               <div>         ::= ( '&amp;&amp;' | '&amp;' ) [a-zA-Z_] [a-zA-Z0-9_]*</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#decode_expression" title="decode_expression">decode_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_default" title="dm_default">dm_default</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_read" title="dm_read">dm_read</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_repeat" title="dm_repeat">dm_repeat</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_set" title="dm_set">dm_set</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_type" title="dm_type">dm_type</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_write" title="dm_write">dm_write</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#show_command" title="show_command">show_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="NAME" data-rule="NAME" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#dm_goto" class="used-by-link">dm_goto</a>
+          <a href="#dm_if" class="used-by-link">dm_if</a>
+          <a href="#dm_repeat" class="used-by-link">dm_repeat</a>
+          <a href="#format_name" class="used-by-link">format_name</a>
+          <a href="#hyphenated_name" class="used-by-link">hyphenated_name</a>
+          <a href="#join_command" class="used-by-link">join_command</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#output_command" class="used-by-link">output_command</a>
+          <a href="#qualified_name" class="used-by-link">qualified_name</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="NAME">NAME:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="283" height="291">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 183 1 179 1 187"></polygon>
+         <polygon points="17 183 9 179 9 187"></polygon>
+         <polygon points="51 185 58 169 104 169 111 185 104 201 58 201"></polygon>
+         <polygon points="49 183 56 167 102 167 109 183 102 199 56 199" class="regexp"></polygon>
+         <text class="regexp" x="64" y="187">[a-z]</text>
+         <polygon points="51 229 58 213 106 213 113 229 106 245 58 245"></polygon>
+         <polygon points="49 227 56 211 104 211 111 227 104 243 56 243" class="regexp"></polygon>
+         <text class="regexp" x="64" y="231">[A-Z]</text>
+         <rect x="51" y="257" width="28" height="32" rx="10"></rect>
+         <rect x="49" y="255" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="275">_</text>
+         <polygon points="173 151 180 135 226 135 233 151 226 167 180 167"></polygon>
+         <polygon points="171 149 178 133 224 133 231 149 224 165 178 165" class="regexp"></polygon>
+         <text class="regexp" x="186" y="153">[a-z]</text>
+         <polygon points="173 107 180 91 228 91 235 107 228 123 180 123"></polygon>
+         <polygon points="171 105 178 89 226 89 233 105 226 121 178 121" class="regexp"></polygon>
+         <text class="regexp" x="186" y="109">[A-Z]</text>
+         <polygon points="173 63 180 47 228 47 235 63 228 79 180 79"></polygon>
+         <polygon points="171 61 178 45 226 45 233 61 226 77 178 77" class="regexp"></polygon>
+         <text class="regexp" x="186" y="65">[0-9]</text>
+         <rect x="173" y="3" width="28" height="32" rx="10"></rect>
+         <rect x="171" y="1" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="181" y="21">_</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 183 h2 m20 0 h10 m60 0 h10 m0 0 h2 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m-92 -10 v20 m102 0 v-20 m-102 20 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m28 0 h10 m0 0 h34 m40 -88 h10 m0 0 h72 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m82 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-82 0 h10 m60 0 h10 m0 0 h2 m-92 10 l0 -44 q0 -10 10 -10 m92 54 l0 -44 q0 -10 -10 -10 m-82 0 h10 m62 0 h10 m-92 10 l0 -44 q0 -10 10 -10 m92 54 l0 -44 q0 -10 -10 -10 m-82 0 h10 m62 0 h10 m-92 10 l0 -44 q0 -10 10 -10 m92 54 l0 -44 q0 -10 -10 -10 m-82 0 h10 m28 0 h10 m0 0 h34 m23 166 h-3"></svg:path>
+         <polygon points="273 183 281 179 281 187"></polygon>
+         <polygon points="273 183 265 179 265 187"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#NAME" title="NAME">NAME</a>     ::= [a-zA-Z_] [a-zA-Z0-9_]*</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_goto" title="dm_goto">dm_goto</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_if" title="dm_if">dm_if</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_repeat" title="dm_repeat">dm_repeat</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#format_name" title="format_name">format_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#join_command" title="join_command">join_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#output_command" title="output_command">output_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#qualified_name" title="qualified_name">qualified_name</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="WS" data-rule="WS" data-description="">
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="WS">WS:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="167" height="229">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <rect x="71" y="19" width="24" height="32" rx="10"></rect>
+         <rect x="69" y="17" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="37"></text>
+         <rect x="71" y="63" width="28" height="32" rx="10"></rect>
+         <rect x="69" y="61" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="81">\</text>
+         <rect x="71" y="107" width="24" height="32" rx="10"></rect>
+         <rect x="69" y="105" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="125">t</text>
+         <rect x="71" y="151" width="26" height="32" rx="10"></rect>
+         <rect x="69" y="149" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="169">r</text>
+         <rect x="71" y="195" width="28" height="32" rx="10"></rect>
+         <rect x="69" y="193" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="213">n</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m40 0 h10 m24 0 h10 m0 0 h4 m-68 0 h20 m48 0 h20 m-88 0 q10 0 10 10 m68 0 q0 -10 10 -10 m-78 10 v24 m68 0 v-24 m-68 24 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m28 0 h10 m-58 -10 v20 m68 0 v-20 m-68 20 v24 m68 0 v-24 m-68 24 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m24 0 h10 m0 0 h4 m-58 -10 v20 m68 0 v-20 m-68 20 v24 m68 0 v-24 m-68 24 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m26 0 h10 m0 0 h2 m-58 -10 v20 m68 0 v-20 m-68 20 v24 m68 0 v-24 m-68 24 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m28 0 h10 m-88 -176 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m88 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-88 0 h10 m0 0 h78 m23 32 h-3"></svg:path>
+         <polygon points="157 33 165 29 165 37"></polygon>
+         <polygon points="157 33 149 29 149 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#WS" title="WS">WS</a>       ::= [ \trn]+</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">no references</xhtml:p>
+   </div>
+   <div class="category-header">Report Requests</div>
+   <div class="rule-container" id="request" data-rule="request" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#start" class="used-by-link">start</a>
+      </div>
+      <div class="rule-example-container">
+          <div class="rule-example-header">Examples</div>
+          <div class="example-row">
+              <code class="rule-example">TABLE FILE CAR PRINT * END</code>
+              <button class="copy-button" onclick="copyExample(this, &quot;TABLE FILE CAR PRINT * END&quot;)">Copy</button>
+          </div>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="request">request:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="697" height="791">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="11 623 3 619 3 627"></polygon>
+         <polygon points="19 623 11 619 11 627"></polygon>
+         <rect x="33" y="609" width="62" height="32" rx="10"></rect>
+         <rect x="31" y="607" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="41" y="627">TABLE</text>
+         <rect x="115" y="609" width="50" height="32" rx="10"></rect>
+         <rect x="113" y="607" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="123" y="627">FILE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="185" y="609" width="118" height="32"></rect>
+            <rect x="183" y="607" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="193" y="627">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#verb_command" xlink:title="verb_command">
+            <rect x="343" y="575" width="118" height="32"></rect>
+            <rect x="341" y="573" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="593">verb_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#by_command" xlink:title="by_command">
+            <rect x="343" y="531" width="104" height="32"></rect>
+            <rect x="341" y="529" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="549">by_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#across_command" xlink:title="across_command">
+            <rect x="343" y="487" width="130" height="32"></rect>
+            <rect x="341" y="485" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="505">across_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#where_command" xlink:title="where_command">
+            <rect x="343" y="443" width="128" height="32"></rect>
+            <rect x="341" y="441" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="461">where_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#when_command" xlink:title="when_command">
+            <rect x="343" y="399" width="122" height="32"></rect>
+            <rect x="341" y="397" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="417">when_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#show_command" xlink:title="show_command">
+            <rect x="343" y="355" width="122" height="32"></rect>
+            <rect x="341" y="353" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="373">show_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#heading_command" xlink:title="heading_command">
+            <rect x="343" y="311" width="140" height="32"></rect>
+            <rect x="341" y="309" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="329">heading_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#footing_command" xlink:title="footing_command">
+            <rect x="343" y="267" width="134" height="32"></rect>
+            <rect x="341" y="265" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="285">footing_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#on_command" xlink:title="on_command">
+            <rect x="343" y="223" width="104" height="32"></rect>
+            <rect x="341" y="221" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="241">on_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#compute_command" xlink:title="compute_command">
+            <rect x="343" y="179" width="144" height="32"></rect>
+            <rect x="341" y="177" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="197">compute_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#recap_command" xlink:title="recap_command">
+            <rect x="343" y="135" width="124" height="32"></rect>
+            <rect x="341" y="133" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="153">recap_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#summarize_command" xlink:title="summarize_command">
+            <rect x="343" y="91" width="158" height="32"></rect>
+            <rect x="341" y="89" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="109">summarize_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_command" xlink:title="dm_command">
+            <rect x="343" y="47" width="108" height="32"></rect>
+            <rect x="341" y="45" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="65">dm_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="343" y="3" width="66" height="32"></rect>
+            <rect x="341" y="1" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="351" y="21">STRING</text></a><rect x="45" y="725" width="60" height="32" rx="10"></rect>
+         <rect x="43" y="723" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="743">MORE</text>
+         <rect x="165" y="725" width="50" height="32" rx="10"></rect>
+         <rect x="163" y="723" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="173" y="743">FILE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="235" y="725" width="118" height="32"></rect>
+            <rect x="233" y="723" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="243" y="743">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#where_command" xlink:title="where_command">
+            <rect x="393" y="691" width="128" height="32"></rect>
+            <rect x="391" y="689" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="401" y="709">where_command</text></a><rect x="621" y="725" width="48" height="32" rx="10"></rect>
+         <rect x="619" y="723" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="629" y="743">END</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m19 623 h2 m0 0 h10 m62 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h168 m-198 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m178 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-178 0 h10 m118 0 h10 m0 0 h40 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m104 0 h10 m0 0 h54 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m130 0 h10 m0 0 h28 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m128 0 h10 m0 0 h30 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m122 0 h10 m0 0 h36 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m122 0 h10 m0 0 h36 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m140 0 h10 m0 0 h18 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m134 0 h10 m0 0 h24 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m104 0 h10 m0 0 h54 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m144 0 h10 m0 0 h14 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m124 0 h10 m0 0 h34 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m158 0 h10 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m108 0 h10 m0 0 h50 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m66 0 h10 m0 0 h92 m22 606 l2 0 m2 0 l2 0 m2 0 l2 0 m-540 116 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m60 0 h10 m40 0 h10 m50 0 h10 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h138 m-168 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m148 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-148 0 h10 m128 0 h10 m-396 34 l20 0 m-1 0 q-9 0 -9 -10 l0 -46 q0 -10 10 -10 m396 66 l20 0 m-20 0 q10 0 10 -10 l0 -46 q0 -10 -10 -10 m-396 0 h10 m0 0 h386 m-436 66 h20 m436 0 h20 m-476 0 q10 0 10 10 m456 0 q0 -10 10 -10 m-466 10 v14 m456 0 v-14 m-456 14 q0 10 10 10 m436 0 q10 0 10 -10 m-446 10 h10 m0 0 h426 m-556 -34 h20 m556 0 h20 m-596 0 q10 0 10 10 m576 0 q0 -10 10 -10 m-586 10 v30 m576 0 v-30 m-576 30 q0 10 10 10 m556 0 q10 0 10 -10 m-566 10 h10 m0 0 h546 m20 -50 h10 m48 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="687 739 695 735 695 743"></polygon>
+         <polygon points="687 739 679 735 679 743"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#request" title="request">request</a>  ::= 'TABLE' 'FILE' <a href="#qualified_name" title="qualified_name">qualified_name</a> ( <a href="#verb_command" title="verb_command">verb_command</a> | <a href="#by_command" title="by_command">by_command</a> | <a href="#across_command" title="across_command">across_command</a> | <a href="#where_command" title="where_command">where_command</a> | <a href="#when_command" title="when_command">when_command</a> | <a href="#show_command" title="show_command">show_command</a> | <a href="#heading_command" title="heading_command">heading_command</a> | <a href="#footing_command" title="footing_command">footing_command</a> | <a href="#on_command" title="on_command">on_command</a> | <a href="#compute_command" title="compute_command">compute_command</a> | <a href="#recap_command" title="recap_command">recap_command</a> | <a href="#summarize_command" title="summarize_command">summarize_command</a> | <a href="#dm_command" title="dm_command">dm_command</a> | <a href="#STRING" title="STRING">STRING</a> )* ( 'MORE' ( 'FILE' <a href="#qualified_name" title="qualified_name">qualified_name</a> <a href="#where_command" title="where_command">where_command</a>* )* )? 'END'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#start" title="start">start</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="match_request" data-rule="match_request" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#start" class="used-by-link">start</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="match_request">match_request:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="1805" height="1857">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 623 1 619 1 627"></polygon>
+         <polygon points="17 623 9 619 9 627"></polygon>
+         <rect x="31" y="609" width="68" height="32" rx="10"></rect>
+         <rect x="29" y="607" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="627">MATCH</text>
+         <rect x="119" y="609" width="50" height="32" rx="10"></rect>
+         <rect x="117" y="607" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="127" y="627">FILE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="189" y="609" width="118" height="32"></rect>
+            <rect x="187" y="607" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="197" y="627">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#verb_command" xlink:title="verb_command">
+            <rect x="347" y="575" width="118" height="32"></rect>
+            <rect x="345" y="573" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="593">verb_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#by_command" xlink:title="by_command">
+            <rect x="347" y="531" width="104" height="32"></rect>
+            <rect x="345" y="529" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="549">by_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#across_command" xlink:title="across_command">
+            <rect x="347" y="487" width="130" height="32"></rect>
+            <rect x="345" y="485" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="505">across_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#where_command" xlink:title="where_command">
+            <rect x="347" y="443" width="128" height="32"></rect>
+            <rect x="345" y="441" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="461">where_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#when_command" xlink:title="when_command">
+            <rect x="347" y="399" width="122" height="32"></rect>
+            <rect x="345" y="397" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="417">when_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#show_command" xlink:title="show_command">
+            <rect x="347" y="355" width="122" height="32"></rect>
+            <rect x="345" y="353" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="373">show_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#heading_command" xlink:title="heading_command">
+            <rect x="347" y="311" width="140" height="32"></rect>
+            <rect x="345" y="309" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="329">heading_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#footing_command" xlink:title="footing_command">
+            <rect x="347" y="267" width="134" height="32"></rect>
+            <rect x="345" y="265" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="285">footing_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#on_command" xlink:title="on_command">
+            <rect x="347" y="223" width="104" height="32"></rect>
+            <rect x="345" y="221" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="241">on_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#compute_command" xlink:title="compute_command">
+            <rect x="347" y="179" width="144" height="32"></rect>
+            <rect x="345" y="177" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="197">compute_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#recap_command" xlink:title="recap_command">
+            <rect x="347" y="135" width="124" height="32"></rect>
+            <rect x="345" y="133" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="153">recap_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#summarize_command" xlink:title="summarize_command">
+            <rect x="347" y="91" width="158" height="32"></rect>
+            <rect x="345" y="89" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="109">summarize_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_command" xlink:title="dm_command">
+            <rect x="347" y="47" width="108" height="32"></rect>
+            <rect x="345" y="45" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="65">dm_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="347" y="3" width="66" height="32"></rect>
+            <rect x="345" y="1" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="21">STRING</text></a><rect x="636" y="725" width="60" height="32" rx="10"></rect>
+         <rect x="634" y="723" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="644" y="743">MORE</text>
+         <rect x="756" y="725" width="50" height="32" rx="10"></rect>
+         <rect x="754" y="723" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="764" y="743">FILE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="826" y="725" width="118" height="32"></rect>
+            <rect x="824" y="723" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="834" y="743">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#where_command" xlink:title="where_command">
+            <rect x="984" y="691" width="128" height="32"></rect>
+            <rect x="982" y="689" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="992" y="709">where_command</text></a><rect x="65" y="1445" width="48" height="32" rx="10"></rect>
+         <rect x="63" y="1443" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="73" y="1463">RUN</text>
+         <rect x="133" y="1445" width="50" height="32" rx="10"></rect>
+         <rect x="131" y="1443" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="141" y="1463">FILE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="203" y="1445" width="118" height="32"></rect>
+            <rect x="201" y="1443" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="211" y="1463">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#verb_command" xlink:title="verb_command">
+            <rect x="361" y="1411" width="118" height="32"></rect>
+            <rect x="359" y="1409" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="1429">verb_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#by_command" xlink:title="by_command">
+            <rect x="361" y="1367" width="104" height="32"></rect>
+            <rect x="359" y="1365" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="1385">by_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#across_command" xlink:title="across_command">
+            <rect x="361" y="1323" width="130" height="32"></rect>
+            <rect x="359" y="1321" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="1341">across_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#where_command" xlink:title="where_command">
+            <rect x="361" y="1279" width="128" height="32"></rect>
+            <rect x="359" y="1277" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="1297">where_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#when_command" xlink:title="when_command">
+            <rect x="361" y="1235" width="122" height="32"></rect>
+            <rect x="359" y="1233" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="1253">when_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#show_command" xlink:title="show_command">
+            <rect x="361" y="1191" width="122" height="32"></rect>
+            <rect x="359" y="1189" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="1209">show_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#heading_command" xlink:title="heading_command">
+            <rect x="361" y="1147" width="140" height="32"></rect>
+            <rect x="359" y="1145" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="1165">heading_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#footing_command" xlink:title="footing_command">
+            <rect x="361" y="1103" width="134" height="32"></rect>
+            <rect x="359" y="1101" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="1121">footing_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#on_command" xlink:title="on_command">
+            <rect x="361" y="1059" width="104" height="32"></rect>
+            <rect x="359" y="1057" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="1077">on_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#compute_command" xlink:title="compute_command">
+            <rect x="361" y="1015" width="144" height="32"></rect>
+            <rect x="359" y="1013" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="1033">compute_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#recap_command" xlink:title="recap_command">
+            <rect x="361" y="971" width="124" height="32"></rect>
+            <rect x="359" y="969" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="989">recap_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#summarize_command" xlink:title="summarize_command">
+            <rect x="361" y="927" width="158" height="32"></rect>
+            <rect x="359" y="925" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="945">summarize_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_command" xlink:title="dm_command">
+            <rect x="361" y="883" width="108" height="32"></rect>
+            <rect x="359" y="881" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="901">dm_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="361" y="839" width="66" height="32"></rect>
+            <rect x="359" y="837" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="369" y="857">STRING</text></a><rect x="579" y="1445" width="60" height="32" rx="10"></rect>
+         <rect x="577" y="1443" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="587" y="1463">MORE</text>
+         <rect x="699" y="1445" width="50" height="32" rx="10"></rect>
+         <rect x="697" y="1443" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="707" y="1463">FILE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="769" y="1445" width="118" height="32"></rect>
+            <rect x="767" y="1443" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="777" y="1463">qualified_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#where_command" xlink:title="where_command">
+            <rect x="927" y="1411" width="128" height="32"></rect>
+            <rect x="925" y="1409" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="935" y="1429">where_command</text></a><rect x="1175" y="1477" width="62" height="32" rx="10"></rect>
+         <rect x="1173" y="1475" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1183" y="1495">AFTER</text>
+         <rect x="1257" y="1477" width="68" height="32" rx="10"></rect>
+         <rect x="1255" y="1475" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1265" y="1495">MATCH</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#output_command" xlink:title="output_command">
+            <rect x="1365" y="1509" width="130" height="32"></rect>
+            <rect x="1363" y="1507" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1373" y="1527">output_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_OR_NEW_KW" xlink:title="OLD_OR_NEW_KW">
+            <rect x="1555" y="1477" width="138" height="32"></rect>
+            <rect x="1553" y="1475" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1563" y="1495">OLD_OR_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_AND_NEW_KW" xlink:title="OLD_AND_NEW_KW">
+            <rect x="1555" y="1521" width="146" height="32"></rect>
+            <rect x="1553" y="1519" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1563" y="1539">OLD_AND_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_NOT_NEW_KW" xlink:title="OLD_NOT_NEW_KW">
+            <rect x="1555" y="1565" width="146" height="32"></rect>
+            <rect x="1553" y="1563" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1563" y="1583">OLD_NOT_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NEW_NOT_OLD_KW" xlink:title="NEW_NOT_OLD_KW">
+            <rect x="1555" y="1609" width="146" height="32"></rect>
+            <rect x="1553" y="1607" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1563" y="1627">NEW_NOT_OLD_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_NOR_NEW_KW" xlink:title="OLD_NOR_NEW_KW">
+            <rect x="1555" y="1653" width="148" height="32"></rect>
+            <rect x="1553" y="1651" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1563" y="1671">OLD_NOR_NEW_KW</text></a><rect x="1555" y="1697" width="48" height="32" rx="10"></rect>
+         <rect x="1553" y="1695" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1563" y="1715">OLD</text>
+         <rect x="1555" y="1741" width="52" height="32" rx="10"></rect>
+         <rect x="1553" y="1739" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1563" y="1759">NEW</text>
+         <rect x="1729" y="1823" width="48" height="32" rx="10"></rect>
+         <rect x="1727" y="1821" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1737" y="1841">END</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 623 h2 m0 0 h10 m68 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h168 m-198 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m178 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-178 0 h10 m118 0 h10 m0 0 h40 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m104 0 h10 m0 0 h54 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m130 0 h10 m0 0 h28 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m128 0 h10 m0 0 h30 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m122 0 h10 m0 0 h36 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m122 0 h10 m0 0 h36 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m140 0 h10 m0 0 h18 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m134 0 h10 m0 0 h24 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m104 0 h10 m0 0 h54 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m144 0 h10 m0 0 h14 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m124 0 h10 m0 0 h34 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m158 0 h10 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m108 0 h10 m0 0 h50 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m66 0 h10 m0 0 h92 m22 606 l2 0 m2 0 l2 0 m2 0 l2 0 m47 116 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m60 0 h10 m40 0 h10 m50 0 h10 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h138 m-168 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m148 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-148 0 h10 m128 0 h10 m-396 34 l20 0 m-1 0 q-9 0 -9 -10 l0 -46 q0 -10 10 -10 m396 66 l20 0 m-20 0 q10 0 10 -10 l0 -46 q0 -10 -10 -10 m-396 0 h10 m0 0 h386 m-436 66 h20 m436 0 h20 m-476 0 q10 0 10 10 m456 0 q0 -10 10 -10 m-466 10 v14 m456 0 v-14 m-456 14 q0 10 10 10 m436 0 q10 0 10 -10 m-446 10 h10 m0 0 h426 m-556 -34 h20 m556 0 h20 m-596 0 q10 0 10 10 m576 0 q0 -10 10 -10 m-586 10 v30 m576 0 v-30 m-576 30 q0 10 10 10 m556 0 q10 0 10 -10 m-566 10 h10 m0 0 h546 m22 -50 l2 0 m2 0 l2 0 m2 0 l2 0 m-1211 720 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m48 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h168 m-198 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m178 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-178 0 h10 m118 0 h10 m0 0 h40 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m104 0 h10 m0 0 h54 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m130 0 h10 m0 0 h28 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m128 0 h10 m0 0 h30 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m122 0 h10 m0 0 h36 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m122 0 h10 m0 0 h36 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m140 0 h10 m0 0 h18 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m134 0 h10 m0 0 h24 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m104 0 h10 m0 0 h54 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m144 0 h10 m0 0 h14 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m124 0 h10 m0 0 h34 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m158 0 h10 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m108 0 h10 m0 0 h50 m-188 10 l0 -44 q0 -10 10 -10 m188 54 l0 -44 q0 -10 -10 -10 m-178 0 h10 m66 0 h10 m0 0 h92 m40 606 h10 m60 0 h10 m40 0 h10 m50 0 h10 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h138 m-168 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m148 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-148 0 h10 m128 0 h10 m-396 34 l20 0 m-1 0 q-9 0 -9 -10 l0 -46 q0 -10 10 -10 m396 66 l20 0 m-20 0 q10 0 10 -10 l0 -46 q0 -10 -10 -10 m-396 0 h10 m0 0 h386 m-436 66 h20 m436 0 h20 m-476 0 q10 0 10 10 m456 0 q0 -10 10 -10 m-466 10 v14 m456 0 v-14 m-456 14 q0 10 10 10 m436 0 q10 0 10 -10 m-446 10 h10 m0 0 h426 m-556 -34 h20 m556 0 h20 m-596 0 q10 0 10 10 m576 0 q0 -10 10 -10 m-586 10 v30 m576 0 v-30 m-576 30 q0 10 10 10 m556 0 q10 0 10 -10 m-566 10 h10 m0 0 h546 m40 -50 h10 m0 0 h558 m-588 0 h20 m568 0 h20 m-608 0 q10 0 10 10 m588 0 q0 -10 10 -10 m-598 10 v12 m588 0 v-12 m-588 12 q0 10 10 10 m568 0 q10 0 10 -10 m-578 10 h10 m62 0 h10 m0 0 h10 m68 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m40 -32 h10 m138 0 h10 m0 0 h10 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m148 0 h10 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-1678 -296 l20 0 m-1 0 q-9 0 -9 -10 l0 -618 q0 -10 10 -10 m1698 638 l20 0 m-20 0 q10 0 10 -10 l0 -618 q0 -10 -10 -10 m-1698 0 h10 m0 0 h1688 m-1738 638 h20 m1738 0 h20 m-1778 0 q10 0 10 10 m1758 0 q0 -10 10 -10 m-1768 10 v310 m1758 0 v-310 m-1758 310 q0 10 10 10 m1738 0 q10 0 10 -10 m-1748 10 h10 m0 0 h1728 m22 -330 l2 0 m2 0 l2 0 m2 0 l2 0 m-98 378 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m48 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="1795 1837 1803 1833 1803 1841"></polygon>
+         <polygon points="1795 1837 1787 1833 1787 1841"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#match_request" title="match_request">match_request</a></div>
+               <div>         ::= 'MATCH' 'FILE' <a href="#qualified_name" title="qualified_name">qualified_name</a> ( <a href="#verb_command" title="verb_command">verb_command</a> | <a href="#by_command" title="by_command">by_command</a> | <a href="#across_command" title="across_command">across_command</a> | <a href="#where_command" title="where_command">where_command</a> | <a href="#when_command" title="when_command">when_command</a> | <a href="#show_command" title="show_command">show_command</a> | <a href="#heading_command" title="heading_command">heading_command</a> | <a href="#footing_command" title="footing_command">footing_command</a> | <a href="#on_command" title="on_command">on_command</a> | <a href="#compute_command" title="compute_command">compute_command</a> | <a href="#recap_command" title="recap_command">recap_command</a> | <a href="#summarize_command" title="summarize_command">summarize_command</a> | <a href="#dm_command" title="dm_command">dm_command</a> | <a href="#STRING" title="STRING">STRING</a> )* ( 'MORE' ( 'FILE' <a href="#qualified_name" title="qualified_name">qualified_name</a> <a href="#where_command" title="where_command">where_command</a>* )* )? ( 'RUN' 'FILE' <a href="#qualified_name" title="qualified_name">qualified_name</a> ( <a href="#verb_command" title="verb_command">verb_command</a> | <a href="#by_command" title="by_command">by_command</a> | <a href="#across_command" title="across_command">across_command</a> | <a href="#where_command" title="where_command">where_command</a> | <a href="#when_command" title="when_command">when_command</a> | <a href="#show_command" title="show_command">show_command</a> | <a href="#heading_command" title="heading_command">heading_command</a> | <a href="#footing_command" title="footing_command">footing_command</a> | <a href="#on_command" title="on_command">on_command</a> | <a href="#compute_command" title="compute_command">compute_command</a> | <a href="#recap_command" title="recap_command">recap_command</a> | <a href="#summarize_command" title="summarize_command">summarize_command</a> | <a href="#dm_command" title="dm_command">dm_command</a> | <a href="#STRING" title="STRING">STRING</a> )* ( 'MORE' ( 'FILE' <a href="#qualified_name" title="qualified_name">qualified_name</a> <a href="#where_command" title="where_command">where_command</a>* )* )? ( 'AFTER' 'MATCH' <a href="#output_command" title="output_command">output_command</a>? ( <a href="#OLD_OR_NEW_KW" title="OLD_OR_NEW_KW">OLD_OR_NEW_KW</a> | <a href="#OLD_AND_NEW_KW" title="OLD_AND_NEW_KW">OLD_AND_NEW_KW</a> | <a href="#OLD_NOT_NEW_KW" title="OLD_NOT_NEW_KW">OLD_NOT_NEW_KW</a> | <a href="#NEW_NOT_OLD_KW" title="NEW_NOT_OLD_KW">NEW_NOT_OLD_KW</a> | <a href="#OLD_NOR_NEW_KW" title="OLD_NOR_NEW_KW">OLD_NOR_NEW_KW</a> | 'OLD' | 'NEW' ) )? )* 'END'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#start" title="start">start</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="compound_layout_block" data-rule="compound_layout_block" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#start" class="used-by-link">start</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="compound_layout_block">compound_layout_block:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="945" height="4663">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="100" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">COMPOUND</text>
+         <rect x="151" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="149" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="159" y="21">LAYOUT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#output_command" xlink:title="output_command">
+            <rect x="245" y="3" width="130" height="32"></rect>
+            <rect x="243" y="1" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="253" y="21">output_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="105" y="279" width="54" height="32"></rect>
+            <rect x="103" y="277" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="113" y="297">NAME</text></a><rect x="105" y="323" width="46" height="32" rx="10"></rect>
+         <rect x="103" y="321" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="341">AVE</text>
+         <rect x="105" y="367" width="48" height="32" rx="10"></rect>
+         <rect x="103" y="365" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="385">MIN</text>
+         <rect x="105" y="411" width="50" height="32" rx="10"></rect>
+         <rect x="103" y="409" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="429">MAX</text>
+         <rect x="105" y="455" width="46" height="32" rx="10"></rect>
+         <rect x="103" y="453" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="473">CNT</text>
+         <rect x="105" y="499" width="44" height="32" rx="10"></rect>
+         <rect x="103" y="497" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="517">FST</text>
+         <rect x="105" y="543" width="44" height="32" rx="10"></rect>
+         <rect x="103" y="541" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="561">LST</text>
+         <rect x="105" y="587" width="48" height="32" rx="10"></rect>
+         <rect x="103" y="585" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="605">ASQ</text>
+         <rect x="105" y="631" width="50" height="32" rx="10"></rect>
+         <rect x="103" y="629" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="649">MDN</text>
+         <rect x="105" y="675" width="50" height="32" rx="10"></rect>
+         <rect x="103" y="673" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="693">MDE</text>
+         <rect x="105" y="719" width="46" height="32" rx="10"></rect>
+         <rect x="103" y="717" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="737">PCT</text>
+         <rect x="105" y="763" width="56" height="32" rx="10"></rect>
+         <rect x="103" y="761" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="781">RPCT</text>
+         <rect x="105" y="807" width="48" height="32" rx="10"></rect>
+         <rect x="103" y="805" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="825">RNK</text>
+         <rect x="105" y="851" width="46" height="32" rx="10"></rect>
+         <rect x="103" y="849" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="869">DST</text>
+         <rect x="105" y="895" width="46" height="32" rx="10"></rect>
+         <rect x="103" y="893" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="913">TOT</text>
+         <rect x="105" y="939" width="50" height="32" rx="10"></rect>
+         <rect x="103" y="937" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="957">SUM</text>
+         <rect x="105" y="983" width="36" height="32" rx="10"></rect>
+         <rect x="103" y="981" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1001">CT</text>
+         <rect x="105" y="1027" width="36" height="32" rx="10"></rect>
+         <rect x="103" y="1025" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1045">IS</text>
+         <rect x="105" y="1071" width="92" height="32" rx="10"></rect>
+         <rect x="103" y="1069" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1089">CONTAINS</text>
+         <rect x="105" y="1115" width="66" height="32" rx="10"></rect>
+         <rect x="103" y="1113" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1133">OMITS</text>
+         <rect x="105" y="1159" width="52" height="32" rx="10"></rect>
+         <rect x="103" y="1157" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1177">LIKE</text>
+         <rect x="105" y="1203" width="64" height="32" rx="10"></rect>
+         <rect x="103" y="1201" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1221">TOTAL</text>
+         <rect x="105" y="1247" width="82" height="32" rx="10"></rect>
+         <rect x="103" y="1245" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1265">MISSING</text>
+         <rect x="105" y="1291" width="90" height="32" rx="10"></rect>
+         <rect x="103" y="1289" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1309">INCLUDES</text>
+         <rect x="105" y="1335" width="90" height="32" rx="10"></rect>
+         <rect x="103" y="1333" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1353">EXCLUDES</text>
+         <rect x="105" y="1379" width="82" height="32" rx="10"></rect>
+         <rect x="103" y="1377" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1397">EXCEEDS</text>
+         <rect x="105" y="1423" width="44" height="32" rx="10"></rect>
+         <rect x="103" y="1421" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1441">ALL</text>
+         <rect x="105" y="1467" width="54" height="32" rx="10"></rect>
+         <rect x="103" y="1465" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1485">LESS</text>
+         <rect x="105" y="1511" width="58" height="32" rx="10"></rect>
+         <rect x="103" y="1509" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1529">THAN</text>
+         <rect x="105" y="1555" width="60" height="32" rx="10"></rect>
+         <rect x="103" y="1553" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1573">MORE</text>
+         <rect x="105" y="1599" width="82" height="32" rx="10"></rect>
+         <rect x="103" y="1597" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1617">GREATER</text>
+         <rect x="105" y="1643" width="46" height="32" rx="10"></rect>
+         <rect x="103" y="1641" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1661">OFF</text>
+         <rect x="105" y="1687" width="40" height="32" rx="10"></rect>
+         <rect x="103" y="1685" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1705">ON</text>
+         <rect x="105" y="1731" width="64" height="32" rx="10"></rect>
+         <rect x="103" y="1729" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1749">RECAP</text>
+         <rect x="105" y="1775" width="72" height="32" rx="10"></rect>
+         <rect x="103" y="1773" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1793">INDENT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ACROSS_TOTAL" xlink:title="ACROSS_TOTAL">
+            <rect x="105" y="1819" width="118" height="32"></rect>
+            <rect x="103" y="1817" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="113" y="1837">ACROSS_TOTAL</text></a><rect x="105" y="1863" width="100" height="32" rx="10"></rect>
+         <rect x="103" y="1861" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1881">COMPOUND</text>
+         <rect x="105" y="1907" width="74" height="32" rx="10"></rect>
+         <rect x="103" y="1905" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1925">LAYOUT</text>
+         <rect x="105" y="1951" width="82" height="32" rx="10"></rect>
+         <rect x="103" y="1949" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1969">SECTION</text>
+         <rect x="105" y="1995" width="110" height="32" rx="10"></rect>
+         <rect x="103" y="1993" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2013">PAGELAYOUT</text>
+         <rect x="105" y="2039" width="108" height="32" rx="10"></rect>
+         <rect x="103" y="2037" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2057">COMPONENT</text>
+         <rect x="105" y="2083" width="66" height="32" rx="10"></rect>
+         <rect x="103" y="2081" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2101">MERGE</text>
+         <rect x="105" y="2127" width="118" height="32" rx="10"></rect>
+         <rect x="103" y="2125" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2145">ORIENTATION</text>
+         <rect x="105" y="2171" width="102" height="32" rx="10"></rect>
+         <rect x="103" y="2169" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2189">LANDSCAPE</text>
+         <rect x="105" y="2215" width="90" height="32" rx="10"></rect>
+         <rect x="103" y="2213" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2233">PORTRAIT</text>
+         <rect x="105" y="2259" width="54" height="32" rx="10"></rect>
+         <rect x="103" y="2257" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2277">TYPE</text>
+         <rect x="105" y="2303" width="90" height="32" rx="10"></rect>
+         <rect x="103" y="2301" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2321">POSITION</text>
+         <rect x="105" y="2347" width="102" height="32" rx="10"></rect>
+         <rect x="103" y="2345" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2365">DIMENSION</text>
+         <rect x="105" y="2391" width="62" height="32" rx="10"></rect>
+         <rect x="103" y="2389" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2409">STYLE</text>
+         <rect x="105" y="2435" width="90" height="32" rx="10"></rect>
+         <rect x="103" y="2433" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2453">ENDSTYLE</text>
+         <rect x="105" y="2479" width="68" height="32" rx="10"></rect>
+         <rect x="103" y="2477" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2497">MATCH</text>
+         <rect x="105" y="2523" width="62" height="32" rx="10"></rect>
+         <rect x="103" y="2521" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2541">AFTER</text>
+         <rect x="105" y="2567" width="48" height="32" rx="10"></rect>
+         <rect x="103" y="2565" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2585">RUN</text>
+         <rect x="105" y="2611" width="48" height="32" rx="10"></rect>
+         <rect x="103" y="2609" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2629">OLD</text>
+         <rect x="105" y="2655" width="52" height="32" rx="10"></rect>
+         <rect x="103" y="2653" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2673">NEW</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_OR_NEW_KW" xlink:title="OLD_OR_NEW_KW">
+            <rect x="105" y="2699" width="138" height="32"></rect>
+            <rect x="103" y="2697" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="113" y="2717">OLD_OR_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_AND_NEW_KW" xlink:title="OLD_AND_NEW_KW">
+            <rect x="105" y="2743" width="146" height="32"></rect>
+            <rect x="103" y="2741" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="113" y="2761">OLD_AND_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_NOT_NEW_KW" xlink:title="OLD_NOT_NEW_KW">
+            <rect x="105" y="2787" width="146" height="32"></rect>
+            <rect x="103" y="2785" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="113" y="2805">OLD_NOT_NEW_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NEW_NOT_OLD_KW" xlink:title="NEW_NOT_OLD_KW">
+            <rect x="105" y="2831" width="146" height="32"></rect>
+            <rect x="103" y="2829" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="113" y="2849">NEW_NOT_OLD_KW</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OLD_NOR_NEW_KW" xlink:title="OLD_NOR_NEW_KW">
+            <rect x="105" y="2875" width="148" height="32"></rect>
+            <rect x="103" y="2873" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="113" y="2893">OLD_NOR_NEW_KW</text></a><rect x="105" y="2919" width="94" height="32" rx="10"></rect>
+         <rect x="103" y="2917" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2937">MATCHING</text>
+         <rect x="105" y="2963" width="86" height="32" rx="10"></rect>
+         <rect x="103" y="2961" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="2981">MATCHED</text>
+         <rect x="105" y="3007" width="74" height="32" rx="10"></rect>
+         <rect x="103" y="3005" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3025">UPDATE</text>
+         <rect x="105" y="3051" width="70" height="32" rx="10"></rect>
+         <rect x="103" y="3049" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3069">INSERT</text>
+         <rect x="105" y="3095" width="56" height="32" rx="10"></rect>
+         <rect x="103" y="3093" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3113">INTO</text>
+         <rect x="105" y="3139" width="84" height="32" rx="10"></rect>
+         <rect x="103" y="3137" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3157">HEADING</text>
+         <rect x="105" y="3183" width="84" height="32" rx="10"></rect>
+         <rect x="103" y="3181" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3201">FOOTING</text>
+         <rect x="105" y="3227" width="84" height="32" rx="10"></rect>
+         <rect x="103" y="3225" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3245">SUBHEAD</text>
+         <rect x="105" y="3271" width="86" height="32" rx="10"></rect>
+         <rect x="103" y="3269" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3289">SUBFOOT</text>
+         <rect x="105" y="3315" width="76" height="32" rx="10"></rect>
+         <rect x="103" y="3313" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3333">FORMAT</text>
+         <rect x="105" y="3359" width="62" height="32" rx="10"></rect>
+         <rect x="103" y="3357" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3377">TIMES</text>
+         <rect x="105" y="3403" width="66" height="32" rx="10"></rect>
+         <rect x="103" y="3401" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3421">WHILE</text>
+         <rect x="105" y="3447" width="62" height="32" rx="10"></rect>
+         <rect x="103" y="3445" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3465">UNTIL</text>
+         <rect x="105" y="3491" width="48" height="32" rx="10"></rect>
+         <rect x="103" y="3489" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3509">FOR</text>
+         <rect x="105" y="3535" width="54" height="32" rx="10"></rect>
+         <rect x="103" y="3533" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3553">STEP</text>
+         <rect x="105" y="3579" width="48" height="32" rx="10"></rect>
+         <rect x="103" y="3577" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3597">TOP</text>
+         <rect x="105" y="3623" width="78" height="32" rx="10"></rect>
+         <rect x="103" y="3621" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3641">BOTTOM</text>
+         <rect x="105" y="3667" width="76" height="32" rx="10"></rect>
+         <rect x="103" y="3665" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3685">RANKED</text>
+         <rect x="105" y="3711" width="84" height="32" rx="10"></rect>
+         <rect x="103" y="3709" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3729">NOPRINT</text>
+         <rect x="105" y="3755" width="38" height="32" rx="10"></rect>
+         <rect x="103" y="3753" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3773">AS</text>
+         <rect x="105" y="3799" width="36" height="32" rx="10"></rect>
+         <rect x="103" y="3797" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3817">IN</text>
+         <rect x="105" y="3843" width="100" height="32" rx="10"></rect>
+         <rect x="103" y="3841" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3861">HIERARCHY</text>
+         <rect x="105" y="3887" width="62" height="32" rx="10"></rect>
+         <rect x="103" y="3885" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3905">WHEN</text>
+         <rect x="105" y="3931" width="64" height="32" rx="10"></rect>
+         <rect x="103" y="3929" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3949">SHOW</text>
+         <rect x="105" y="3975" width="38" height="32" rx="10"></rect>
+         <rect x="103" y="3973" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="3993">UP</text>
+         <rect x="105" y="4019" width="64" height="32" rx="10"></rect>
+         <rect x="103" y="4017" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="4037">DOWN</text>
+         <rect x="105" y="4063" width="58" height="32" rx="10"></rect>
+         <rect x="103" y="4061" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="4081">OPEN</text>
+         <rect x="105" y="4107" width="64" height="32" rx="10"></rect>
+         <rect x="103" y="4105" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="4125">CLOSE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#PAGE_BREAK" xlink:title="PAGE_BREAK">
+            <rect x="105" y="4151" width="102" height="32"></rect>
+            <rect x="103" y="4149" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="113" y="4169">PAGE_BREAK</text></a><rect x="105" y="4195" width="130" height="32" rx="10"></rect>
+         <rect x="103" y="4193" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="4213">DRILLTHROUGH</text>
+         <rect x="105" y="4239" width="78" height="32" rx="10"></rect>
+         <rect x="103" y="4237" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="4257">COLUMN</text>
+         <rect x="105" y="4283" width="52" height="32" rx="10"></rect>
+         <rect x="103" y="4281" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="4301">LINE</text>
+         <rect x="105" y="4327" width="54" height="32" rx="10"></rect>
+         <rect x="103" y="4325" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="4345">ITEM</text>
+         <rect x="105" y="4371" width="68" height="32" rx="10"></rect>
+         <rect x="103" y="4369" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="4389">COLOR</text>
+         <rect x="105" y="4415" width="80" height="32" rx="10"></rect>
+         <rect x="103" y="4413" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="4433">DEFAULT</text>
+         <rect x="105" y="4459" width="56" height="32" rx="10"></rect>
+         <rect x="103" y="4457" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="4477">READ</text>
+         <rect x="105" y="4503" width="66" height="32" rx="10"></rect>
+         <rect x="103" y="4501" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="4521">WRITE</text>
+         <rect x="105" y="4547" width="54" height="32" rx="10"></rect>
+         <rect x="103" y="4545" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="4565">TYPE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="293" y="279" width="36" height="32"></rect>
+            <rect x="291" y="277" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="301" y="297">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#layout_value" xlink:title="layout_value">
+            <rect x="349" y="279" width="102" height="32"></rect>
+            <rect x="347" y="277" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="357" y="297">layout_value</text></a><rect x="85" y="235" width="24" height="32" rx="10"></rect>
+         <rect x="83" y="233" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="253">,</text>
+         <rect x="531" y="343" width="24" height="32" rx="10"></rect>
+         <rect x="529" y="341" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="539" y="361">,</text>
+         <rect x="595" y="311" width="28" height="32" rx="10"></rect>
+         <rect x="593" y="309" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="603" y="329">$</text>
+         <rect x="703" y="279" width="48" height="32" rx="10"></rect>
+         <rect x="701" y="277" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="711" y="297">END</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#request" xlink:title="request">
+            <rect x="791" y="245" width="68" height="32"></rect>
+            <rect x="789" y="243" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="799" y="263">request</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_command" xlink:title="dm_command">
+            <rect x="791" y="201" width="108" height="32"></rect>
+            <rect x="789" y="199" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="799" y="219">dm_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#join_command" xlink:title="join_command">
+            <rect x="791" y="157" width="112" height="32"></rect>
+            <rect x="789" y="155" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="799" y="175">join_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#set_command" xlink:title="set_command">
+            <rect x="791" y="113" width="108" height="32"></rect>
+            <rect x="789" y="111" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="799" y="131">set_command</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#define_file" xlink:title="define_file">
+            <rect x="791" y="69" width="86" height="32"></rect>
+            <rect x="789" y="67" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="799" y="87">define_file</text></a><rect x="749" y="4629" width="100" height="32" rx="10"></rect>
+         <rect x="747" y="4627" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="757" y="4647">COMPOUND</text>
+         <rect x="869" y="4629" width="48" height="32" rx="10"></rect>
+         <rect x="867" y="4627" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="877" y="4647">END</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m100 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m130 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-394 276 l2 0 m2 0 l2 0 m2 0 l2 0 m82 0 h10 m54 0 h10 m0 0 h94 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m50 0 h10 m0 0 h98 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m92 0 h10 m0 0 h56 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m44 0 h10 m0 0 h104 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m58 0 h10 m0 0 h90 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m60 0 h10 m0 0 h88 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m46 0 h10 m0 0 h102 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m40 0 h10 m0 0 h108 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m72 0 h10 m0 0 h76 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m118 0 h10 m0 0 h30 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m100 0 h10 m0 0 h48 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m74 0 h10 m0 0 h74 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m82 0 h10 m0 0 h66 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m110 0 h10 m0 0 h38 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m108 0 h10 m0 0 h40 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m118 0 h10 m0 0 h30 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m90 0 h10 m0 0 h58 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m68 0 h10 m0 0 h80 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m138 0 h10 m0 0 h10 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m146 0 h10 m0 0 h2 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m148 0 h10 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m94 0 h10 m0 0 h54 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m86 0 h10 m0 0 h62 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m74 0 h10 m0 0 h74 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m70 0 h10 m0 0 h78 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m86 0 h10 m0 0 h62 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m76 0 h10 m0 0 h72 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m48 0 h10 m0 0 h100 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m78 0 h10 m0 0 h70 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m76 0 h10 m0 0 h72 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m84 0 h10 m0 0 h64 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m38 0 h10 m0 0 h110 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m36 0 h10 m0 0 h112 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m100 0 h10 m0 0 h48 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m62 0 h10 m0 0 h86 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m38 0 h10 m0 0 h110 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m58 0 h10 m0 0 h90 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h84 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m102 0 h10 m0 0 h46 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m130 0 h10 m0 0 h18 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m78 0 h10 m0 0 h70 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m52 0 h10 m0 0 h96 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m68 0 h10 m0 0 h80 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m80 0 h10 m0 0 h68 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m56 0 h10 m0 0 h92 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m66 0 h10 m0 0 h82 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m54 0 h10 m0 0 h94 m20 -4268 h10 m36 0 h10 m0 0 h10 m102 0 h10 m-406 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m386 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-386 0 h10 m24 0 h10 m0 0 h342 m40 44 h10 m0 0 h122 m-152 0 h20 m132 0 h20 m-172 0 q10 0 10 10 m152 0 q0 -10 10 -10 m-162 10 v12 m152 0 v-12 m-152 12 q0 10 10 10 m132 0 q10 0 10 -10 m-122 10 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m20 -32 h10 m28 0 h10 m-598 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -56 q0 -10 10 -10 m598 76 l20 0 m-20 0 q10 0 10 -10 l0 -56 q0 -10 -10 -10 m-598 0 h10 m0 0 h588 m-638 76 h20 m638 0 h20 m-678 0 q10 0 10 10 m658 0 q0 -10 10 -10 m-668 10 v4282 m658 0 v-4282 m-658 4282 q0 10 10 10 m638 0 q10 0 10 -10 m-648 10 h10 m0 0 h628 m20 -4302 h10 m48 0 h10 m20 0 h10 m0 0 h122 m-152 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m132 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-132 0 h10 m68 0 h10 m0 0 h44 m-142 10 l0 -44 q0 -10 10 -10 m142 54 l0 -44 q0 -10 -10 -10 m-132 0 h10 m108 0 h10 m0 0 h4 m-142 10 l0 -44 q0 -10 10 -10 m142 54 l0 -44 q0 -10 -10 -10 m-132 0 h10 m112 0 h10 m-142 10 l0 -44 q0 -10 10 -10 m142 54 l0 -44 q0 -10 -10 -10 m-132 0 h10 m108 0 h10 m0 0 h4 m-142 10 l0 -44 q0 -10 10 -10 m142 54 l0 -44 q0 -10 -10 -10 m-132 0 h10 m86 0 h10 m0 0 h26 m22 210 l2 0 m2 0 l2 0 m2 0 l2 0 m-218 4350 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m100 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="935 4643 943 4639 943 4647"></polygon>
+         <polygon points="935 4643 927 4639 927 4647"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</a></div>
+               <div>         ::= 'COMPOUND' 'LAYOUT' <a href="#output_command" title="output_command">output_command</a> ( ( <a href="#NAME" title="NAME">NAME</a> | 'AVE' | 'MIN' | 'MAX' | 'CNT' | 'FST' | 'LST' | 'ASQ' | 'MDN' | 'MDE' | 'PCT' |
+                  'RPCT' | 'RNK' | 'DST' | 'TOT' | 'SUM' | 'CT' | 'IS' | 'CONTAINS' | 'OMITS' | 'LIKE'
+                  | 'TOTAL' | 'MISSING' | 'INCLUDES' | 'EXCLUDES' | 'EXCEEDS' | 'ALL' | 'LESS' | 'THAN'
+                  | 'MORE' | 'GREATER' | 'OFF' | 'ON' | 'RECAP' | 'INDENT' | <a href="#ACROSS_TOTAL" title="ACROSS_TOTAL">ACROSS_TOTAL</a> | 'COMPOUND' | 'LAYOUT' | 'SECTION' | 'PAGELAYOUT' | 'COMPONENT' | 'MERGE' | 'ORIENTATION'
+                  | 'LANDSCAPE' | 'PORTRAIT' | 'TYPE' | 'POSITION' | 'DIMENSION' | 'STYLE' | 'ENDSTYLE'
+                  | 'MATCH' | 'AFTER' | 'RUN' | 'OLD' | 'NEW' | <a href="#OLD_OR_NEW_KW" title="OLD_OR_NEW_KW">OLD_OR_NEW_KW</a> | <a href="#OLD_AND_NEW_KW" title="OLD_AND_NEW_KW">OLD_AND_NEW_KW</a> | <a href="#OLD_NOT_NEW_KW" title="OLD_NOT_NEW_KW">OLD_NOT_NEW_KW</a> | <a href="#NEW_NOT_OLD_KW" title="NEW_NOT_OLD_KW">NEW_NOT_OLD_KW</a> | <a href="#OLD_NOR_NEW_KW" title="OLD_NOR_NEW_KW">OLD_NOR_NEW_KW</a> | 'MATCHING' | 'MATCHED' | 'UPDATE' | 'INSERT' | 'INTO' | 'HEADING' | 'FOOTING' |
+                  'SUBHEAD' | 'SUBFOOT' | 'FORMAT' | 'TIMES' | 'WHILE' | 'UNTIL' | 'FOR' | 'STEP' |
+                  'TOP' | 'BOTTOM' | 'RANKED' | 'NOPRINT' | 'AS' | 'IN' | 'HIERARCHY' | 'WHEN' | 'SHOW'
+                  | 'UP' | 'DOWN' | 'OPEN' | 'CLOSE' | <a href="#PAGE_BREAK" title="PAGE_BREAK">PAGE_BREAK</a> | 'DRILLTHROUGH' | 'COLUMN' | 'LINE' | 'ITEM' | 'COLOR' | 'DEFAULT' | 'READ' | 'WRITE'
+                  | 'TYPE' ) <a href="#EQ" title="EQ">EQ</a> <a href="#layout_value" title="layout_value">layout_value</a> ( ',' ( <a href="#NAME" title="NAME">NAME</a> | 'AVE' | 'MIN' | 'MAX' | 'CNT' | 'FST' | 'LST' | 'ASQ' | 'MDN' | 'MDE' | 'PCT' |
+                  'RPCT' | 'RNK' | 'DST' | 'TOT' | 'SUM' | 'CT' | 'IS' | 'CONTAINS' | 'OMITS' | 'LIKE'
+                  | 'TOTAL' | 'MISSING' | 'INCLUDES' | 'EXCLUDES' | 'EXCEEDS' | 'ALL' | 'LESS' | 'THAN'
+                  | 'MORE' | 'GREATER' | 'OFF' | 'ON' | 'RECAP' | 'INDENT' | <a href="#ACROSS_TOTAL" title="ACROSS_TOTAL">ACROSS_TOTAL</a> | 'COMPOUND' | 'LAYOUT' | 'SECTION' | 'PAGELAYOUT' | 'COMPONENT' | 'MERGE' | 'ORIENTATION'
+                  | 'LANDSCAPE' | 'PORTRAIT' | 'TYPE' | 'POSITION' | 'DIMENSION' | 'STYLE' | 'ENDSTYLE'
+                  | 'MATCH' | 'AFTER' | 'RUN' | 'OLD' | 'NEW' | <a href="#OLD_OR_NEW_KW" title="OLD_OR_NEW_KW">OLD_OR_NEW_KW</a> | <a href="#OLD_AND_NEW_KW" title="OLD_AND_NEW_KW">OLD_AND_NEW_KW</a> | <a href="#OLD_NOT_NEW_KW" title="OLD_NOT_NEW_KW">OLD_NOT_NEW_KW</a> | <a href="#NEW_NOT_OLD_KW" title="NEW_NOT_OLD_KW">NEW_NOT_OLD_KW</a> | <a href="#OLD_NOR_NEW_KW" title="OLD_NOR_NEW_KW">OLD_NOR_NEW_KW</a> | 'MATCHING' | 'MATCHED' | 'UPDATE' | 'INSERT' | 'INTO' | 'HEADING' | 'FOOTING' |
+                  'SUBHEAD' | 'SUBFOOT' | 'FORMAT' | 'TIMES' | 'WHILE' | 'UNTIL' | 'FOR' | 'STEP' |
+                  'TOP' | 'BOTTOM' | 'RANKED' | 'NOPRINT' | 'AS' | 'IN' | 'HIERARCHY' | 'WHEN' | 'SHOW'
+                  | 'UP' | 'DOWN' | 'OPEN' | 'CLOSE' | <a href="#PAGE_BREAK" title="PAGE_BREAK">PAGE_BREAK</a> | 'DRILLTHROUGH' | 'COLUMN' | 'LINE' | 'ITEM' | 'COLOR' | 'DEFAULT' | 'READ' | 'WRITE'
+                  | 'TYPE' ) <a href="#EQ" title="EQ">EQ</a> <a href="#layout_value" title="layout_value">layout_value</a> )* ( ','? '$' )? )* 'END' ( <a href="#request" title="request">request</a> | <a href="#dm_command" title="dm_command">dm_command</a> | <a href="#join_command" title="join_command">join_command</a> | <a href="#set_command" title="set_command">set_command</a> | <a href="#define_file" title="define_file">define_file</a> )* 'COMPOUND' 'END'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#start" title="start">start</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="verb_command" data-rule="verb_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#request" class="used-by-link">request</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="verb_command">verb_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="239" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#verb" xlink:title="verb">
+            <rect x="31" y="3" width="48" height="32"></rect>
+            <rect x="29" y="1" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">verb</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#field_list" xlink:title="field_list">
+            <rect x="119" y="3" width="72" height="32"></rect>
+            <rect x="117" y="1" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="127" y="21">field_list</text></a><rect x="119" y="47" width="28" height="32" rx="10"></rect>
+         <rect x="117" y="45" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="127" y="65">*</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m48 0 h10 m20 0 h10 m72 0 h10 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v24 m112 0 v-24 m-112 24 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m28 0 h10 m0 0 h44 m23 -44 h-3"></svg:path>
+         <polygon points="229 17 237 13 237 21"></polygon>
+         <polygon points="229 17 221 13 221 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#verb_command" title="verb_command">verb_command</a></div>
+               <div>         ::= <a href="#verb" title="verb">verb</a> ( <a href="#field_list" title="field_list">field_list</a> | '*' )</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="verb" data-rule="verb" data-description="Supported report verbs.">
+      <div class="rule-description">Supported report verbs.</div>
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#output_command" class="used-by-link">output_command</a>
+          <a href="#verb_command" class="used-by-link">verb_command</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="verb">verb:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="167" height="257">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">PRINT</text>
+         <rect x="51" y="47" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">SUM</text>
+         <rect x="51" y="91" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">LIST</text>
+         <rect x="51" y="135" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">COUNT</text>
+         <rect x="51" y="179" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">WRITE</text>
+         <rect x="51" y="223" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">ADD</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m62 0 h10 m0 0 h6 m-108 0 h20 m88 0 h20 m-128 0 q10 0 10 10 m108 0 q0 -10 10 -10 m-118 10 v24 m108 0 v-24 m-108 24 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m50 0 h10 m0 0 h18 m-98 -10 v20 m108 0 v-20 m-108 20 v24 m108 0 v-24 m-108 24 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m52 0 h10 m0 0 h16 m-98 -10 v20 m108 0 v-20 m-108 20 v24 m108 0 v-24 m-108 24 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m68 0 h10 m-98 -10 v20 m108 0 v-20 m-108 20 v24 m108 0 v-24 m-108 24 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m66 0 h10 m0 0 h2 m-98 -10 v20 m108 0 v-20 m-108 20 v24 m108 0 v-24 m-108 24 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m48 0 h10 m0 0 h20 m23 -220 h-3"></svg:path>
+         <polygon points="157 17 165 13 165 21"></polygon>
+         <polygon points="157 17 149 13 149 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#verb" title="verb">verb</a>     ::= 'PRINT'</div>
+               <div>           | 'SUM'</div>
+               <div>           | 'LIST'</div>
+               <div>           | 'COUNT'</div>
+               <div>           | 'WRITE'</div>
+               <div>           | 'ADD'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#output_command" title="output_command">output_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#verb_command" title="verb_command">verb_command</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="by_command" data-rule="by_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#request" class="used-by-link">request</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="by_command">by_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="981" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="35" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="33" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="53">RANKED</text>
+         <rect x="167" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="165" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="175" y="21">BY</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#sort_options" xlink:title="sort_options">
+            <rect x="245" y="35" width="100" height="32"></rect>
+            <rect x="243" y="33" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="253" y="53">sort_options</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#field" xlink:title="field">
+            <rect x="385" y="3" width="46" height="32"></rect>
+            <rect x="383" y="1" width="46" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="393" y="21">field</text></a><rect x="471" y="35" width="100" height="32" rx="10"></rect>
+         <rect x="469" y="33" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="479" y="53">HIERARCHY</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#summarize_command" xlink:title="summarize_command">
+            <rect x="631" y="35" width="158" height="32"></rect>
+            <rect x="629" y="33" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="639" y="53">summarize_command</text></a><rect x="849" y="35" width="84" height="32" rx="10"></rect>
+         <rect x="847" y="33" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="857" y="53">NOPRINT</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m0 0 h86 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v12 m116 0 v-12 m-116 12 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m20 -32 h10 m38 0 h10 m20 0 h10 m0 0 h110 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v12 m140 0 v-12 m-140 12 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m100 0 h10 m20 -32 h10 m46 0 h10 m20 0 h10 m0 0 h110 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v12 m140 0 v-12 m-140 12 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m100 0 h10 m40 -32 h10 m0 0 h168 m-198 0 h20 m178 0 h20 m-218 0 q10 0 10 10 m198 0 q0 -10 10 -10 m-208 10 v12 m198 0 v-12 m-198 12 q0 10 10 10 m178 0 q10 0 10 -10 m-188 10 h10 m158 0 h10 m40 -32 h10 m0 0 h94 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v12 m124 0 v-12 m-124 12 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m84 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="971 17 979 13 979 21"></polygon>
+         <polygon points="971 17 963 13 963 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#by_command" title="by_command">by_command</a></div>
+               <div>         ::= 'RANKED'? 'BY' <a href="#sort_options" title="sort_options">sort_options</a>? <a href="#field" title="field">field</a> 'HIERARCHY'? <a href="#summarize_command" title="summarize_command">summarize_command</a>? 'NOPRINT'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="where_command" data-rule="where_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#request" class="used-by-link">request</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="where_command">where_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="521" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="70" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">WHERE</text>
+         <rect x="141" y="35" width="64" height="32" rx="10"></rect>
+         <rect x="139" y="33" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="149" y="53">TOTAL</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_logical_expression" xlink:title="dm_logical_expression">
+            <rect x="245" y="3" width="164" height="32"></rect>
+            <rect x="243" y="1" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="253" y="21">dm_logical_expression</text></a><rect x="449" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="447" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="457" y="53">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m20 -32 h10 m164 0 h10 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="511 17 519 13 519 21"></polygon>
+         <polygon points="511 17 503 13 503 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#where_command" title="where_command">where_command</a></div>
+               <div>         ::= 'WHERE' 'TOTAL'? <a href="#dm_logical_expression" title="dm_logical_expression">dm_logical_expression</a> ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="heading_command" data-rule="heading_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#request" class="used-by-link">request</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="heading_command">heading_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="401" height="85">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <rect x="31" y="19" width="84" height="32" rx="10"></rect>
+         <rect x="29" y="17" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="37">HEADING</text>
+         <rect x="155" y="51" width="72" height="32" rx="10"></rect>
+         <rect x="153" y="49" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="163" y="69">CENTER</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="287" y="19" width="66" height="32"></rect>
+            <rect x="285" y="17" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="295" y="37">STRING</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m0 0 h10 m84 0 h10 m20 0 h10 m0 0 h82 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v12 m112 0 v-12 m-112 12 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m72 0 h10 m40 -32 h10 m66 0 h10 m-106 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m86 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-86 0 h10 m0 0 h76 m23 32 h-3"></svg:path>
+         <polygon points="391 33 399 29 399 37"></polygon>
+         <polygon points="391 33 383 29 383 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#heading_command" title="heading_command">heading_command</a></div>
+               <div>         ::= 'HEADING' 'CENTER'? <a href="#STRING" title="STRING">STRING</a>+</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="category-header">Environment</div>
+   <div class="rule-container" id="join_command" data-rule="join_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#start" class="used-by-link">start</a>
+      </div>
+      <div class="rule-example-container">
+          <div class="rule-example-header">Examples</div>
+          <div class="example-row">
+              <code class="rule-example">JOIN CAR.BODY.COUNTRY TO ALL COUNTRY.COUNTRY.COUNTRY AS J1</code>
+              <button class="copy-button" onclick="copyExample(this, &quot;JOIN CAR.BODY.COUNTRY TO ALL COUNTRY.COUNTRY.COUNTRY AS J1&quot;)">Copy</button>
+          </div>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="join_command">join_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="1303" height="297">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">JOIN</text>
+         <rect x="45" y="69" width="64" height="32" rx="10"></rect>
+         <rect x="43" y="67" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="87">CLEAR</text>
+         <rect x="129" y="69" width="28" height="32" rx="10"></rect>
+         <rect x="127" y="67" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="137" y="87">*</text>
+         <rect x="85" y="177" width="52" height="32" rx="10"></rect>
+         <rect x="83" y="175" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="195">LEFT</text>
+         <rect x="177" y="145" width="66" height="32" rx="10"></rect>
+         <rect x="175" y="143" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="185" y="163">OUTER</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="283" y="113" width="118" height="32"></rect>
+            <rect x="281" y="111" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="291" y="131">qualified_name</text></a><rect x="421" y="113" width="36" height="32" rx="10"></rect>
+         <rect x="419" y="111" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="429" y="131">IN</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="477" y="113" width="118" height="32"></rect>
+            <rect x="475" y="111" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="485" y="131">qualified_name</text></a><rect x="615" y="113" width="38" height="32" rx="10"></rect>
+         <rect x="613" y="111" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="623" y="131">TO</text>
+         <rect x="693" y="145" width="44" height="32" rx="10"></rect>
+         <rect x="691" y="143" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="701" y="163">ALL</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="777" y="113" width="118" height="32"></rect>
+            <rect x="775" y="111" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="785" y="131">qualified_name</text></a><rect x="915" y="113" width="36" height="32" rx="10"></rect>
+         <rect x="913" y="111" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="923" y="131">IN</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="971" y="113" width="118" height="32"></rect>
+            <rect x="969" y="111" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="979" y="131">qualified_name</text></a><rect x="1129" y="145" width="38" height="32" rx="10"></rect>
+         <rect x="1127" y="143" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1137" y="163">AS</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NAME" xlink:title="NAME">
+            <rect x="1187" y="145" width="54" height="32"></rect>
+            <rect x="1185" y="143" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1195" y="163">NAME</text></a><rect x="1231" y="263" width="24" height="32" rx="10"></rect>
+         <rect x="1229" y="261" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="1239" y="281">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-104 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m64 0 h10 m0 0 h10 m28 0 h10 m0 0 h1104 m-1256 0 h20 m1236 0 h20 m-1276 0 q10 0 10 10 m1256 0 q0 -10 10 -10 m-1266 10 v24 m1256 0 v-24 m-1256 24 q0 10 10 10 m1236 0 q10 0 10 -10 m-1226 10 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-188 10 h10 m0 0 h62 m-92 0 h20 m72 0 h20 m-112 0 q10 0 10 10 m92 0 q0 -10 10 -10 m-102 10 v12 m92 0 v-12 m-92 12 q0 10 10 10 m72 0 q10 0 10 -10 m-82 10 h10 m52 0 h10 m20 -32 h10 m66 0 h10 m20 -32 h10 m118 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m0 0 h54 m-84 0 h20 m64 0 h20 m-104 0 q10 0 10 10 m84 0 q0 -10 10 -10 m-94 10 v12 m84 0 v-12 m-84 12 q0 10 10 10 m64 0 q10 0 10 -10 m-74 10 h10 m44 0 h10 m20 -32 h10 m118 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m118 0 h10 m20 0 h10 m0 0 h122 m-152 0 h20 m132 0 h20 m-172 0 q10 0 10 10 m152 0 q0 -10 10 -10 m-162 10 v12 m152 0 v-12 m-152 12 q0 10 10 10 m132 0 q10 0 10 -10 m-142 10 h10 m38 0 h10 m0 0 h10 m54 0 h10 m42 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-114 162 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="1293 245 1301 241 1301 249"></polygon>
+         <polygon points="1293 245 1285 241 1285 249"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#join_command" title="join_command">join_command</a></div>
+               <div>         ::= 'JOIN' ( 'CLEAR' '*' | ( 'LEFT'? 'OUTER' )? <a href="#qualified_name" title="qualified_name">qualified_name</a> 'IN' <a href="#qualified_name" title="qualified_name">qualified_name</a> 'TO' 'ALL'? <a href="#qualified_name" title="qualified_name">qualified_name</a> 'IN' <a href="#qualified_name" title="qualified_name">qualified_name</a> ( 'AS' <a href="#NAME" title="NAME">NAME</a> )? ) ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#start" title="start">start</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="set_command" data-rule="set_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#on_table_options" class="used-by-link">on_table_options</a>
+          <a href="#start" class="used-by-link">start</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="set_command">set_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="585" height="101">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="44" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SET</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#hyphenated_name" xlink:title="hyphenated_name">
+            <rect x="95" y="3" width="140" height="32"></rect>
+            <rect x="93" y="1" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="103" y="21">hyphenated_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EQ" xlink:title="EQ">
+            <rect x="295" y="67" width="36" height="32"></rect>
+            <rect x="293" y="65" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="303" y="85">EQ</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#set_value" xlink:title="set_value">
+            <rect x="371" y="35" width="82" height="32"></rect>
+            <rect x="369" y="33" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="379" y="53">set_value</text></a><rect x="513" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="511" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="521" y="53">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m44 0 h10 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-188 10 h10 m0 0 h46 m-76 0 h20 m56 0 h20 m-96 0 q10 0 10 10 m76 0 q0 -10 10 -10 m-86 10 v12 m76 0 v-12 m-76 12 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m36 0 h10 m20 -32 h10 m82 0 h10 m40 -32 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="575 17 583 13 583 21"></polygon>
+         <polygon points="575 17 567 13 567 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#set_command" title="set_command">set_command</a></div>
+               <div>         ::= 'SET' <a href="#hyphenated_name" title="hyphenated_name">hyphenated_name</a> ( <a href="#EQ" title="EQ">EQ</a>? <a href="#set_value" title="set_value">set_value</a> )? ';'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#on_table_options" title="on_table_options">on_table_options</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#start" title="start">start</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="category-header">Dialogue Manager</div>
+   <div class="rule-container" id="dm_command" data-rule="dm_command" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compound_layout_block" class="used-by-link">compound_layout_block</a>
+          <a href="#match_request" class="used-by-link">match_request</a>
+          <a href="#request" class="used-by-link">request</a>
+          <a href="#start" class="used-by-link">start</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_command">dm_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="203" height="565">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_set" xlink:title="dm_set">
+            <rect x="51" y="3" width="68" height="32"></rect>
+            <rect x="49" y="1" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">dm_set</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_goto" xlink:title="dm_goto">
+            <rect x="51" y="47" width="76" height="32"></rect>
+            <rect x="49" y="45" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">dm_goto</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_label" xlink:title="dm_label">
+            <rect x="51" y="91" width="78" height="32"></rect>
+            <rect x="49" y="89" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">dm_label</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_if" xlink:title="dm_if">
+            <rect x="51" y="135" width="54" height="32"></rect>
+            <rect x="49" y="133" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">dm_if</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_type" xlink:title="dm_type">
+            <rect x="51" y="179" width="76" height="32"></rect>
+            <rect x="49" y="177" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">dm_type</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_include" xlink:title="dm_include">
+            <rect x="51" y="223" width="92" height="32"></rect>
+            <rect x="49" y="221" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="241">dm_include</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_run" xlink:title="dm_run">
+            <rect x="51" y="267" width="68" height="32"></rect>
+            <rect x="49" y="265" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="285">dm_run</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_exit" xlink:title="dm_exit">
+            <rect x="51" y="311" width="70" height="32"></rect>
+            <rect x="49" y="309" width="70" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="329">dm_exit</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_repeat" xlink:title="dm_repeat">
+            <rect x="51" y="355" width="90" height="32"></rect>
+            <rect x="49" y="353" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="373">dm_repeat</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_htmlform" xlink:title="dm_htmlform">
+            <rect x="51" y="399" width="104" height="32"></rect>
+            <rect x="49" y="397" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="417">dm_htmlform</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_read" xlink:title="dm_read">
+            <rect x="51" y="443" width="76" height="32"></rect>
+            <rect x="49" y="441" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="461">dm_read</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_write" xlink:title="dm_write">
+            <rect x="51" y="487" width="78" height="32"></rect>
+            <rect x="49" y="485" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="505">dm_write</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_default" xlink:title="dm_default">
+            <rect x="51" y="531" width="92" height="32"></rect>
+            <rect x="49" y="529" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="549">dm_default</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m68 0 h10 m0 0 h36 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m76 0 h10 m0 0 h28 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m78 0 h10 m0 0 h26 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m54 0 h10 m0 0 h50 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m76 0 h10 m0 0 h28 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m92 0 h10 m0 0 h12 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m68 0 h10 m0 0 h36 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m70 0 h10 m0 0 h34 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m90 0 h10 m0 0 h14 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m104 0 h10 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m76 0 h10 m0 0 h28 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m78 0 h10 m0 0 h26 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m92 0 h10 m0 0 h12 m23 -528 h-3"></svg:path>
+         <polygon points="193 17 201 13 201 21"></polygon>
+         <polygon points="193 17 185 13 185 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_command" title="dm_command">dm_command</a></div>
+               <div>         ::= <a href="#dm_set" title="dm_set">dm_set</a></div>
+               <div>           | <a href="#dm_goto" title="dm_goto">dm_goto</a></div>
+               <div>           | <a href="#dm_label" title="dm_label">dm_label</a></div>
+               <div>           | <a href="#dm_if" title="dm_if">dm_if</a></div>
+               <div>           | <a href="#dm_type" title="dm_type">dm_type</a></div>
+               <div>           | <a href="#dm_include" title="dm_include">dm_include</a></div>
+               <div>           | <a href="#dm_run" title="dm_run">dm_run</a></div>
+               <div>           | <a href="#dm_exit" title="dm_exit">dm_exit</a></div>
+               <div>           | <a href="#dm_repeat" title="dm_repeat">dm_repeat</a></div>
+               <div>           | <a href="#dm_htmlform" title="dm_htmlform">dm_htmlform</a></div>
+               <div>           | <a href="#dm_read" title="dm_read">dm_read</a></div>
+               <div>           | <a href="#dm_write" title="dm_write">dm_write</a></div>
+               <div>           | <a href="#dm_default" title="dm_default">dm_default</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compound_layout_block" title="compound_layout_block">compound_layout_block</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#match_request" title="match_request">match_request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#request" title="request">request</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#start" title="start">start</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="category-header">Expressions</div>
+   <div class="rule-container" id="dm_expression" data-rule="dm_expression" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#compute_command" class="used-by-link">compute_command</a>
+          <a href="#decode_expression" class="used-by-link">decode_expression</a>
+          <a href="#define_assignment" class="used-by-link">define_assignment</a>
+          <a href="#dm_default" class="used-by-link">dm_default</a>
+          <a href="#dm_if_expression" class="used-by-link">dm_if_expression</a>
+          <a href="#dm_repeat" class="used-by-link">dm_repeat</a>
+          <a href="#dm_set" class="used-by-link">dm_set</a>
+          <a href="#dm_type" class="used-by-link">dm_type</a>
+          <a href="#dm_unary_expression" class="used-by-link">dm_unary_expression</a>
+          <a href="#dm_write" class="used-by-link">dm_write</a>
+          <a href="#recap_assignment" class="used-by-link">recap_assignment</a>
+          <a href="#show_command" class="used-by-link">show_command</a>
+          <a href="#when_matched_clause" class="used-by-link">when_matched_clause</a>
+          <a href="#when_not_matched_clause" class="used-by-link">when_not_matched_clause</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_expression">dm_expression:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="191" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_if_expression" xlink:title="dm_if_expression">
+            <rect x="31" y="3" width="132" height="32"></rect>
+            <rect x="29" y="1" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">dm_if_expression</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="181 17 189 13 189 21"></polygon>
+         <polygon points="181 17 173 13 173 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_expression" title="dm_expression">dm_expression</a></div>
+               <div>         ::= <a href="#dm_if_expression" title="dm_if_expression">dm_if_expression</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#compute_command" title="compute_command">compute_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#decode_expression" title="decode_expression">decode_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#define_assignment" title="define_assignment">define_assignment</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_default" title="dm_default">dm_default</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_if_expression" title="dm_if_expression">dm_if_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_repeat" title="dm_repeat">dm_repeat</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_set" title="dm_set">dm_set</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_type" title="dm_type">dm_type</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_unary_expression" title="dm_unary_expression">dm_unary_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#dm_write" title="dm_write">dm_write</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#recap_assignment" title="recap_assignment">recap_assignment</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#show_command" title="show_command">show_command</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#when_matched_clause" title="when_matched_clause">when_matched_clause</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#when_not_matched_clause" title="when_not_matched_clause">when_not_matched_clause</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+   <div class="rule-container" id="dm_if_expression" data-rule="dm_if_expression" data-description="">
+      <div class="used-by-container">
+          <div class="used-by-header">Used By:</div>
+          <a href="#dm_expression" class="used-by-link">dm_expression</a>
+      </div>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="dm_if_expression">dm_if_expression:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="737" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #001133; stroke-width: 1;}
+    .bold-line            {stroke: #000714; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #000A1F; shape-rendering: crispEdges}
+    .filled               {fill: #001133; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000714;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #00091A;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #000A1F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #001133; stroke: #001133;}
+    rect.terminal         {fill: #4D88FF; stroke: #001133; stroke-width: 1;}
+    rect.nonterminal      {fill: #9EBFFF; stroke: #001133; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #C7DAFF; stroke: #001133; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="34" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">IF</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_logical_expression" xlink:title="dm_logical_expression">
+            <rect x="105" y="3" width="164" height="32"></rect>
+            <rect x="103" y="1" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="113" y="21">dm_logical_expression</text></a><rect x="289" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="287" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="297" y="21">THEN</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="365" y="3" width="116" height="32"></rect>
+            <rect x="363" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="21">dm_expression</text></a><rect x="501" y="3" width="52" height="32" rx="10"></rect>
+         <rect x="499" y="1" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="509" y="21">ELSE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_expression" xlink:title="dm_expression">
+            <rect x="573" y="3" width="116" height="32"></rect>
+            <rect x="571" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="581" y="21">dm_expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#dm_logical_expression" xlink:title="dm_logical_expression">
+            <rect x="51" y="47" width="164" height="32"></rect>
+            <rect x="49" y="45" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">dm_logical_expression</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m34 0 h10 m0 0 h10 m164 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m52 0 h10 m0 0 h10 m116 0 h10 m-678 0 h20 m658 0 h20 m-698 0 q10 0 10 10 m678 0 q0 -10 10 -10 m-688 10 v24 m678 0 v-24 m-678 24 q0 10 10 10 m658 0 q10 0 10 -10 m-668 10 h10 m164 0 h10 m0 0 h474 m23 -44 h-3"></svg:path>
+         <polygon points="727 17 735 13 735 21"></polygon>
+         <polygon points="727 17 719 13 719 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#dm_if_expression" title="dm_if_expression">dm_if_expression</a></div>
+               <div>         ::= 'IF' <a href="#dm_logical_expression" title="dm_logical_expression">dm_logical_expression</a> 'THEN' <a href="#dm_expression" title="dm_expression">dm_expression</a> 'ELSE' <a href="#dm_expression" title="dm_expression">dm_expression</a></div>
+               <div>           | <a href="#dm_logical_expression" title="dm_logical_expression">dm_logical_expression</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#dm_expression" title="dm_expression">dm_expression</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p>
+   </div>
+</div>
+<xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:table border="0" class="signature">
+            <xhtml:tr>
+               <xhtml:td style="width: 100%"> </xhtml:td>
+               <xhtml:td valign="top">
+                  <xhtml:nobr class="signature">... generated by <xhtml:a name="Railroad-Diagram-Generator" class="signature" title="https://bottlecaps.de/rr" href="https://bottlecaps.de/rr" target="_blank">RR - Railroad Diagram Generator</xhtml:a></xhtml:nobr>
+               </xhtml:td>
+               <xhtml:td><xhtml:a name="Railroad-Diagram-Generator" title="https://bottlecaps.de/rr" href="https://bottlecaps.de/rr" target="_blank"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+                        <g transform="scale(0.178)">
+                           <circle cx="45" cy="45" r="45" style="stroke:none; fill:#FFCC00"></circle>
+                           <circle cx="45" cy="45" r="42" style="stroke:#332900; stroke-width:2px; fill:#FFCC00"></circle>
+                           <line x1="15" y1="15" x2="75" y2="75" stroke="#332900" style="stroke-width:9px;"></line>
+                           <line x1="15" y1="75" x2="75" y2="15" stroke="#332900" style="stroke-width:9px;"></line>
+                           <text x="7" y="54" style="font-size:26px; font-family:Arial, Sans-serif; font-weight:bold; fill: #332900">R</text>
+                           <text x="64" y="54" style="font-size:26px; font-family:Arial, Sans-serif; font-weight:bold; fill: #332900">R</text>
+                        </g></svg></xhtml:a></xhtml:td>
+            </xhtml:tr>
+         </xhtml:table>
+      </xhtml:p>
+
+    <script type="text/javascript">
+    /* <![CDATA[ */
+    document.addEventListener('DOMContentLoaded', function() {
+        const searchInput = document.getElementById('rule-search');
+        const clearButton = document.getElementById('clear-search');
+        const resultCount = document.getElementById('result-count');
+        const containers = document.querySelectorAll('.rule-container');
+        const categoryHeaders = document.querySelectorAll('.category-header');
+
+        function updateFilter() {
+            const query = searchInput.value.toLowerCase();
+            let visibleCount = 0;
+
+            // Filter rules
+            containers.forEach(container => {
+                const ruleName = container.getAttribute('data-rule').toLowerCase();
+                const description = (container.getAttribute('data-description') || "").toLowerCase();
+                if (ruleName.includes(query) || description.includes(query)) {
+                    container.style.display = 'block';
+                    visibleCount++;
+                } else {
+                    container.style.display = 'none';
+                }
+            });
+
+            // Hide/show category headers
+            categoryHeaders.forEach(header => {
+                let next = header.nextElementSibling;
+                let hasVisibleRule = false;
+                while (next && next.classList.contains('rule-container')) {
+                    if (next.style.display !== 'none') {
+                        hasVisibleRule = true;
+                        break;
+                    }
+                    next = next.nextElementSibling;
+                }
+                header.style.display = hasVisibleRule ? 'block' : 'none';
+            });
+
+            resultCount.textContent = `${visibleCount} rules found`;
+        }
+
+        searchInput.addEventListener('input', updateFilter);
+
+        clearButton.addEventListener('click', function() {
+            searchInput.value = '';
+            updateFilter();
+            searchInput.focus();
+        });
+
+        window.copyExample = function(btn, text) {
+            navigator.clipboard.writeText(text).then(function() {
+                const originalText = btn.textContent;
+                btn.textContent = 'COPIED!';
+                btn.style.backgroundColor = '#28a745';
+                btn.style.color = '#fff';
+                setTimeout(function() {
+                    btn.textContent = originalText;
+                    btn.style.backgroundColor = '';
+                    btn.style.color = '';
+                }, 2000);
+            }, function(err) {
+                console.error('Could not copy text: ', err);
+            });
+        }
+
+        function handleHashChange() {
+            if (window.location.hash) {
+                const hash = window.location.hash.substring(1);
+                const target = document.getElementById(hash);
+                if (target) {
+                    // When a rule is targeted, we should clear the search to make sure it's visible
+                    if (searchInput.value !== '') {
+                        searchInput.value = '';
+                        updateFilter();
+                    }
+                    target.style.display = 'block';
+                    target.scrollIntoView();
+                }
+            }
+        }
+
+        window.addEventListener('hashchange', handleHashChange);
+
+        // Initial setup
+        updateFilter();
+        handleHashChange();
+    });
+    /* ]]> */
+    </script>
+
+   </body>
+</html>

--- a/docs_test/index.html
+++ b/docs_test/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>WebFocus Syntax Railroad Diagrams</title>
+    <style>
+        body { font-family: sans-serif; margin: 40px; background-color: #f0f5ff; }
+        h1 { color: #002b80; }
+        .metadata { color: #666; font-size: 0.9em; margin-bottom: 20px; }
+        ul { list-style-type: none; padding: 0; }
+        li { margin: 10px 0; }
+        a { text-decoration: none; color: #4D88FF; font-weight: bold; font-size: 1.2em; }
+        a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <h1>WebFocus Syntax Railroad Diagrams</h1>
+    <p>Visual representation of the WebFocus grammars.</p>
+    <div class="metadata">Generated on: 2026-05-23 12:58:08</div>
+    <ul>
+        <li><a href="WebFocusReport.xhtml">WebFocusReport.g4</a></li>
+    </ul>
+</body>
+</html>

--- a/scripts/generate_railroad.py
+++ b/scripts/generate_railroad.py
@@ -169,8 +169,21 @@ def post_process_xhtml(filepath, metadata=None):
         color: #002b80;
         font-size: 11px;
         text-transform: uppercase;
-        margin-bottom: 4px;
+        margin-bottom: 8px;
         font-family: 'Verdana', sans-serif;
+    }
+    .example-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 6px;
+        background-color: #ffffff;
+        padding: 4px 8px;
+        border-radius: 4px;
+        border: 1px solid #eef0f2;
+    }
+    .example-row:last-child {
+        margin-bottom: 0;
     }
     .rule-example {
         font-family: 'Courier New', monospace;
@@ -178,7 +191,25 @@ def post_process_xhtml(filepath, metadata=None):
         color: #333;
         white-space: pre-wrap;
         display: block;
-        margin-bottom: 4px;
+        flex-grow: 1;
+    }
+    .copy-button {
+        background-color: #f0f5ff;
+        color: #002b80;
+        border: 1px solid #d0d7de;
+        border-radius: 3px;
+        padding: 2px 8px;
+        font-size: 10px;
+        cursor: pointer;
+        margin-left: 10px;
+        font-family: 'Verdana', sans-serif;
+        text-transform: uppercase;
+        font-weight: bold;
+        transition: all 0.2s;
+    }
+    .copy-button:hover {
+        background-color: #002b80;
+        color: #ffffff;
     }
     .rule-example:last-child {
         margin-bottom: 0;
@@ -294,6 +325,22 @@ def post_process_xhtml(filepath, metadata=None):
             updateFilter();
             searchInput.focus();
         });
+
+        window.copyExample = function(btn, text) {
+            navigator.clipboard.writeText(text).then(function() {
+                const originalText = btn.textContent;
+                btn.textContent = 'COPIED!';
+                btn.style.backgroundColor = '#28a745';
+                btn.style.color = '#fff';
+                setTimeout(function() {
+                    btn.textContent = originalText;
+                    btn.style.backgroundColor = '';
+                    btn.style.color = '';
+                }, 2000);
+            }, function(err) {
+                console.error('Could not copy text: ', err);
+            });
+        }
 
         function handleHashChange() {
             if (window.location.hash) {
@@ -421,10 +468,17 @@ def wrap_rules_in_containers(content, metadata):
                 new_content += '      </div>\n'
 
             if examples:
+                import json
                 new_content += '      <div class="rule-example-container">\n'
                 new_content += '          <div class="rule-example-header">Examples</div>\n'
                 for example in examples:
-                    new_content += f'          <code class="rule-example">{html.escape(example)}</code>\n'
+                    safe_example = html.escape(example)
+                    # We use json.dumps to ensure it's a valid JS string literal, then escape it for HTML
+                    js_safe_example = html.escape(json.dumps(example))
+                    new_content += '          <div class="example-row">\n'
+                    new_content += f'              <code class="rule-example">{safe_example}</code>\n'
+                    new_content += f'              <button class="copy-button" onclick="copyExample(this, {js_safe_example})">Copy</button>\n'
+                    new_content += '          </div>\n'
                 new_content += '      </div>\n'
 
             new_content += f'      {block["body"]}\n'


### PR DESCRIPTION
This change implements an interactive 'Copy' button for all rule examples in the generated railroad diagram documentation. 

Key changes:
- **`scripts/generate_railroad.py`**: Added Oracle-inspired styling for the copy button, a JavaScript helper for clipboard interaction with visual feedback ("COPIED!"), and updated the XHTML post-processing logic to inject these elements.
- **`RAILROAD_ROADMAP.md`**: Added Phase 10 (UI & Interactivity) and marked 10.1 as complete.
- **`ROADMAP.md`**: Marked task 0.13 as complete.

Verification:
- Ran `test/test_rr_wrapper.py`, `test/test_railroad_integration.py`, `test/test_railroad_golden.py`, and `test/test_antlr4_to_ebnf.py` (all passed).
- Performed visual verification using a Playwright script (`/home/jules/verification/verify_copy_button.py`) which confirmed the button appears, hovers correctly, and changes state on click.

Fixes #405

---
*PR created automatically by Jules for task [11984098986478711697](https://jules.google.com/task/11984098986478711697) started by @chatelao*