### PR TITLE
feat: Port DecodeExpression ASG node to Java

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -17,7 +17,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
     - [x] 2.1.2.3 Function calls and Built-in functions.
     - [ ] 2.1.2.4 Conditional expressions:
       - [x] 2.1.2.4.1 IfExpression (IF-THEN-ELSE).
-      - [ ] 2.1.2.4.2 DecodeExpression (DECODE).
+      - [x] 2.1.2.4.2 DecodeExpression (DECODE).
     - [ ] 2.1.2.5 Set-based expressions (IN, BETWEEN, IS MISSING).
   - [ ] 2.1.3 Dialogue Manager Commands: Goto, Label, IfDM, Repeat, SetDM, etc.
   - [ ] 2.1.4 Report Commands: ReportRequest, VerbCommand, SortCommand, WhereClause, etc.

--- a/src/main/java/com/transpiler/asg/DecodeExpression.java
+++ b/src/main/java/com/transpiler/asg/DecodeExpression.java
@@ -1,0 +1,13 @@
+package com.transpiler.asg;
+
+import java.util.List;
+
+/**
+ * Represents a DECODE expression.
+ */
+public record DecodeExpression(Expression expression, List<Pair> pairs, Expression defaultValue) implements Expression {
+    /**
+     * Represents a search-result pair in a DECODE expression.
+     */
+    public record Pair(Expression search, Expression result) {}
+}

--- a/src/test/java/com/transpiler/asg/ExpressionTest.java
+++ b/src/test/java/com/transpiler/asg/ExpressionTest.java
@@ -91,4 +91,21 @@ class ExpressionTest {
         assertEquals(elseExpr, ifExpr.elseExpression());
         assertTrue(ifExpr instanceof Expression);
     }
+
+    @Test
+    void testDecodeExpression() {
+        Expression target = new Identifier("COUNTRY");
+        List<DecodeExpression.Pair> pairs = List.of(
+            new DecodeExpression.Pair(new Literal("ENGLAND"), new Literal("UK")),
+            new DecodeExpression.Pair(new Literal("FRANCE"), new Literal("EU"))
+        );
+        Expression defaultValue = new Literal("OTHER");
+        DecodeExpression decode = new DecodeExpression(target, pairs, defaultValue);
+
+        assertEquals(target, decode.expression());
+        assertEquals(pairs, decode.pairs());
+        assertEquals(2, decode.pairs().size());
+        assertEquals(defaultValue, decode.defaultValue());
+        assertTrue(decode instanceof Expression);
+    }
 }


### PR DESCRIPTION
This PR implements the `DecodeExpression` ASG node in Java as part of the Phase 2.1.2.4 porting efforts. 

Key changes:
1. Created `src/main/java/com/transpiler/asg/DecodeExpression.java` as a Java `record`.
2. Added a `Pair` nested record within `DecodeExpression` to represent the search/result mapping.
3. Added `testDecodeExpression` to `src/test/java/com/transpiler/asg/ExpressionTest.java` to verify correct instantiation and parity with the Python implementation.
4. Updated `JAVA_PORT_ROADMAP.md` to reflect the completion of task 2.1.2.4.2.

All tests passed successfully via `mvn test`.

Fixes #423

---
*PR created automatically by Jules for task [17135557760700541110](https://jules.google.com/task/17135557760700541110) started by @chatelao*