### PR TITLE
Implement I/O and Match/More ASG Nodes in Java

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -22,13 +22,22 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
   - [ ] 2.1.3 Dialogue Manager Commands:
     - [x] 2.1.3.1 Control Flow: Goto, Label, IfDM.
     - [x] 2.1.3.2 Variables & Defaults: SetDM, DefaultDM.
-    - [x] 2.1.3.3 Output: TypeDM, HtmlFormDM (Partial).
+    - [x] 2.1.3.3 Output: TypeDM, HtmlFormDM.
     - [x] 2.1.3.4 Loops: Repeat.
     - [x] 2.1.3.5 I/O: ReadDM, WriteDM, IncludeDM.
     - [x] 2.1.3.6 Execution Control: RunDM, ExitDM.
-  - [x] 2.1.4 Report Commands: ReportRequest, VerbCommand, SortCommand, WhereClause, etc.
+  - [ ] 2.1.4 Report Commands:
+    - [x] 2.1.4.1 Basic: ReportRequest, VerbCommand, SortCommand, WhereClause, etc.
+    - [x] 2.1.4.2 Output: OutputCommand (HOLD, PCHOLD, etc.).
+    - [x] 2.1.4.3 Multi-file: MatchRequest, SubMatch, AfterMatchPhrase, MoreClause, MoreSubRequest.
   - [x] 2.1.5 Data Model Nodes: MasterFile, Segment, Field.
 - [ ] 2.2 IR Instruction Porting: Implement IR instruction set and Control Flow Graph (CFG) structures using JGraphT.
+  - [ ] 2.2.1 Base IR Infrastructure (IRNode, Instruction, BasicBlock, ControlFlowGraph).
+  - [ ] 2.2.2 Control Flow Instructions (Label, Jump, Branch, Phi).
+  - [ ] 2.2.3 Data & Assignment Instructions (Assign, SetEnv, Default).
+  - [ ] 2.2.4 Procedure & I/O Instructions (Call, Type, HtmlForm, Read, Write).
+  - [ ] 2.2.5 Relational Instructions (Join, JoinClear, Define, Report, Match).
+  - [ ] 2.2.6 Layout Instructions (CompoundLayout, CompoundEnd).
 - [ ] 2.3 Metadata Models: Port Master File and Segment metadata models.
 
 ## Phase 3: Frontend & Semantic Analysis

--- a/src/main/java/com/transpiler/asg/AfterMatchPhrase.java
+++ b/src/main/java/com/transpiler/asg/AfterMatchPhrase.java
@@ -1,0 +1,10 @@
+package com.transpiler.asg;
+
+/**
+ * Represents an AFTER MATCH phrase.
+ */
+public record AfterMatchPhrase(
+    String mergeType,
+    OutputCommand outputCommand
+) implements ASGNode {
+}

--- a/src/main/java/com/transpiler/asg/HtmlFormDM.java
+++ b/src/main/java/com/transpiler/asg/HtmlFormDM.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a Dialogue Manager -HTMLFORM command or block.
+ */
+public record HtmlFormDM(String filename, String content) implements Command {
+}

--- a/src/main/java/com/transpiler/asg/MatchRequest.java
+++ b/src/main/java/com/transpiler/asg/MatchRequest.java
@@ -1,0 +1,18 @@
+package com.transpiler.asg;
+
+import java.util.List;
+
+/**
+ * Represents a MATCH FILE request.
+ */
+public record MatchRequest(
+    String filename,
+    List<ASGNode> components,
+    MoreClause moreClause,
+    List<SubMatch> subMatches
+) implements Statement {
+    public MatchRequest {
+        components = List.copyOf(components);
+        subMatches = List.copyOf(subMatches);
+    }
+}

--- a/src/main/java/com/transpiler/asg/MoreClause.java
+++ b/src/main/java/com/transpiler/asg/MoreClause.java
@@ -1,0 +1,12 @@
+package com.transpiler.asg;
+
+import java.util.List;
+
+/**
+ * Represents a MORE phrase.
+ */
+public record MoreClause(List<MoreSubRequest> subRequests) implements ASGNode {
+    public MoreClause {
+        subRequests = List.copyOf(subRequests);
+    }
+}

--- a/src/main/java/com/transpiler/asg/MoreSubRequest.java
+++ b/src/main/java/com/transpiler/asg/MoreSubRequest.java
@@ -1,0 +1,15 @@
+package com.transpiler.asg;
+
+import java.util.List;
+
+/**
+ * Represents a FILE entry within a MORE phrase.
+ */
+public record MoreSubRequest(
+    String filename,
+    List<WhereClause> whereClauses
+) implements ASGNode {
+    public MoreSubRequest {
+        whereClauses = List.copyOf(whereClauses);
+    }
+}

--- a/src/main/java/com/transpiler/asg/OutputCommand.java
+++ b/src/main/java/com/transpiler/asg/OutputCommand.java
@@ -1,0 +1,12 @@
+package com.transpiler.asg;
+
+/**
+ * Represents an output command (HOLD, PCHOLD, SAVE, SAVB).
+ */
+public record OutputCommand(
+    String outputType,
+    String filename,
+    String format,
+    String openClose
+) implements Command {
+}

--- a/src/main/java/com/transpiler/asg/ReadDM.java
+++ b/src/main/java/com/transpiler/asg/ReadDM.java
@@ -1,0 +1,12 @@
+package com.transpiler.asg;
+
+import java.util.List;
+
+/**
+ * Represents a Dialogue Manager -READ command.
+ */
+public record ReadDM(String filename, List<String> variables) implements Command {
+    public ReadDM {
+        variables = List.copyOf(variables);
+    }
+}

