### PR TITLE
Java Port: Granularize Expressions Roadmap and Implement Basic Nodes

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -11,7 +11,12 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
 ## Phase 2: ASG & IR Models (Data Structures)
 - [ ] 2.1 ASG Node Porting: Implement Java `record` types or immutable classes for ASG nodes (`asg.py` parity).
   - [x] 2.1.1 Base Nodes: ASGNode, Expression, Statement, Command.
-  - [ ] 2.1.2 Expressions: Literals, Identifiers, Binary/Unary operations, Function calls.
+  - [ ] 2.1.2 Expressions:
+    - [x] 2.1.2.1 Literals, Identifiers, AmperVars.
+    - [ ] 2.1.2.2 Binary and Unary operations.
+    - [ ] 2.1.2.3 Function calls and Built-in functions.
+    - [ ] 2.1.2.4 Conditional expressions (IF-THEN-ELSE, DECODE).
+    - [ ] 2.1.2.5 Set-based expressions (IN, BETWEEN, IS MISSING).
   - [ ] 2.1.3 Dialogue Manager Commands: Goto, Label, IfDM, Repeat, SetDM, etc.
   - [ ] 2.1.4 Report Commands: ReportRequest, VerbCommand, SortCommand, WhereClause, etc.
   - [ ] 2.1.5 Data Model Nodes: MasterFile, Segment, Field.

--- a/src/main/java/com/transpiler/asg/AmperVar.java
+++ b/src/main/java/com/transpiler/asg/AmperVar.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a Dialogue Manager variable (e.g., &VAR).
+ */
+public record AmperVar(String name) implements Expression {
+}

--- a/src/main/java/com/transpiler/asg/Identifier.java
+++ b/src/main/java/com/transpiler/asg/Identifier.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a field or variable name.
+ */
+public record Identifier(String name) implements Expression {
+}

--- a/src/main/java/com/transpiler/asg/Literal.java
+++ b/src/main/java/com/transpiler/asg/Literal.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a literal value (number, string, etc.).
+ */
+public record Literal(Object value) implements Expression {
+}

--- a/src/test/java/com/transpiler/asg/ExpressionTest.java
+++ b/src/test/java/com/transpiler/asg/ExpressionTest.java
@@ -1,0 +1,43 @@
+package com.transpiler.asg;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExpressionTest {
+
+    @Test
+    void testLiteral() {
+        Literal stringLiteral = new Literal("hello");
+        assertEquals("hello", stringLiteral.value());
+
+        Literal numberLiteral = new Literal(42);
+        assertEquals(42, numberLiteral.value());
+    }
+
+    @Test
+    void testIdentifier() {
+        Identifier id = new Identifier("MYFIELD");
+        assertEquals("MYFIELD", id.name());
+    }
+
+    @Test
+    void testAmperVar() {
+        AmperVar var = new AmperVar("MYVAR");
+        assertEquals("MYVAR", var.name());
+    }
+
+    @Test
+    void testExpressionInterfaces() {
+        Literal lit = new Literal(1);
+        Identifier id = new Identifier("A");
+        AmperVar var = new AmperVar("V");
+
+        assertTrue(lit instanceof Expression);
+        assertTrue(id instanceof Expression);
+        assertTrue(var instanceof Expression);
+
+        assertTrue(lit instanceof ASGNode);
+        assertTrue(id instanceof ASGNode);
+        assertTrue(var instanceof ASGNode);
+    }
+}


### PR DESCRIPTION
This change moves the Java port forward by breaking down the broad "Expressions" task into manageable sub-tasks and implementing the first set of basic expression nodes (Literal, Identifier, and AmperVar). 

Key changes:
1. **JAVA_PORT_ROADMAP.md**: Granularized Phase 2.1.2 into 2.1.2.1 through 2.1.2.5 to better track progress on different expression types.
2. **src/main/java/com/transpiler/asg/**: Added `Literal.java`, `Identifier.java`, and `AmperVar.java` as immutable Java records implementing the `Expression` interface.
3. **src/test/java/com/transpiler/asg/ExpressionTest.java**: Added unit tests to ensure correct instantiation and interface implementation for the new nodes.
4. **Verification**: Successfully ran `mvn test` to confirm all changes are correct.

Fixes #417

---
*PR created automatically by Jules for task [10956618390327720003](https://jules.google.com/task/10956618390327720003) started by @chatelao*