### PR TITLE
Implement Data & Assignment IR Instructions in Java

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -34,7 +34,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
 - [ ] 2.2 IR Instruction Porting: Implement IR instruction set and Control Flow Graph (CFG) structures using JGraphT.
   - [x] 2.2.1 Base IR Infrastructure (IRNode, Instruction, BasicBlock, ControlFlowGraph).
   - [x] 2.2.2 Control Flow Instructions (Label, Jump, Branch, Phi).
-  - [ ] 2.2.3 Data & Assignment Instructions (Assign, SetEnv, Default).
+  - [x] 2.2.3 Data & Assignment Instructions (Assign, SetEnv, Default).
   - [ ] 2.2.4 Procedure & I/O Instructions (Call, Type, HtmlForm, Read, Write).
   - [ ] 2.2.5 Relational Instructions (Join, JoinClear, Define, Report, Match).
   - [ ] 2.2.6 Layout Instructions (CompoundLayout, CompoundEnd).

--- a/src/main/java/com/transpiler/ir/Assign.java
+++ b/src/main/java/com/transpiler/ir/Assign.java
@@ -1,0 +1,9 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.Expression;
+
+/**
+ * Represents an assignment: target = source.
+ */
+public record Assign(String target, Expression source) implements Instruction {
+}

--- a/src/main/java/com/transpiler/ir/Default.java
+++ b/src/main/java/com/transpiler/ir/Default.java
@@ -1,0 +1,9 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.Expression;
+
+/**
+ * Represents a -DEFAULT, -DEFAULTS, or -DEFAULTH command.
+ */
+public record Default(String variable, Expression expression) implements Instruction {
+}

--- a/src/main/java/com/transpiler/ir/SetEnv.java
+++ b/src/main/java/com/transpiler/ir/SetEnv.java
@@ -1,0 +1,7 @@
+package com.transpiler.ir;
+
+/**
+ * Represents an environment setting (SET parameter = value).
+ */
+public record SetEnv(String parameter, String value) implements Instruction {
+}

--- a/src/test/java/com/transpiler/ir/DataInstructionTest.java
+++ b/src/test/java/com/transpiler/ir/DataInstructionTest.java
@@ -1,0 +1,33 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.Identifier;
+import com.transpiler.asg.Literal;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DataInstructionTest {
+
+    @Test
+    void testAssign() {
+        Identifier source = new Identifier("VAR1");
+        Assign assign = new Assign("target", source);
+        assertEquals("target", assign.target());
+        assertEquals(source, assign.source());
+    }
+
+    @Test
+    void testSetEnv() {
+        SetEnv setEnv = new SetEnv("AUTOCOMMIT", "ON");
+        assertEquals("AUTOCOMMIT", setEnv.parameter());
+        assertEquals("ON", setEnv.value());
+    }
+
+    @Test
+    void testDefault() {
+        Literal expression = new Literal("val1");
+        Default defaultInstr = new Default("VAR1", expression);
+        assertEquals("VAR1", defaultInstr.variable());
+        assertEquals(expression, defaultInstr.expression());
+    }
+}


### PR DESCRIPTION
Implemented the next modest step in the Java port roadmap by porting Data and Assignment IR instructions (Assign, SetEnv, Default) to Java records. Added comprehensive unit tests and updated the roadmap documentation. All tests passed.

Fixes #443

---
*PR created automatically by Jules for task [14682217632080116648](https://jules.google.com/task/14682217632080116648) started by @chatelao*