--- a/src/main/java/com/transpiler/asg/SubMatch.java
+++ b/src/main/java/com/transpiler/asg/SubMatch.java
@@ -1,0 +1,17 @@
+package com.transpiler.asg;
+
+import java.util.List;
+
+/**
+ * Represents a FILE entry within a MATCH request.
+ */
+public record SubMatch(
+    String filename,
+    List<ASGNode> components,
+    MoreClause moreClause,
+    AfterMatchPhrase afterMatch
+) implements ASGNode {
+    public SubMatch {
+        components = List.copyOf(components);
+    }
+}

--- a/src/main/java/com/transpiler/asg/WriteDM.java
+++ b/src/main/java/com/transpiler/asg/WriteDM.java
@@ -1,0 +1,12 @@
+package com.transpiler.asg;
+
+import java.util.List;
+
+/**
+ * Represents a Dialogue Manager -WRITE command.
+ */
+public record WriteDM(String filename, List<String> messages) implements Command {
+    public WriteDM {
+        messages = List.copyOf(messages);
+    }
+}

--- a/src/test/java/com/transpiler/asg/ASGParityTest.java
+++ b/src/test/java/com/transpiler/asg/ASGParityTest.java
@@ -16,6 +16,27 @@ class ASGParityTest {
     }
 
     @Test
+    void testOutputAndMatchNodes() {
+        OutputCommand hold = new OutputCommand("HOLD", "MYHOLD", "FOCUS", null);
+        assertEquals("HOLD", hold.outputType());
+        assertEquals("MYHOLD", hold.filename());
+
+        MoreSubRequest moreSub = new MoreSubRequest("FILE2", List.of(new WhereClause("COUNTRY EQ 'USA'", false)));
+        MoreClause more = new MoreClause(List.of(moreSub));
+        assertEquals(1, more.subRequests().size());
+        assertEquals("FILE2", more.subRequests().get(0).filename());
+
+        AfterMatchPhrase after = new AfterMatchPhrase("OLD-OR-NEW", hold);
+        SubMatch subMatch = new SubMatch("FILE1", List.of(new FieldSelection("ID")), null, after);
+
+        MatchRequest match = new MatchRequest("MAINFILE", List.of(new FieldSelection("ID")), more, List.of(subMatch));
+        assertEquals("MAINFILE", match.filename());
+        assertEquals(more, match.moreClause());
+        assertEquals(1, match.subMatches().size());
+        assertEquals(after, match.subMatches().get(0).afterMatch());
+    }
+
+    @Test
     void testStatementInstantiation() {
         // In Java, Statement is an interface, so we test one of its implementations
         Statement stmt = new ReportRequest("EMPLOYEE");

--- a/src/test/java/com/transpiler/asg/CommandTest.java
+++ b/src/test/java/com/transpiler/asg/CommandTest.java
@@ -54,4 +54,42 @@ class CommandTest {
         assertEquals(expr, defaultDM.expression());
         assertTrue(defaultDM instanceof Command);
     }
+
+    @Test
+    void testReadDM() {
+        ReadDM readDM = new java.util.ArrayList<String>() {{
+            add("&VAR1");
+            add("&VAR2");
+        }}.stream().collect(java.util.stream.Collectors.collectingAndThen(
+            java.util.stream.Collectors.toList(),
+            vars -> new ReadDM("MYFILE", vars)
+        ));
+
+        assertEquals("MYFILE", readDM.filename());
+        assertEquals(2, readDM.variables().size());
+        assertEquals("&VAR1", readDM.variables().get(0));
+        assertTrue(readDM instanceof Command);
+    }
+
+    @Test
+    void testWriteDM() {
+        WriteDM writeDM = new WriteDM("LOGFILE", java.util.List.of("Message 1", "Message 2"));
+
+        assertEquals("LOGFILE", writeDM.filename());
+        assertEquals(2, writeDM.messages().size());
+        assertEquals("Message 1", writeDM.messages().get(0));
+        assertTrue(writeDM instanceof Command);
+    }
+
+    @Test
+    void testHtmlFormDM() {
+        HtmlFormDM htmlFormDM = new HtmlFormDM("TEMPLATE.HTML", null);
+        assertEquals("TEMPLATE.HTML", htmlFormDM.filename());
+        assertNull(htmlFormDM.content());
+
+        HtmlFormDM htmlBlock = new HtmlFormDM(null, "<html><body>Hello</body></html>");
+        assertNull(htmlBlock.filename());
+        assertEquals("<html><body>Hello</body></html>", htmlBlock.content());
+        assertTrue(htmlFormDM instanceof Command);
+    }
 }


### PR DESCRIPTION
This change completes the porting of the remaining Abstract Semantic Graph (ASG) nodes to Java. It specifically focuses on Dialogue Manager I/O commands (-READ, -WRITE, -HTMLFORM) and multi-file reporting structures (MATCH FILE, MORE). 

Key changes:
1.  **New Java Records:** Created immutable `record` types in `com.transpiler.asg` for `ReadDM`, `WriteDM`, `HtmlFormDM`, `OutputCommand`, `MatchRequest`, `SubMatch`, `AfterMatchPhrase`, `MoreClause`, and `MoreSubRequest`.
2.  **Immutability:** Followed the established pattern of using `List.copyOf` in canonical constructors to ensure ASG node immutability.
3.  **Testing:** Added new test cases to `CommandTest.java` and `ASGParityTest.java`, bringing the total unit test count to 33, all of which pass via `mvn test`.
4.  **Roadmap Update:** Updated `JAVA_PORT_ROADMAP.md` to reflect these completions and provided a detailed breakdown for the next major phase: IR Instruction Porting.

Fixes #437

---
*PR created automatically by Jules for task [12244266956204886728](https://jules.google.com/task/12244266956204886728) started by @chatelao*