### PR TITLE
Implement data-driven and layout IR instructions in Java

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -38,9 +38,9 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
   - [x] 2.2.4 Procedure & I/O Instructions (Call, Type, HtmlForm, Read, Write).
   - [ ] 2.2.5 Relational Instructions:
     - [x] 2.2.5.1 Join-related IR (Join, JoinClear).
-    - [ ] 2.2.5.2 Data-driven IR (Define, Report, Match).
-  - [ ] 2.2.6 Layout Instructions:
-    - [ ] 2.2.6.1 Layout blocks (CompoundLayout, CompoundEnd).
+    - [x] 2.2.5.2 Data-driven IR (Define, Report, Match).
+  - [x] 2.2.6 Layout Instructions:
+    - [x] 2.2.6.1 Layout blocks (CompoundLayout, CompoundEnd).
 - [ ] 2.3 Metadata Models: Port Master File and Segment metadata models.
 
 ## Phase 3: Frontend & Semantic Analysis

--- a/src/main/java/com/transpiler/ir/CompoundEnd.java
+++ b/src/main/java/com/transpiler/ir/CompoundEnd.java
@@ -1,0 +1,7 @@
+package com.transpiler.ir;
+
+/**
+ * Represents the end of a COMPOUND LAYOUT block in the IR.
+ */
+public record CompoundEnd() implements Instruction {
+}

--- a/src/main/java/com/transpiler/ir/CompoundLayout.java
+++ b/src/main/java/com/transpiler/ir/CompoundLayout.java
@@ -1,0 +1,18 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.OutputCommand;
+import com.transpiler.asg.Statement;
+import java.util.List;
+
+/**
+ * Represents the start of a COMPOUND LAYOUT block in the IR.
+ */
+public record CompoundLayout(
+    OutputCommand outputCommand,
+    List<Statement> statements
+) implements Instruction {
+    public CompoundLayout(OutputCommand outputCommand, List<Statement> statements) {
+        this.outputCommand = outputCommand;
+        this.statements = statements != null ? List.copyOf(statements) : List.of();
+    }
+}

--- a/src/main/java/com/transpiler/ir/Define.java
+++ b/src/main/java/com/transpiler/ir/Define.java
@@ -1,0 +1,17 @@
+package com.transpiler.ir;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a set of virtual field definitions (DEFINE FILE) in the IR.
+ */
+public record Define(
+    String filename,
+    List<Map<String, String>> assignments
+) implements Instruction {
+    public Define(String filename, List<Map<String, String>> assignments) {
+        this.filename = filename;
+        this.assignments = assignments != null ? List.copyOf(assignments) : List.of();
+    }
+}

--- a/src/main/java/com/transpiler/ir/Match.java
+++ b/src/main/java/com/transpiler/ir/Match.java
@@ -1,0 +1,23 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.ASGNode;
+import com.transpiler.asg.MoreClause;
+import com.transpiler.asg.SubMatch;
+import java.util.List;
+
+/**
+ * Represents a match request (MATCH FILE) in the IR.
+ */
+public record Match(
+    String filename,
+    List<ASGNode> components,
+    List<SubMatch> subMatches,
+    MoreClause moreClause
+) implements Instruction {
+    public Match(String filename, List<ASGNode> components, List<SubMatch> subMatches, MoreClause moreClause) {
+        this.filename = filename;
+        this.components = components != null ? List.copyOf(components) : List.of();
+        this.subMatches = subMatches != null ? List.copyOf(subMatches) : List.of();
+        this.moreClause = moreClause;
+    }
+}

