### PR TITLE
Implement Data-driven and Layout IR instructions in Java

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -36,11 +36,11 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
   - [x] 2.2.2 Control Flow Instructions (Label, Jump, Branch, Phi).
   - [x] 2.2.3 Data & Assignment Instructions (Assign, SetEnv, Default).
   - [x] 2.2.4 Procedure & I/O Instructions (Call, Type, HtmlForm, Read, Write).
-  - [ ] 2.2.5 Relational Instructions:
+  - [x] 2.2.5 Relational Instructions:
     - [x] 2.2.5.1 Join-related IR (Join, JoinClear).
-    - [ ] 2.2.5.2 Data-driven IR (Define, Report, Match).
-  - [ ] 2.2.6 Layout Instructions:
-    - [ ] 2.2.6.1 Layout blocks (CompoundLayout, CompoundEnd).
+    - [x] 2.2.5.2 Data-driven IR (Define, Report, Match).
+  - [x] 2.2.6 Layout Instructions:
+    - [x] 2.2.6.1 Layout blocks (CompoundLayout, CompoundEnd).
 - [ ] 2.3 Metadata Models: Port Master File and Segment metadata models.
 
 ## Phase 3: Frontend & Semantic Analysis

--- a/src/main/java/com/transpiler/ir/CompoundEnd.java
+++ b/src/main/java/com/transpiler/ir/CompoundEnd.java
@@ -1,0 +1,7 @@
+package com.transpiler.ir;
+
+/**
+ * Represents the end of a COMPOUND LAYOUT block.
+ */
+public record CompoundEnd() implements Instruction {
+}

--- a/src/main/java/com/transpiler/ir/CompoundLayout.java
+++ b/src/main/java/com/transpiler/ir/CompoundLayout.java
@@ -1,0 +1,18 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.OutputCommand;
+import com.transpiler.asg.Statement;
+import java.util.List;
+
+/**
+ * Represents the start of a COMPOUND LAYOUT block.
+ */
+public record CompoundLayout(
+    OutputCommand outputCommand,
+    List<Statement> statements
+) implements Instruction {
+    public CompoundLayout(OutputCommand outputCommand, List<Statement> statements) {
+        this.outputCommand = outputCommand;
+        this.statements = statements != null ? List.copyOf(statements) : List.of();
+    }
+}

--- a/src/main/java/com/transpiler/ir/Define.java
+++ b/src/main/java/com/transpiler/ir/Define.java
@@ -1,0 +1,17 @@
+package com.transpiler.ir;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a set of virtual field definitions (DEFINE FILE).
+ */
+public record Define(
+    String filename,
+    List<Map<String, String>> assignments
+) implements Instruction {
+    public Define(String filename, List<Map<String, String>> assignments) {
+        this.filename = filename;
+        this.assignments = assignments != null ? List.copyOf(assignments) : List.of();
+    }
+}

--- a/src/main/java/com/transpiler/ir/Match.java
+++ b/src/main/java/com/transpiler/ir/Match.java
@@ -1,0 +1,27 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.Command;
+import com.transpiler.asg.MoreClause;
+import com.transpiler.asg.SubMatch;
+import java.util.List;
+
+/**
+ * Represents a match request (MATCH FILE).
+ */
+public record Match(
+    String filename,
+    List<Command> components,
+    List<SubMatch> subMatches,
+    MoreClause moreClause
+) implements Instruction {
+    public Match(String filename, List<Command> components, List<SubMatch> subMatches, MoreClause moreClause) {
+        this.filename = filename;
+        this.components = components != null ? List.copyOf(components) : List.of();
+        this.subMatches = subMatches != null ? List.copyOf(subMatches) : List.of();
+        this.moreClause = moreClause;
+    }
+
+    public Match(String filename, List<Command> components) {
+        this(filename, components, List.of(), null);
+    }
+}

