### PR TITLE
Implement SetDM and DefaultDM Java ASG nodes

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -21,7 +21,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
     - [x] 2.1.2.5 Set-based expressions (IN, BETWEEN, IS MISSING).
   - [ ] 2.1.3 Dialogue Manager Commands:
     - [x] 2.1.3.1 Control Flow: Goto, Label, IfDM.
-    - [ ] 2.1.3.2 Variables & Defaults: SetDM, DefaultDM.
+    - [x] 2.1.3.2 Variables & Defaults: SetDM, DefaultDM.
     - [ ] 2.1.3.3 Output: TypeDM, HtmlFormDM.
     - [ ] 2.1.3.4 Loops: Repeat.
     - [ ] 2.1.3.5 I/O: ReadDM, WriteDM, IncludeDM.

--- a/src/main/java/com/transpiler/asg/DefaultDM.java
+++ b/src/main/java/com/transpiler/asg/DefaultDM.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a Dialogue Manager -DEFAULT, -DEFAULTS, or -DEFAULTH command.
+ */
+public record DefaultDM(String variable, Expression expression) implements Command {
+}

--- a/src/main/java/com/transpiler/asg/SetDM.java
+++ b/src/main/java/com/transpiler/asg/SetDM.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a Dialogue Manager -SET command.
+ */
+public record SetDM(String variable, Expression expression) implements Command {
+}

--- a/src/test/java/com/transpiler/asg/CommandTest.java
+++ b/src/test/java/com/transpiler/asg/CommandTest.java
@@ -34,4 +34,24 @@ class CommandTest {
         IfDM ifDMNoElse = new IfDM(condition, "THEN_LABEL");
         assertNull(ifDMNoElse.elseTarget());
     }
+
+    @Test
+    void testSetDM() {
+        Expression expr = new Literal(100);
+        SetDM setDM = new SetDM("&MYVAR", expr);
+
+        assertEquals("&MYVAR", setDM.variable());
+        assertEquals(expr, setDM.expression());
+        assertTrue(setDM instanceof Command);
+    }
+
+    @Test
+    void testDefaultDM() {
+        Expression expr = new Literal("DEFAULT_VAL");
+        DefaultDM defaultDM = new DefaultDM("&MYVAR", expr);
+
+        assertEquals("&MYVAR", defaultDM.variable());
+        assertEquals(expr, defaultDM.expression());
+        assertTrue(defaultDM instanceof Command);
+    }
 }


### PR DESCRIPTION
Implemented the Dialogue Manager variable assignment nodes (`-SET` and `-DEFAULT`) as Java records in the `com.transpiler.asg` package. This completes Phase 2.1.3.2 of the Java Port Roadmap.

Changes:
- New file: `src/main/java/com/transpiler/asg/SetDM.java`
- New file: `src/main/java/com/transpiler/asg/DefaultDM.java`
- Modified: `src/test/java/com/transpiler/asg/CommandTest.java` (added tests)
- Modified: `JAVA_PORT_ROADMAP.md` (updated status)

All tests passed successfully.

Fixes #433

---
*PR created automatically by Jules for task [9178705976437025575](https://jules.google.com/task/9178705976437025575) started by @chatelao*