### PR TITLE
Implement Procedure and I/O IR Instructions in Java

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -35,7 +35,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
   - [x] 2.2.1 Base IR Infrastructure (IRNode, Instruction, BasicBlock, ControlFlowGraph).
   - [x] 2.2.2 Control Flow Instructions (Label, Jump, Branch, Phi).
   - [x] 2.2.3 Data & Assignment Instructions (Assign, SetEnv, Default).
-  - [ ] 2.2.4 Procedure & I/O Instructions (Call, Type, HtmlForm, Read, Write).
+  - [x] 2.2.4 Procedure & I/O Instructions (Call, Type, HtmlForm, Read, Write).
   - [ ] 2.2.5 Relational Instructions (Join, JoinClear, Define, Report, Match).
   - [ ] 2.2.6 Layout Instructions (CompoundLayout, CompoundEnd).
 - [ ] 2.3 Metadata Models: Port Master File and Segment metadata models.

--- a/src/main/java/com/transpiler/ir/Call.java
+++ b/src/main/java/com/transpiler/ir/Call.java
@@ -1,0 +1,12 @@
+package com.transpiler.ir;
+
+import java.util.List;
+
+/**
+ * Represents a call to another procedure or an external action (JOIN, INCLUDE).
+ */
+public record Call(String target, List<String> arguments) implements Instruction {
+    public Call {
+        arguments = List.copyOf(arguments);
+    }
+}

--- a/src/main/java/com/transpiler/ir/HtmlForm.java
+++ b/src/main/java/com/transpiler/ir/HtmlForm.java
@@ -1,0 +1,7 @@
+package com.transpiler.ir;
+
+/**
+ * Represents a -HTMLFORM command or block in the IR.
+ */
+public record HtmlForm(String filename, String content) implements Instruction {
+}

--- a/src/main/java/com/transpiler/ir/Read.java
+++ b/src/main/java/com/transpiler/ir/Read.java
@@ -1,0 +1,12 @@
+package com.transpiler.ir;
+
+import java.util.List;
+
+/**
+ * Represents a -READ command in the IR.
+ */
+public record Read(String filename, List<String> variables) implements Instruction {
+    public Read {
+        variables = List.copyOf(variables);
+    }
+}

--- a/src/main/java/com/transpiler/ir/Type.java
+++ b/src/main/java/com/transpiler/ir/Type.java
@@ -1,0 +1,12 @@
+package com.transpiler.ir;
+
+import java.util.List;
+
+/**
+ * Represents a -TYPE message in the IR.
+ */
+public record Type(List<String> messages) implements Instruction {
+    public Type {
+        messages = List.copyOf(messages);
+    }
+}

--- a/src/main/java/com/transpiler/ir/Write.java
+++ b/src/main/java/com/transpiler/ir/Write.java
@@ -1,0 +1,12 @@
+package com.transpiler.ir;
+
+import java.util.List;
+
+/**
+ * Represents a -WRITE command in the IR.
+ */
+public record Write(String filename, List<String> messages) implements Instruction {
+    public Write {
+        messages = List.copyOf(messages);
+    }
+}

--- a/src/test/java/com/transpiler/ir/ProcedureInstructionTest.java
+++ b/src/test/java/com/transpiler/ir/ProcedureInstructionTest.java
@@ -1,0 +1,78 @@
+package com.transpiler.ir;
+
+import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProcedureInstructionTest {
+
+    @Test
+    void testType() {
+        List<String> messages = List.of("Hello", "World");
+        Type type = new Type(messages);
+        assertEquals(messages, type.messages());
+
+        // Verify immutability
+        List<String> mutableMessages = new ArrayList<>();
+        mutableMessages.add("Test");
+        Type type2 = new Type(mutableMessages);
+        mutableMessages.add("Changed");
+        assertEquals(1, type2.messages().size());
+        assertEquals("Test", type2.messages().get(0));
+        assertThrows(UnsupportedOperationException.class, () -> type2.messages().add("New"));
+    }
+
+    @Test
+    void testCall() {
+        List<String> args = List.of("arg1", "arg2");
+        Call call = new Call("proc.fex", args);
+        assertEquals("proc.fex", call.target());
+        assertEquals(args, call.arguments());
+
+        // Verify immutability
+        List<String> mutableArgs = new ArrayList<>();
+        mutableArgs.add("a");
+        Call call2 = new Call("target", mutableArgs);
+        mutableArgs.add("b");
+        assertEquals(1, call2.arguments().size());
+        assertThrows(UnsupportedOperationException.class, () -> call2.arguments().add("c"));
+    }
+
+    @Test
+    void testHtmlForm() {
+        HtmlForm form = new HtmlForm("template.html", "<html></html>");
+        assertEquals("template.html", form.filename());
+        assertEquals("<html></html>", form.content());
+    }
+
+    @Test
+    void testRead() {
+        List<String> vars = List.of("&VAR1", "&VAR2");
+        Read read = new Read("data.txt", vars);
+        assertEquals("data.txt", read.filename());
+        assertEquals(vars, read.variables());
+
+        // Verify immutability
+        List<String> mutableVars = new ArrayList<>();
+        mutableVars.add("v");
+        Read read2 = new Read("file", mutableVars);
+        mutableVars.add("v2");
+        assertEquals(1, read2.variables().size());
+    }
+
+    @Test
+    void testWrite() {
+        List<String> msgs = List.of("Line 1", "Line 2");
+        Write write = new Write("output.txt", msgs);
+        assertEquals("output.txt", write.filename());
+        assertEquals(msgs, write.messages());
+
+        // Verify immutability
+        List<String> mutableMsgs = new ArrayList<>();
+        mutableMsgs.add("m");
+        Write write2 = new Write("file", mutableMsgs);
+        mutableMsgs.add("m2");
+        assertEquals(1, write2.messages().size());
+    }
+}


### PR DESCRIPTION
This PR implements Phase 2.2.4 of the Java port roadmap, adding Intermediate Representation (IR) instructions for procedure calls and I/O operations.

Key changes:
- Created Java records for `Call`, `Type`, `HtmlForm`, `Read`, and `Write` in `src/main/java/com/transpiler/ir/`.
- Ensured immutability using `List.copyOf` for all collection-based fields.
- Added comprehensive unit tests in `src/test/java/com/transpiler/ir/ProcedureInstructionTest.java`.
- Updated `JAVA_PORT_ROADMAP.md` to reflect completion of this step.

All 48 project tests passed.

Fixes #445

---
*PR created automatically by Jules for task [15759314574160957039](https://jules.google.com/task/15759314574160957039) started by @chatelao*