--- a/src/main/java/com/transpiler/ir/Report.java
+++ b/src/main/java/com/transpiler/ir/Report.java
@@ -1,0 +1,26 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.Command;
+import com.transpiler.asg.MoreClause;
+import java.util.List;
+
+/**
+ * Represents a report request (TABLE FILE).
+ */
+public record Report(
+    String filename,
+    List<Command> components,
+    List<Join> joins,
+    MoreClause moreClause
+) implements Instruction {
+    public Report(String filename, List<Command> components, List<Join> joins, MoreClause moreClause) {
+        this.filename = filename;
+        this.components = components != null ? List.copyOf(components) : List.of();
+        this.joins = joins != null ? List.copyOf(joins) : List.of();
+        this.moreClause = moreClause;
+    }
+
+    public Report(String filename, List<Command> components) {
+        this(filename, components, List.of(), null);
+    }
+}

--- a/src/test/java/com/transpiler/ir/LayoutInstructionTest.java
+++ b/src/test/java/com/transpiler/ir/LayoutInstructionTest.java
@@ -1,0 +1,24 @@
+package com.transpiler.ir;
+
+import com.transpiler.asg.OutputCommand;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LayoutInstructionTest {
+
+    @Test
+    void testCompoundLayoutInstruction() {
+        OutputCommand output = new OutputCommand("HOLD", "MYFILE", "FORMAT", null);
+        CompoundLayout layout = new CompoundLayout(output, List.of());
+        assertEquals(output, layout.outputCommand());
+        assertTrue(layout.statements().isEmpty());
+    }
+
+    @Test
+    void testCompoundEndInstruction() {
+        CompoundEnd end = new CompoundEnd();
+        assertNotNull(end);
+        assertTrue(end instanceof Instruction);
+    }
+}

--- a/src/test/java/com/transpiler/ir/RelationalInstructionTest.java
+++ b/src/test/java/com/transpiler/ir/RelationalInstructionTest.java
@@ -23,4 +23,31 @@ class RelationalInstructionTest {
         assertNotNull(joinClear);
         assertTrue(joinClear instanceof Instruction);
     }
+
+    @Test
+    void testDefineInstruction() {
+        java.util.Map<String, String> assignment = java.util.Map.of("NAME", "VAL", "FORMAT", "A10");
+        Define define = new Define("EMP", java.util.List.of(assignment));
+        assertEquals("EMP", define.filename());
+        assertEquals(1, define.assignments().size());
+        assertEquals("VAL", define.assignments().get(0).get("NAME"));
+    }
+
+    @Test
+    void testReportInstruction() {
+        Report report = new Report("EMP", java.util.List.of());
+        assertEquals("EMP", report.filename());
+        assertTrue(report.components().isEmpty());
+        assertTrue(report.joins().isEmpty());
+        assertNull(report.moreClause());
+    }
+
+    @Test
+    void testMatchInstruction() {
+        Match match = new Match("EMP", java.util.List.of());
+        assertEquals("EMP", match.filename());
+        assertTrue(match.components().isEmpty());
+        assertTrue(match.subMatches().isEmpty());
+        assertNull(match.moreClause());
+    }
 }


### PR DESCRIPTION
This change implements the remaining IR instructions for Phase 2 of the Java port roadmap. 

Specifically:
- **Data-driven IR instructions**: `Define`, `Report`, and `Match` were added as immutable records in `com.transpiler.ir`.
- **Layout IR instructions**: `CompoundLayout` and `CompoundEnd` were added as immutable records in `com.transpiler.ir`.
- **Unit Testing**: Existing tests in `RelationalInstructionTest` were expanded, and a new `LayoutInstructionTest` was created to verify the new components.
- **Roadmap Update**: `JAVA_PORT_ROADMAP.md` was updated to reflect that Phase 2.2.5 (Relational Instructions) and Phase 2.2.6 (Layout Instructions) are now complete.

All 55 tests in the Java suite passed successfully.

Fixes #450

---
*PR created automatically by Jules for task [17291494024049249446](https://jules.google.com/task/17291494024049249446) started by @chatelao*