### PR TITLE
Implement Control Flow Dialogue Manager ASG nodes in Java

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -19,7 +19,13 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
       - [x] 2.1.2.4.1 IfExpression (IF-THEN-ELSE).
       - [x] 2.1.2.4.2 DecodeExpression (DECODE).
     - [x] 2.1.2.5 Set-based expressions (IN, BETWEEN, IS MISSING).
-  - [ ] 2.1.3 Dialogue Manager Commands: Goto, Label, IfDM, Repeat, SetDM, etc.
+  - [ ] 2.1.3 Dialogue Manager Commands:
+    - [x] 2.1.3.1 Control Flow: Goto, Label, IfDM.
+    - [ ] 2.1.3.2 Variables & Defaults: SetDM, DefaultDM.
+    - [ ] 2.1.3.3 Output: TypeDM, HtmlFormDM.
+    - [ ] 2.1.3.4 Loops: Repeat.
+    - [ ] 2.1.3.5 I/O: ReadDM, WriteDM, IncludeDM.
+    - [ ] 2.1.3.6 Execution Control: RunDM, ExitDM.
   - [ ] 2.1.4 Report Commands: ReportRequest, VerbCommand, SortCommand, WhereClause, etc.
   - [ ] 2.1.5 Data Model Nodes: MasterFile, Segment, Field.
 - [ ] 2.2 IR Instruction Porting: Implement IR instruction set and Control Flow Graph (CFG) structures using JGraphT.

--- a/src/main/java/com/transpiler/asg/Goto.java
+++ b/src/main/java/com/transpiler/asg/Goto.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a Dialogue Manager -GOTO command.
+ */
+public record Goto(String target) implements Command {
+}

--- a/src/main/java/com/transpiler/asg/IfDM.java
+++ b/src/main/java/com/transpiler/asg/IfDM.java
@@ -1,0 +1,10 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a Dialogue Manager -IF command.
+ */
+public record IfDM(Expression condition, String thenTarget, String elseTarget) implements Command {
+    public IfDM(Expression condition, String thenTarget) {
+        this(condition, thenTarget, null);
+    }
+}

--- a/src/main/java/com/transpiler/asg/Label.java
+++ b/src/main/java/com/transpiler/asg/Label.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a Dialogue Manager label.
+ */
+public record Label(String name) implements Command {
+}

--- a/src/test/java/com/transpiler/asg/CommandTest.java
+++ b/src/test/java/com/transpiler/asg/CommandTest.java
@@ -1,0 +1,37 @@
+package com.transpiler.asg;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommandTest {
+
+    @Test
+    void testGoto() {
+        Goto gotoNode = new Goto("MYLABEL");
+        assertEquals("MYLABEL", gotoNode.target());
+        assertTrue(gotoNode instanceof Command);
+        assertTrue(gotoNode instanceof ASGNode);
+    }
+
+    @Test
+    void testLabel() {
+        Label labelNode = new Label("MYLABEL");
+        assertEquals("MYLABEL", labelNode.name());
+        assertTrue(labelNode instanceof Command);
+        assertTrue(labelNode instanceof ASGNode);
+    }
+
+    @Test
+    void testIfDM() {
+        Expression condition = new BinaryOperation(new AmperVar("A"), "EQ", new Literal(10));
+        IfDM ifDM = new IfDM(condition, "THEN_LABEL", "ELSE_LABEL");
+
+        assertEquals(condition, ifDM.condition());
+        assertEquals("THEN_LABEL", ifDM.thenTarget());
+        assertEquals("ELSE_LABEL", ifDM.elseTarget());
+        assertTrue(ifDM instanceof Command);
+
+        IfDM ifDMNoElse = new IfDM(condition, "THEN_LABEL");
+        assertNull(ifDMNoElse.elseTarget());
+    }
+}


### PR DESCRIPTION
This change progresses the Java port of the WebFOCUS transpiler by implementing the Abstract Semantic Graph (ASG) nodes for Dialogue Manager control flow commands: `-GOTO`, labels, and `-IF`. 

Specifically, it:
1. Breaks down the monolithic Phase 2.1.3 in `JAVA_PORT_ROADMAP.md` into logical sub-tasks for better tracking.
2. Introduces `Goto`, `Label`, and `IfDM` as immutable Java records in `com.transpiler.asg`.
3. Adds a new test suite `CommandTest` to verify the new nodes and their integration with the `Command` and `ASGNode` interfaces.
4. Marks the first sub-task of Phase 2.1.3 as complete in the roadmap.

Fixes #430

---
*PR created automatically by Jules for task [12890169908846697519](https://jules.google.com/task/12890169908846697519) started by @chatelao*