### PR TITLE
Implement Join-related IR and Roadmap Refinement

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -36,8 +36,11 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
   - [x] 2.2.2 Control Flow Instructions (Label, Jump, Branch, Phi).
   - [x] 2.2.3 Data & Assignment Instructions (Assign, SetEnv, Default).
   - [x] 2.2.4 Procedure & I/O Instructions (Call, Type, HtmlForm, Read, Write).
-  - [ ] 2.2.5 Relational Instructions (Join, JoinClear, Define, Report, Match).
-  - [ ] 2.2.6 Layout Instructions (CompoundLayout, CompoundEnd).
+  - [ ] 2.2.5 Relational Instructions:
+    - [x] 2.2.5.1 Join-related IR (Join, JoinClear).
+    - [ ] 2.2.5.2 Data-driven IR (Define, Report, Match).
+  - [ ] 2.2.6 Layout Instructions:
+    - [ ] 2.2.6.1 Layout blocks (CompoundLayout, CompoundEnd).
 - [ ] 2.3 Metadata Models: Port Master File and Segment metadata models.
 
 ## Phase 3: Frontend & Semantic Analysis

--- a/src/main/java/com/transpiler/asg/JoinClear.java
+++ b/src/main/java/com/transpiler/asg/JoinClear.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a JOIN CLEAR * command.
+ */
+public record JoinClear() implements Command {
+}

--- a/src/main/java/com/transpiler/ir/Join.java
+++ b/src/main/java/com/transpiler/ir/Join.java
@@ -1,7 +1,7 @@
-package com.transpiler.asg;
+package com.transpiler.ir;
 
 /**
- * Represents a JOIN command.
+ * Represents a JOIN command in the IR.
  */
 public record Join(
     String leftFile,
@@ -11,5 +11,5 @@ public record Join(
     String joinAs,
     boolean outer,
     boolean isAll
-) implements Command {
+) implements Instruction {
 }

--- a/src/main/java/com/transpiler/ir/JoinClear.java
+++ b/src/main/java/com/transpiler/ir/JoinClear.java
@@ -1,0 +1,7 @@
+package com.transpiler.ir;
+
+/**
+ * Represents a JOIN CLEAR * command in the IR.
+ */
+public record JoinClear() implements Instruction {
+}

--- a/src/test/java/com/transpiler/asg/ASGParityTest.java
+++ b/src/test/java/com/transpiler/asg/ASGParityTest.java
@@ -161,10 +161,17 @@ class ASGParityTest {
 
     @Test
     void testEnvironmentAndVirtualFieldNodes() {
-        Join join = new Join("EMP", "ID", "SAL", "ID", "EMPSAL", true);
+        Join join = new Join("EMP", "ID", "SAL", "ID", "EMPSAL", true, false);
         assertEquals("EMP", join.leftFile());
         assertEquals("EMPSAL", join.joinAs());
         assertTrue(join.outer());
+        assertFalse(join.isAll());
+
+        Join joinAll = new Join("EMP", "ID", "SAL", "ID", "EMPSAL", false, true);
+        assertTrue(joinAll.isAll());
+
+        JoinClear joinClear = new JoinClear();
+        assertNotNull(joinClear);
 
         SetCommand setCmd = new SetCommand("NODATA", "MISSING");
         assertEquals("NODATA", setCmd.parameter());

--- a/src/test/java/com/transpiler/ir/RelationalInstructionTest.java
+++ b/src/test/java/com/transpiler/ir/RelationalInstructionTest.java
@@ -1,0 +1,26 @@
+package com.transpiler.ir;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RelationalInstructionTest {
+
+    @Test
+    void testJoinInstruction() {
+        Join join = new Join("EMP", "ID", "SAL", "ID", "EMPSAL", true, true);
+        assertEquals("EMP", join.leftFile());
+        assertEquals("ID", join.leftField());
+        assertEquals("SAL", join.rightFile());
+        assertEquals("ID", join.rightField());
+        assertEquals("EMPSAL", join.joinAs());
+        assertTrue(join.outer());
+        assertTrue(join.isAll());
+    }
+
+    @Test
+    void testJoinClearInstruction() {
+        JoinClear joinClear = new JoinClear();
+        assertNotNull(joinClear);
+        assertTrue(joinClear instanceof Instruction);
+    }
+}


### PR DESCRIPTION
This change progresses the Java port by implementing Join-related Intermediate Representation (IR) instructions and granularizing the remaining relational and layout instructions in the roadmap. 

Specifically:
- `JAVA_PORT_ROADMAP.md` was updated to break down Phase 2.2.5 and 2.2.6 into smaller, more manageable sub-tasks.
- The `Join` node in both ASG and IR was enhanced/implemented to support the `isAll` flag, maintaining parity with the Python implementation.
- The `JoinClear` node was added to both ASG and IR.
- Unit tests were added and updated to verify these new data structures, with all 50 tests in the suite passing.

Fixes #447

---
*PR created automatically by Jules for task [15234272491437205562](https://jules.google.com/task/15234272491437205562) started by @chatelao*