--- a/src/main/java/com/transpiler/ir/Report.java
+++ b/src/main/java/com/transpiler/ir/Report.java
@@ -1,0 +1,22 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.Command;
+import com.transpiler.asg.MoreClause;
+import java.util.List;
+
+/**
+ * Represents a report request (TABLE FILE) in the IR.
+ */
+public record Report(
+    String filename,
+    List<Command> components,
+    List<Join> joins,
+    MoreClause moreClause
+) implements Instruction {
+    public Report(String filename, List<Command> components, List<Join> joins, MoreClause moreClause) {
+        this.filename = filename;
+        this.components = components != null ? List.copyOf(components) : List.of();
+        this.joins = joins != null ? List.copyOf(joins) : List.of();
+        this.moreClause = moreClause;
+    }
+}

--- a/src/test/java/com/transpiler/ir/LayoutInstructionTest.java
+++ b/src/test/java/com/transpiler/ir/LayoutInstructionTest.java
@@ -1,0 +1,25 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.OutputCommand;
+import com.transpiler.asg.ReportRequest;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LayoutInstructionTest {
+
+    @Test
+    void testCompoundLayoutInstructions() {
+        OutputCommand hold = new OutputCommand("PCHOLD", "REPORT1", "PDF", null);
+        ReportRequest report = new ReportRequest("EMPLOYEE");
+
+        CompoundLayout layout = new CompoundLayout(hold, List.of(report));
+        assertEquals(hold, layout.outputCommand());
+        assertEquals(1, layout.statements().size());
+        assertEquals(report, layout.statements().get(0));
+
+        CompoundEnd end = new CompoundEnd();
+        assertNotNull(end);
+        assertTrue(end instanceof Instruction);
+    }
+}

--- a/src/test/java/com/transpiler/ir/RelationalInstructionTest.java
+++ b/src/test/java/com/transpiler/ir/RelationalInstructionTest.java
@@ -1,9 +1,51 @@
 package com.transpiler.ir;
 
+import com.transpiler.asg.FieldSelection;
+import com.transpiler.asg.MoreClause;
+import com.transpiler.asg.MoreSubRequest;
+import com.transpiler.asg.VerbCommand;
+import com.transpiler.asg.WhereClause;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class RelationalInstructionTest {
+
+    @Test
+    void testReportInstruction() {
+        Join join = new Join("EMP", "ID", "SAL", "ID", "EMPSAL", true, true);
+        VerbCommand verb = new VerbCommand("PRINT", List.of(new FieldSelection("LASTNAME")));
+        MoreClause more = new MoreClause(List.of(new MoreSubRequest("FILE2", List.of())));
+
+        Report report = new Report("EMPLOYEE", List.of(verb), List.of(join), more);
+
+        assertEquals("EMPLOYEE", report.filename());
+        assertEquals(1, report.components().size());
+        assertEquals(1, report.joins().size());
+        assertEquals(more, report.moreClause());
+    }
+
+    @Test
+    void testMatchInstruction() {
+        FieldSelection field = new FieldSelection("ID");
+        Match match = new Match("MAINFILE", List.of(field), List.of(), null);
+
+        assertEquals("MAINFILE", match.filename());
+        assertEquals(1, match.components().size());
+        assertTrue(match.subMatches().isEmpty());
+        assertNull(match.moreClause());
+    }
+
+    @Test
+    void testDefineInstruction() {
+        Define define = new Define("EMPLOYEE", List.of(Map.of("name", "FULLNAME", "expression", "FIRSTNAME || LASTNAME")));
+        assertEquals("EMPLOYEE", define.filename());
+        assertEquals(1, define.assignments().size());
+        assertEquals("FULLNAME", define.assignments().get(0).get("name"));
+    }
 
     @Test
     void testJoinInstruction() {


### PR DESCRIPTION
Implemented data-driven (`Define`, `Report`, `Match`) and layout (`CompoundLayout`, `CompoundEnd`) IR instructions as immutable Java records in `com.transpiler.ir`. Added comprehensive unit tests and updated the Java port roadmap. All 54 tests passed.

Fixes #449

---
*PR created automatically by Jules for task [16604346352424565521](https://jules.google.com/task/16604346352424565521) started by @chatelao*