### PR TITLE
Implement rule count display on railroad index page

### DIFF
--- a/RAILROAD_ROADMAP.md
+++ b/RAILROAD_ROADMAP.md
@@ -74,3 +74,6 @@ This document outlines the tasks required to implement the automated railroad di
 
 ## Phase 10: UI & Interactivity
 - [x] 10.1 Add a 'Copy' button to all rule examples for easy extraction.
+
+## Phase 11: Index Page Enhancements
+- [x] 11.1 Display total rule count for each grammar on the index page.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,5 @@
 # ROADMAP
-- [ ] 0.14 Implement a next, modest, very small, feasible and reasonable RAILROAD_ROADMAP.md step (#407)
+- [x] 0.14 Implement a next, modest, very small, feasible and reasonable RAILROAD_ROADMAP.md step (#407) (completed at 2026-05-23 14:46:41)
 - [x] 0.13 Implement a next, modest, very small, feasible and reasonable RAILROAD_ROADMAP.md step (#405) (completed at 2026-05-23 12:58:41)
 - [x] 0.12 Implement a next, modest, very small, feasible and reasonable RAILROAD_ROADMAP.md step (#403) (completed at 2026-05-21 12:03:01)
 - [x] 0.11 Implement a next, modest, very small, feasible and reasonable ROADMAP.md step of chapter 'Chapter 7: CI/CD & Verification' (#395) (completed at 2026-05-21 08:35:00)

--- a/docs/MasterFile.xhtml
+++ b/docs/MasterFile.xhtml
@@ -319,8 +319,21 @@
         color: #002b80;
         font-size: 11px;
         text-transform: uppercase;
-        margin-bottom: 4px;
+        margin-bottom: 8px;
         font-family: 'Verdana', sans-serif;
+    }
+    .example-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 6px;
+        background-color: #ffffff;
+        padding: 4px 8px;
+        border-radius: 4px;
+        border: 1px solid #eef0f2;
+    }
+    .example-row:last-child {
+        margin-bottom: 0;
     }
     .rule-example {
         font-family: 'Courier New', monospace;
@@ -328,7 +341,25 @@
         color: #333;
         white-space: pre-wrap;
         display: block;
-        margin-bottom: 4px;
+        flex-grow: 1;
+    }
+    .copy-button {
+        background-color: #f0f5ff;
+        color: #002b80;
+        border: 1px solid #d0d7de;
+        border-radius: 3px;
+        padding: 2px 8px;
+        font-size: 10px;
+        cursor: pointer;
+        margin-left: 10px;
+        font-family: 'Verdana', sans-serif;
+        text-transform: uppercase;
+        font-weight: bold;
+        transition: all 0.2s;
+    }
+    .copy-button:hover {
+        background-color: #002b80;
+        color: #ffffff;
     }
     .rule-example:last-child {
         margin-bottom: 0;
@@ -2217,6 +2248,22 @@
             updateFilter();
             searchInput.focus();
         });
+
+        window.copyExample = function(btn, text) {
+            navigator.clipboard.writeText(text).then(function() {
+                const originalText = btn.textContent;
+                btn.textContent = 'COPIED!';
+                btn.style.backgroundColor = '#28a745';
+                btn.style.color = '#fff';
+                setTimeout(function() {
+                    btn.textContent = originalText;
+                    btn.style.backgroundColor = '';
+                    btn.style.color = '';
+                }, 2000);
+            }, function(err) {
+                console.error('Could not copy text: ', err);
+            });
+        }
 
         function handleHashChange() {
             if (window.location.hash) {

--- a/docs/WebFocusReport.xhtml
+++ b/docs/WebFocusReport.xhtml
@@ -319,8 +319,21 @@
         color: #002b80;
         font-size: 11px;
         text-transform: uppercase;
-        margin-bottom: 4px;
+        margin-bottom: 8px;
         font-family: 'Verdana', sans-serif;
+    }
+    .example-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 6px;
+        background-color: #ffffff;
+        padding: 4px 8px;
+        border-radius: 4px;
+        border: 1px solid #eef0f2;
+    }
+    .example-row:last-child {
+        margin-bottom: 0;
     }
     .rule-example {
         font-family: 'Courier New', monospace;
@@ -328,7 +341,25 @@
         color: #333;
         white-space: pre-wrap;
         display: block;
-        margin-bottom: 4px;
+        flex-grow: 1;
+    }
+    .copy-button {
+        background-color: #f0f5ff;
+        color: #002b80;
+        border: 1px solid #d0d7de;
+        border-radius: 3px;
+        padding: 2px 8px;
+        font-size: 10px;
+        cursor: pointer;
+        margin-left: 10px;
+        font-family: 'Verdana', sans-serif;
+        text-transform: uppercase;
+        font-weight: bold;
+        transition: all 0.2s;
+    }
+    .copy-button:hover {
+        background-color: #002b80;
+        color: #ffffff;
     }
     .rule-example:last-child {
         margin-bottom: 0;
@@ -8942,7 +8973,10 @@
       </div>
       <div class="rule-example-container">
           <div class="rule-example-header">Examples</div>
-          <code class="rule-example">TABLE FILE CAR PRINT * END</code>
+          <div class="example-row">
+              <code class="rule-example">TABLE FILE CAR PRINT * END</code>
+              <button class="copy-button" onclick="copyExample(this, &quot;TABLE FILE CAR PRINT * END&quot;)">Copy</button>
+          </div>
       </div>
       <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="request">request:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="697" height="791">
          <defs>
@@ -9999,7 +10033,10 @@
       </div>
       <div class="rule-example-container">
           <div class="rule-example-header">Examples</div>
-          <code class="rule-example">JOIN CAR.BODY.COUNTRY TO ALL COUNTRY.COUNTRY.COUNTRY AS J1</code>
+          <div class="example-row">
+              <code class="rule-example">JOIN CAR.BODY.COUNTRY TO ALL COUNTRY.COUNTRY.COUNTRY AS J1</code>
+              <button class="copy-button" onclick="copyExample(this, &quot;JOIN CAR.BODY.COUNTRY TO ALL COUNTRY.COUNTRY.COUNTRY AS J1&quot;)">Copy</button>
+          </div>
       </div>
       <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="join_command">join_command:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="1303" height="297">
          <defs>
@@ -10483,6 +10520,22 @@
             updateFilter();
             searchInput.focus();
         });
+
+        window.copyExample = function(btn, text) {
+            navigator.clipboard.writeText(text).then(function() {
+                const originalText = btn.textContent;
+                btn.textContent = 'COPIED!';
+                btn.style.backgroundColor = '#28a745';
+                btn.style.color = '#fff';
+                setTimeout(function() {
+                    btn.textContent = originalText;
+                    btn.style.backgroundColor = '';
+                    btn.style.color = '';
+                }, 2000);
+            }, function(err) {
+                console.error('Could not copy text: ', err);
+            });
+        }
 
         function handleHashChange() {
             if (window.location.hash) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,14 +10,15 @@
         li { margin: 10px 0; }
         a { text-decoration: none; color: #4D88FF; font-weight: bold; font-size: 1.2em; }
         a:hover { text-decoration: underline; }
+        .rule-count { color: #666; font-size: 0.9em; margin-left: 10px; font-style: italic; }
     </style>
 </head>
 <body>
     <h1>WebFocus Syntax Railroad Diagrams</h1>
     <p>Visual representation of the WebFocus grammars.</p>
-    <div class="metadata">Generated on: 2026-05-21 11:51:53</div>
+    <div class="metadata">Generated on: 2026-05-23 14:44:34</div>
     <ul>
-        <li><a href="WebFocusReport.xhtml">WebFocusReport.g4</a></li><li><a href="MasterFile.xhtml">MasterFile.g4</a></li>
+        <li><a href="WebFocusReport.xhtml">WebFocusReport.g4</a> <span class="rule-count">(253 rules)</span></li><li><a href="MasterFile.xhtml">MasterFile.g4</a> <span class="rule-count">(31 rules)</span></li>
     </ul>
 </body>
 </html>

--- a/scripts/generate_railroad.py
+++ b/scripts/generate_railroad.py
@@ -20,6 +20,17 @@ def is_up_to_date(source_path, target_path):
         return False
     return os.path.getmtime(target_path) > os.path.getmtime(source_path)
 
+def count_ebnf_rules(ebnf_path):
+    """Counts the number of rules in an EBNF file."""
+    if not os.path.exists(ebnf_path):
+        return 0
+    count = 0
+    with open(ebnf_path, "r") as f:
+        for line in f:
+            if "::=" in line:
+                count += 1
+    return count
+
 def post_process_xhtml(filepath, metadata=None):
     """Injects custom CSS and JS into the generated XHTML to match Oracle style and add filtering."""
     print(f"Post-processing {filepath} for Oracle styling and filtering...")
@@ -518,7 +529,8 @@ def generate_docs(grammars=None, output_dir="docs", ebnf_dir="build/ebnf", metad
 
         if not force and is_up_to_date(grammar_path, xhtml_path):
             print(f"Skipping {grammar_name} (already up-to-date).")
-            generated_files.append((grammar_name, xhtml_name))
+            rule_count = count_ebnf_rules(ebnf_path)
+            generated_files.append((grammar_name, xhtml_name, rule_count))
             continue
 
         print(f"Generating EBNF and Metadata for {grammar_name}...")
@@ -526,7 +538,8 @@ def generate_docs(grammars=None, output_dir="docs", ebnf_dir="build/ebnf", metad
             # We assume scripts/antlr4_to_ebnf.py exists and is in the current working directory or relative to it.
             subprocess.run(["python3", "scripts/antlr4_to_ebnf.py", grammar_path, "--check", "--metadata", metadata_path], stdout=f, check=True)
 
-        print(f"Generating Railroad Diagram for {grammar_name}...")
+        rule_count = count_ebnf_rules(ebnf_path)
+        print(f"Generating Railroad Diagram for {grammar_name} ({rule_count} rules)...")
         rr.generate(ebnf_path, out_path=xhtml_path, color=color, width=width,
                     suppress_ebnf=suppress_ebnf, offset=offset)
 
@@ -538,7 +551,7 @@ def generate_docs(grammars=None, output_dir="docs", ebnf_dir="build/ebnf", metad
 
         post_process_xhtml(xhtml_path, metadata=metadata)
         validate_output(xhtml_path)
-        generated_files.append((grammar_name, xhtml_name))
+        generated_files.append((grammar_name, xhtml_name, rule_count))
 
     generate_index(output_dir, generated_files)
 
@@ -547,7 +560,7 @@ def generate_index(output_dir, files):
     index_path = os.path.join(output_dir, "index.html")
     print(f"Generating Index at {index_path}...")
 
-    links = "".join([f'<li><a href="{path}">{name}</a></li>' for name, path in files])
+    links = "".join([f'<li><a href="{path}">{name}</a> <span class="rule-count">({count} rules)</span></li>' for name, path, count in files])
     now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     html_content = f"""<!DOCTYPE html>
@@ -562,6 +575,7 @@ def generate_index(output_dir, files):
         li {{ margin: 10px 0; }}
         a {{ text-decoration: none; color: #4D88FF; font-weight: bold; font-size: 1.2em; }}
         a:hover {{ text-decoration: underline; }}
+        .rule-count {{ color: #666; font-size: 0.9em; margin-left: 10px; font-style: italic; }}
     </style>
 </head>
 <body>


### PR DESCRIPTION
This change implements a new modest step from the `RAILROAD_ROADMAP.md`. It enhances the railroad diagram index page by displaying the total number of rules for each grammar (e.g., "WebFocusReport.g4 (253 rules)"). 

Key changes:
1. **scripts/generate_railroad.py**: Added logic to count `::=` assignments in generated EBNF files. This count is now passed to the index generator.
2. **scripts/generate_railroad.py (generate_index)**: Updated the HTML template to include a styled `.rule-count` span next to each grammar link.
3. **RAILROAD_ROADMAP.md**: Added Phase 11 for "Index Page Enhancements" and marked the rule count task as complete.
4. **ROADMAP.md**: Marked task 0.14 as complete.

Verification:
- Ran `python3 scripts/generate_railroad.py --force` to regenerate documentation.
- Used Playwright (`xvfb-run python3 verify_index_counts.py`) to confirm the rule counts appear correctly on the index page.
- Ran the full test suite (`python3 -m unittest discover test`) and all 340 tests passed.

Fixes #407

---
*PR created automatically by Jules for task [6389748391488661595](https://jules.google.com/task/6389748391488661595) started by @chatelao*