### PR TITLE
feat(java-port): implement IR control flow instructions

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -33,7 +33,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
   - [x] 2.1.5 Data Model Nodes: MasterFile, Segment, Field.
 - [ ] 2.2 IR Instruction Porting: Implement IR instruction set and Control Flow Graph (CFG) structures using JGraphT.
   - [x] 2.2.1 Base IR Infrastructure (IRNode, Instruction, BasicBlock, ControlFlowGraph).
-  - [ ] 2.2.2 Control Flow Instructions (Label, Jump, Branch, Phi).
+  - [x] 2.2.2 Control Flow Instructions (Label, Jump, Branch, Phi).
   - [ ] 2.2.3 Data & Assignment Instructions (Assign, SetEnv, Default).
   - [ ] 2.2.4 Procedure & I/O Instructions (Call, Type, HtmlForm, Read, Write).
   - [ ] 2.2.5 Relational Instructions (Join, JoinClear, Define, Report, Match).

--- a/src/main/java/com/transpiler/ir/Branch.java
+++ b/src/main/java/com/transpiler/ir/Branch.java
@@ -1,0 +1,9 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.Expression;
+
+/**
+ * Represents a conditional branch: if condition goto trueTarget else goto falseTarget.
+ */
+public record Branch(Expression condition, String trueTarget, String falseTarget) implements Instruction {
+}

--- a/src/main/java/com/transpiler/ir/Jump.java
+++ b/src/main/java/com/transpiler/ir/Jump.java
@@ -1,0 +1,7 @@
+package com.transpiler.ir;
+
+/**
+ * Represents an unconditional jump: goto target.
+ */
+public record Jump(String target) implements Instruction {
+}

--- a/src/main/java/com/transpiler/ir/Label.java
+++ b/src/main/java/com/transpiler/ir/Label.java
@@ -1,0 +1,7 @@
+package com.transpiler.ir;
+
+/**
+ * Represents a label in the instruction stream.
+ */
+public record Label(String name) implements Instruction {
+}

--- a/src/main/java/com/transpiler/ir/Phi.java
+++ b/src/main/java/com/transpiler/ir/Phi.java
@@ -1,0 +1,12 @@
+package com.transpiler.ir;
+
+import java.util.List;
+
+/**
+ * Represents a Phi node in SSA form: target = Phi(v1, v2, ...).
+ */
+public record Phi(String target, List<String> sources) implements Instruction {
+    public Phi {
+        sources = List.copyOf(sources);
+    }
+}

--- a/src/test/java/com/transpiler/ir/ControlFlowInstructionTest.java
+++ b/src/test/java/com/transpiler/ir/ControlFlowInstructionTest.java
@@ -1,0 +1,42 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.Identifier;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ControlFlowInstructionTest {
+
+    @Test
+    void testLabel() {
+        Label label = new Label("START");
+        assertEquals("START", label.name());
+    }
+
+    @Test
+    void testJump() {
+        Jump jump = new Jump("END");
+        assertEquals("END", jump.target());
+    }
+
+    @Test
+    void testBranch() {
+        Identifier condition = new Identifier("VAR1");
+        Branch branch = new Branch(condition, "TRUE_BLOCK", "FALSE_BLOCK");
+        assertEquals(condition, branch.condition());
+        assertEquals("TRUE_BLOCK", branch.trueTarget());
+        assertEquals("FALSE_BLOCK", branch.falseTarget());
+    }
+
+    @Test
+    void testPhi() {
+        List<String> sources = new java.util.ArrayList<>(List.of("v1", "v2"));
+        Phi phi = new Phi("x", sources);
+        assertEquals("x", phi.target());
+        assertEquals(sources, phi.sources());
+        assertNotSame(sources, phi.sources()); // Ensure copy
+        assertThrows(UnsupportedOperationException.class, () -> phi.sources().add("v3"));
+    }
+}


### PR DESCRIPTION
This PR implements Phase 2.2.2 of the Java port roadmap by introducing control flow instructions (`Label`, `Jump`, `Branch`, `Phi`) to the Java IR implementation. These instructions are implemented as immutable records, following the design patterns established for ASG nodes. Unit tests have been added to ensure correct state management and immutability.

Fixes #441

---
*PR created automatically by Jules for task [13533737694280115804](https://jules.google.com/task/13533737694280115804) started by @chatelao*