### PR TITLE
High-level concept and skeleton for Java port

### DIFF
--- a/JAVA_PORT_DESIGN.md
+++ b/JAVA_PORT_DESIGN.md
@@ -1,0 +1,84 @@
+# Java Port Design: WebFOCUS to PostgreSQL Transpiler
+
+## 1. Introduction
+This document outlines the high-level concept for porting the WebFOCUS to PostgreSQL Transpiler from Python to Java. The goal is to provide a robust, enterprise-ready JVM-based tool that maintains 100% functional parity with the existing Python implementation while leveraging the Java ecosystem for performance and integration.
+
+## 2. Business Requirements & Use Cases
+The business objectives remain unchanged from the original `CONCEPT.md`:
+
+- **Business Case 1:** Migrating legacy reporting systems to open-source relational databases (PostgreSQL).
+- **Business Case 2:** Standardizing WebFOCUS development through formal specification.
+- **Use Case 1:** Automated transpilation of WebFOCUS requests to PostgreSQL Stored Procedures.
+- **Use Case 2:** Analysis and optimization of legacy procedural logic for set-based execution.
+
+## 3. Tech Stack Mapping
+
+| Component | Python Implementation (Current) | Java Port (Target) |
+| --- | --- | --- |
+| **Language** | Python 3.10+ | Java 21 (LTS) |
+| **Parser Generator** | ANTLR4 (Python3 Runtime) | ANTLR4 (Java Runtime) |
+| **Template Engine** | Jinja2 | Apache FreeMarker |
+| **CLI Framework** | argparse | Picocli |
+| **Build System** | pip / requirements.txt | Apache Maven 3.9+ |
+| **Testing** | unittest / pytest | JUnit 5 + AssertJ |
+| **Logging** | logging module | SLF4J + Logback |
+| **JSON/Serialization** | json module | Jackson |
+
+## 4. Architecture
+
+The Java port will follow the same multi-pass compiler architecture:
+
+### 4.1 Frontend (ANTLR4 Java)
+- Re-use the existing `.g4` grammars (`WebFocusReport.g4`, `MasterFile.g4`).
+- Generate Java Lexer, Parser, and Visitors using the ANTLR4 Maven plugin.
+- Implement `WebFocusReportVisitor` to construct the Java-based ASG.
+
+### 4.2 Semantic Analysis (ASG & Symbol Table)
+- **ASG Nodes:** Implement as Java `record` types or immutable classes where appropriate to represent the Abstract Semantic Graph.
+- **Symbol Table:** Use a hierarchical `Map`-based structure to track Dialogue Manager variables and database fields.
+- **Type System:** Port the `TypeInferrer` and `TypeMapper` logic to Java's type system.
+
+### 4.3 Optimization (SSA-based IR)
+- **Control Flow Graph (CFG):** Implement using a graph library (e.g., JGraphT) or a custom adjacency-list structure.
+- **SSA Transformation:** Port the SSA transformer logic, including Phi-node insertion and variable renaming.
+- **Optimizers:** Implement `ConstantPropagator`, `DeadCodeElimination`, and `RelationalLiftingOptimizer` as separate passes over the CFG.
+
+### 4.4 Backend (FreeMarker Emitter)
+- Use **Apache FreeMarker** to manage SQL templates.
+- Port existing Jinja2 templates (`.sql`) to FreeMarker syntax (mostly syntax mapping like `{{ var }}` to `${var}`).
+- Implement a `PostgresEmitter` class that traverses the optimized IR and populates FreeMarker models.
+
+## 5. CLI Tool Design
+The CLI will be implemented using **Picocli** to provide a professional command-line interface.
+
+### Commands & Options
+- `transpile`: Main command to convert `.fex` files.
+    - `-i, --input`: Input file or directory.
+    - `-o, --output`: Output directory.
+    - `-m, --master-path`: Search paths for Master Files.
+    - `--stats`: Display source code diagnostics and complexity.
+- `check`: Validate WebFOCUS syntax without full transpilation.
+- `lineage`: Output data lineage in JSON format.
+
+### Example Usage
+```bash
+java -jar wf2pg-transpiler.jar transpile -i ./reports -o ./dist -m ./metadata --stats
+```
+
+## 6. Build & Dependency Management (Maven)
+A `pom.xml` will manage dependencies:
+- `antlr4-runtime`
+- `freemarker`
+- `picocli`
+- `jackson-databind`
+- `junit-jupiter`
+- `slf4j-api`
+
+## 7. Migration Strategy
+1. **Infrastructure:** Set up Maven project and ANTLR4 plugin.
+2. **ASG/IR Models:** Port the core data structures (`asg.py`, `ir.py`).
+3. **Frontend:** Port `asg_builder.py` to Java Visitor implementation.
+4. **Logic:** Port Symbol Table and Type Inference.
+5. **Optimization:** Port SSA transformer and Relational Lifting logic.
+6. **Backend:** Port Emitter and Templates.
+7. **Verification:** Use the existing Python test suite to generate "Golden Files" and verify Java output parity.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.transpiler</groupId>
+    <artifactId>wf2pg-transpiler</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <antlr4.version>4.13.2</antlr4.version>
+        <picocli.version>4.7.6</picocli.version>
+        <freemarker.version>2.3.32</freemarker.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>${antlr4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>${picocli.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+            <version>${freemarker.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jgrapht</groupId>
+            <artifactId>jgrapht-core</artifactId>
+            <version>1.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.4.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-maven-plugin</artifactId>
+                <version>${antlr4.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>antlr4</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/transpiler/Main.java
+++ b/src/main/java/com/transpiler/Main.java
@@ -1,0 +1,71 @@
+package com.transpiler;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+@Command(name = "wf2pg", mixinStandardHelpOptions = true, version = "1.0",
+        description = "WebFOCUS to PostgreSQL Transpiler CLI",
+        subcommands = {Main.TranspileCommand.class, Main.CheckCommand.class, Main.LineageCommand.class})
+public class Main implements Runnable {
+
+    @Override
+    public void run() {
+        CommandLine.usage(this, System.out);
+    }
+
+    @Command(name = "transpile", description = "Main command to convert .fex files")
+    static class TranspileCommand implements Callable<Integer> {
+        @Option(names = {"-i", "--input"}, required = true, description = "Input .fex file or directory")
+        private File input;
+
+        @Option(names = {"-o", "--output"}, description = "Output directory")
+        private File output;
+
+        @Option(names = {"-m", "--master-path"}, description = "Search paths for Master Files")
+        private List<File> masterPaths;
+
+        @Option(names = {"--stats"}, description = "Display source code statistics")
+        private boolean showStats;
+
+        @Override
+        public Integer call() {
+            System.out.println("Transpiling: " + input.getAbsolutePath());
+            return 0;
+        }
+    }
+
+    @Command(name = "check", description = "Validate WebFOCUS syntax without full transpilation")
+    static class CheckCommand implements Callable<Integer> {
+        @Option(names = {"-i", "--input"}, required = true, description = "Input .fex file")
+        private File input;
+
+        @Override
+        public Integer call() {
+            System.out.println("Checking syntax: " + input.getAbsolutePath());
+            return 0;
+        }
+    }
+
+    @Command(name = "lineage", description = "Output data lineage in JSON format")
+    static class LineageCommand implements Callable<Integer> {
+        @Option(names = {"-i", "--input"}, required = true, description = "Input .fex file")
+        private File input;
+
+        @Override
+        public Integer call() {
+            System.out.println("Analyzing lineage: " + input.getAbsolutePath());
+            return 0;
+        }
+    }
+
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new Main()).execute(args);
+        System.exit(exitCode);
+    }
+}


### PR DESCRIPTION
This PR introduces the high-level design and initial project structure for porting the WebFOCUS to PostgreSQL transpiler from Python to Java.

Key changes:
- `JAVA_PORT_DESIGN.md`: Detailed plan for porting the compiler pipeline, mapping Python components to Java/JVM equivalents (ANTLR4 Java, FreeMarker, JGraphT, Jackson).
- `pom.xml`: Maven configuration including dependencies for the target tech stack.
- `src/main/java/com/transpiler/Main.java`: Skeleton CLI implementation using Picocli to define the user interface.

These changes provide the foundational infrastructure and roadmap for the Java implementation while maintaining parity with the existing tool's business requirements and use cases.

Fixes #409

---
*PR created automatically by Jules for task [15374308190972916894](https://jules.google.com/task/15374308190972916894) started by @chatelao*