### PR TITLE
Implement Binary/Unary Operations and Function Calls in Java ASG

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -13,8 +13,8 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
   - [x] 2.1.1 Base Nodes: ASGNode, Expression, Statement, Command.
   - [ ] 2.1.2 Expressions:
     - [x] 2.1.2.1 Literals, Identifiers, AmperVars.
-    - [ ] 2.1.2.2 Binary and Unary operations.
-    - [ ] 2.1.2.3 Function calls and Built-in functions.
+    - [x] 2.1.2.2 Binary and Unary operations.
+    - [x] 2.1.2.3 Function calls and Built-in functions.
     - [ ] 2.1.2.4 Conditional expressions (IF-THEN-ELSE, DECODE).
     - [ ] 2.1.2.5 Set-based expressions (IN, BETWEEN, IS MISSING).
   - [ ] 2.1.3 Dialogue Manager Commands: Goto, Label, IfDM, Repeat, SetDM, etc.

--- a/src/main/java/com/transpiler/asg/BinaryOperation.java
+++ b/src/main/java/com/transpiler/asg/BinaryOperation.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a binary operation (e.g., a + b, a AND b).
+ */
+public record BinaryOperation(Expression left, String operator, Expression right) implements Expression {
+}

--- a/src/main/java/com/transpiler/asg/FunctionCall.java
+++ b/src/main/java/com/transpiler/asg/FunctionCall.java
@@ -1,0 +1,9 @@
+package com.transpiler.asg;
+
+import java.util.List;
+
+/**
+ * Represents a function call (e.g., ABS(field)).
+ */
+public record FunctionCall(String functionName, List<Expression> arguments) implements Expression {
+}

--- a/src/main/java/com/transpiler/asg/UnaryOperation.java
+++ b/src/main/java/com/transpiler/asg/UnaryOperation.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a unary operation (e.g., -a, NOT a).
+ */
+public record UnaryOperation(String operator, Expression operand) implements Expression {
+}

--- a/src/test/java/com/transpiler/asg/ExpressionTest.java
+++ b/src/test/java/com/transpiler/asg/ExpressionTest.java
@@ -1,6 +1,9 @@
 package com.transpiler.asg;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class ExpressionTest {
@@ -39,5 +42,40 @@ class ExpressionTest {
         assertTrue(lit instanceof ASGNode);
         assertTrue(id instanceof ASGNode);
         assertTrue(var instanceof ASGNode);
+    }
+
+    @Test
+    void testBinaryOperation() {
+        Expression left = new Literal(1);
+        Expression right = new Literal(2);
+        BinaryOperation op = new BinaryOperation(left, "+", right);
+
+        assertEquals(left, op.left());
+        assertEquals("+", op.operator());
+        assertEquals(right, op.right());
+        assertTrue(op instanceof Expression);
+    }
+
+    @Test
+    void testUnaryOperation() {
+        Expression operand = new Identifier("MYFIELD");
+        UnaryOperation op = new UnaryOperation("-", operand);
+
+        assertEquals("-", op.operator());
+        assertEquals(operand, op.operand());
+        assertTrue(op instanceof Expression);
+    }
+
+    @Test
+    void testFunctionCall() {
+        Expression arg1 = new Identifier("FIELD1");
+        Expression arg2 = new Literal(10);
+        List<Expression> args = List.of(arg1, arg2);
+        FunctionCall call = new FunctionCall("ABS", args);
+
+        assertEquals("ABS", call.functionName());
+        assertEquals(args, call.arguments());
+        assertEquals(2, call.arguments().size());
+        assertTrue(call instanceof Expression);
     }
 }


### PR DESCRIPTION
Implemented Java records for `BinaryOperation`, `UnaryOperation`, and `FunctionCall` in the `com.transpiler.asg` package. These nodes are essential for representing expressions in the Abstract Semantic Graph (ASG) during the Java port of the WebFOCUS transpiler.

Key changes:
- Created `BinaryOperation.java`, `UnaryOperation.java`, and `FunctionCall.java`.
- Expanded `ExpressionTest.java` with unit tests for these new nodes.
- Updated `JAVA_PORT_ROADMAP.md` to reflect progress on expression nodes.
- Verified all tests pass using `mvn test`.

Fixes #419

---
*PR created automatically by Jules for task [15886349279213544479](https://jules.google.com/task/15886349279213544479) started by @chatelao*