### PR TITLE
Create JAVA_PORT_ROADMAP.md

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -1,0 +1,36 @@
+# Java Port Roadmap: WebFOCUS to PostgreSQL Transpiler
+
+This document outlines the strategic porting of the WebFOCUS to PostgreSQL Transpiler from Python to Java, as defined in `JAVA_PORT_DESIGN.md`.
+
+## Phase 1: Infrastructure & Project Setup
+- [x] 1.1 Maven Project Initialization: Setup `pom.xml` with dependencies (ANTLR4, Picocli, FreeMarker, Jackson, JGraphT, JUnit 5).
+- [x] 1.2 ANTLR4 Configuration: Integrate `antlr4-maven-plugin` and verify grammar compilation.
+- [x] 1.3 CLI Foundation: Implement basic command-line interface using Picocli (transpile, check, lineage).
+- [ ] 1.4 Logging & Diagnostics: Setup SLF4J/Logback and initial diagnostic reporting.
+
+## Phase 2: ASG & IR Models (Data Structures)
+- [ ] 2.1 ASG Node Porting: Implement Java `record` types or immutable classes for all ASG nodes (`asg.py` parity).
+- [ ] 2.2 IR Instruction Porting: Implement IR instruction set and Control Flow Graph (CFG) structures using JGraphT.
+- [ ] 2.3 Metadata Models: Port Master File and Segment metadata models.
+
+## Phase 3: Frontend & Semantic Analysis
+- [ ] 3.1 ASG Builder: Port `asg_builder.py` to Java `WebFocusReportVisitor` implementation.
+- [ ] 3.2 Symbol Table: Port hierarchical symbol resolution and scoping logic.
+- [ ] 3.3 Type System: Port `TypeInferrer` and `TypeMapper` to Java.
+- [ ] 3.4 Master File Parser: Port `master_file_parser.py` to Java implementation.
+
+## Phase 4: Optimization (SSA & Relational Lifting)
+- [ ] 4.1 SSA Transformer: Port SSA transformation logic (dominator analysis, Phi-node insertion, variable renaming).
+- [ ] 4.2 Constant Propagation: Implement IR-level constant folding.
+- [ ] 4.3 Dead Code Elimination: Implement reachability analysis and unused assignment removal.
+- [ ] 4.4 Relational Lifting: Port advanced pattern matching for set-based SQL synthesis.
+
+## Phase 5: Backend & Emission (FreeMarker)
+- [ ] 5.1 Template Migration: Convert Jinja2 `.sql` templates to Apache FreeMarker syntax.
+- [ ] 5.2 Postgres Emitter: Implement IR-to-SQL translation logic using FreeMarker.
+- [ ] 5.3 Variable Mapping: Implement Java-based mapping between SSA versions and SQL identifiers.
+
+## Phase 6: Verification & Parity
+- [ ] 6.1 Unit Test Porting: Port core unit tests to JUnit 5.
+- [ ] 6.2 Golden File Verification: Compare Java output against Python "Golden Files" for functional parity.
+- [ ] 6.3 E2E Integration: Execute generated Java output against live PostgreSQL and verify result-set parity.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,5 @@
 # ROADMAP
-- [ ] 0.16 Create a `JAVA_PORT_ROADMAP.md` based on the `JAVA_PORT_DESIGN.md` (#411)
+- [x] 0.16 Create a `JAVA_PORT_ROADMAP.md` based on the `JAVA_PORT_DESIGN.md` (#411) (completed at 2026-05-29 18:35:38)
 - [ ] 0.15 Create a high-level concept to port the tool from Python to Java callecd `JAVA_PORT_DESIGN.md` (#409)
 - [x] 0.14 Implement a next, modest, very small, feasible and reasonable RAILROAD_ROADMAP.md step (#407) (completed at 2026-05-23 14:46:41)
 - [x] 0.13 Implement a next, modest, very small, feasible and reasonable RAILROAD_ROADMAP.md step (#405) (completed at 2026-05-23 12:58:41)


### PR DESCRIPTION
I have created a new `JAVA_PORT_ROADMAP.md` file that outlines the strategic porting of the WebFOCUS to PostgreSQL Transpiler from Python to Java. This roadmap is based on the `JAVA_PORT_DESIGN.md` and is organized into six logical phases:
1. Infrastructure & Project Setup
2. ASG & IR Models (Data Structures)
3. Frontend & Semantic Analysis
4. Optimization (SSA & Relational Lifting)
5. Backend & Emission (FreeMarker)
6. Verification & Parity

I have also updated the main `ROADMAP.md` file to mark task 0.16 as complete, including the completion timestamp. All existing tests were run and passed.

Fixes #411

---
*PR created automatically by Jules for task [17551365022306713175](https://jules.google.com/task/17551365022306713175) started by @chatelao*