### PR TITLE
Implement enhanced metadata ASG nodes and refine roadmap

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -30,7 +30,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
     - [x] 2.1.4.1 Basic: ReportRequest, VerbCommand, SortCommand, WhereClause, etc.
     - [x] 2.1.4.2 Output: OutputCommand (HOLD, PCHOLD, etc.).
     - [x] 2.1.4.3 Multi-file: MatchRequest, SubMatch, AfterMatchPhrase, MoreClause, MoreSubRequest.
-  - [x] 2.1.5 Data Model Nodes: MasterFile, Segment, Field.
+  - [x] 2.1.5 Data Model Nodes: MasterFile, Segment, Field, DefineAssignment, Dimension, Hierarchy.
 - [ ] 2.2 IR Instruction Porting: Implement IR instruction set and Control Flow Graph (CFG) structures using JGraphT.
   - [x] 2.2.1 Base IR Infrastructure (IRNode, Instruction, BasicBlock, ControlFlowGraph).
   - [x] 2.2.2 Control Flow Instructions (Label, Jump, Branch, Phi).
@@ -44,10 +44,22 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
 - [ ] 2.3 Metadata Models: Port Master File and Segment metadata models.
 
 ## Phase 3: Frontend & Semantic Analysis
-- [ ] 3.1 ASG Builder: Port `asg_builder.py` to Java `WebFocusReportVisitor` implementation.
-- [ ] 3.2 Symbol Table: Port hierarchical symbol resolution and scoping logic.
-- [ ] 3.3 Type System: Port `TypeInferrer` and `TypeMapper` to Java.
-- [ ] 3.4 Master File Parser: Port `master_file_parser.py` to Java implementation.
+- [ ] 3.1 ASG Builder Infrastructure:
+  - [ ] 3.1.1 Base Visitor: Implement `WebFocusReportVisitor` and `MasterFileVisitor` skeleton.
+  - [ ] 3.1.2 Dispatcher Logic: Implement node traversal and construction orchestration.
+- [ ] 3.2 Expression & Command Builders:
+  - [ ] 3.2.1 Expression Builder: Support all arithmetic, character, and logical expressions.
+  - [ ] 3.2.2 Dialogue Manager Builder: Port visitor logic for -SET, -IF, -GOTO, -REPEAT, etc.
+  - [ ] 3.2.3 Report Request Builder: Port visitor logic for TABLE FILE, verbs, sorts, and filters.
+  - [ ] 3.2.4 Environment Builder: Port visitor logic for JOIN, SET, and DEFINE FILE.
+- [ ] 3.3 Master File Parser & Builder:
+  - [ ] 3.3.1 Port `MasterFileParserWrapper` and `MasterFileASGBuilder` to Java.
+- [ ] 3.4 Symbol Table & Scoping:
+  - [ ] 3.4.1 Implement hierarchical `SymbolTable` (block-level and global).
+  - [ ] 3.4.2 Port `SymbolResolver` for AmperVars and database field resolution.
+- [ ] 3.5 Type System:
+  - [ ] 3.5.1 Implement `TypeInferrer` for literal and expression typing.
+  - [ ] 3.5.2 Implement `TypeMapper` for metadata-driven type resolution.
 
 ## Phase 4: Optimization (SSA & Relational Lifting)
 - [ ] 4.1 SSA Transformer: Port SSA transformation logic (dominator analysis, Phi-node insertion, variable renaming).

--- a/src/main/java/com/transpiler/asg/DefineAssignment.java
+++ b/src/main/java/com/transpiler/asg/DefineAssignment.java
@@ -1,0 +1,11 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a single assignment within a DEFINE FILE block or Master File.
+ */
+public record DefineAssignment(
+    String name,
+    String expression,
+    String format
+) implements ASGNode {
+}

--- a/src/main/java/com/transpiler/asg/DefineFile.java
+++ b/src/main/java/com/transpiler/asg/DefineFile.java
@@ -1,16 +1,15 @@
 package com.transpiler.asg;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Represents a DEFINE FILE block.
  */
 public record DefineFile(
     String filename,
-    List<Map<String, String>> assignments
+    List<DefineAssignment> assignments
 ) implements Statement {
-    public DefineFile(String filename, List<Map<String, String>> assignments) {
+    public DefineFile(String filename, List<DefineAssignment> assignments) {
         this.filename = filename;
         this.assignments = assignments != null ? List.copyOf(assignments) : List.of();
     }

--- a/src/main/java/com/transpiler/asg/Dimension.java
+++ b/src/main/java/com/transpiler/asg/Dimension.java
@@ -1,0 +1,9 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a DIMENSION in a Master File.
+ */
+public record Dimension(
+    String name
+) implements ASGNode {
+}

--- a/src/main/java/com/transpiler/asg/Hierarchy.java
+++ b/src/main/java/com/transpiler/asg/Hierarchy.java
@@ -1,0 +1,9 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a HIERARCHY in a Master File.
+ */
+public record Hierarchy(
+    String name
+) implements ASGNode {
+}

--- a/src/main/java/com/transpiler/asg/MasterFile.java
+++ b/src/main/java/com/transpiler/asg/MasterFile.java
@@ -8,15 +8,27 @@ import java.util.List;
 public record MasterFile(
     String name,
     String suffix,
-    List<Segment> segments
+    List<Segment> segments,
+    List<DefineAssignment> virtualFields,
+    List<Dimension> dimensions,
+    List<Hierarchy> hierarchies
 ) implements ASGNode {
-    public MasterFile(String name, String suffix, List<Segment> segments) {
+    public MasterFile(String name, String suffix, List<Segment> segments,
+                      List<DefineAssignment> virtualFields, List<Dimension> dimensions,
+                      List<Hierarchy> hierarchies) {
         this.name = name;
         this.suffix = suffix;
         this.segments = segments != null ? List.copyOf(segments) : List.of();
+        this.virtualFields = virtualFields != null ? List.copyOf(virtualFields) : List.of();
+        this.dimensions = dimensions != null ? List.copyOf(dimensions) : List.of();
+        this.hierarchies = hierarchies != null ? List.copyOf(hierarchies) : List.of();
     }
 
     public MasterFile(String name, String suffix) {
-        this(name, suffix, List.of());
+        this(name, suffix, List.of(), List.of(), List.of(), List.of());
+    }
+
+    public MasterFile(String name, String suffix, List<Segment> segments) {
+        this(name, suffix, segments, List.of(), List.of(), List.of());
     }
 }

--- a/src/main/java/com/transpiler/asg/Segment.java
+++ b/src/main/java/com/transpiler/asg/Segment.java
@@ -9,16 +9,22 @@ public record Segment(
     String name,
     String segtype,
     String parent,
-    List<Field> fields
+    List<Field> fields,
+    List<DefineAssignment> virtualFields
 ) implements ASGNode {
-    public Segment(String name, String segtype, String parent, List<Field> fields) {
+    public Segment(String name, String segtype, String parent, List<Field> fields, List<DefineAssignment> virtualFields) {
         this.name = name;
         this.segtype = segtype;
         this.parent = parent;
         this.fields = fields != null ? List.copyOf(fields) : List.of();
+        this.virtualFields = virtualFields != null ? List.copyOf(virtualFields) : List.of();
     }
 
     public Segment(String name, String segtype) {
-        this(name, segtype, null, List.of());
+        this(name, segtype, null, List.of(), List.of());
+    }
+
+    public Segment(String name, String segtype, String parent, List<Field> fields) {
+        this(name, segtype, parent, fields, List.of());
     }
 }

--- a/src/main/java/com/transpiler/ir/Define.java
+++ b/src/main/java/com/transpiler/ir/Define.java
@@ -1,16 +1,16 @@
 package com.transpiler.ir;
 
+import com.transpiler.asg.DefineAssignment;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Represents a set of virtual field definitions (DEFINE FILE).
  */
 public record Define(
     String filename,
-    List<Map<String, String>> assignments
+    List<DefineAssignment> assignments
 ) implements Instruction {
-    public Define(String filename, List<Map<String, String>> assignments) {
+    public Define(String filename, List<DefineAssignment> assignments) {
         this.filename = filename;
         this.assignments = assignments != null ? List.copyOf(assignments) : List.of();
     }

--- a/src/test/java/com/transpiler/asg/ASGParityTest.java
+++ b/src/test/java/com/transpiler/asg/ASGParityTest.java
@@ -56,6 +56,9 @@ class ASGParityTest {
         assertEquals("EMPLOYEE", mf.name());
         assertEquals("FOC", mf.suffix());
         assertTrue(mf.segments().isEmpty());
+        assertTrue(mf.virtualFields().isEmpty());
+        assertTrue(mf.dimensions().isEmpty());
+        assertTrue(mf.hierarchies().isEmpty());
     }
 
     @Test
@@ -64,6 +67,7 @@ class ASGParityTest {
         assertEquals("EMPDATA", seg.name());
         assertEquals("S1", seg.segtype());
         assertTrue(seg.fields().isEmpty());
+        assertTrue(seg.virtualFields().isEmpty());
     }
 
     @Test
@@ -77,13 +81,16 @@ class ASGParityTest {
     @Test
     void testNodeNesting() {
         Field fld = new Field("LASTNAME", "LN", "A15");
-        Segment seg = new Segment("EMPDATA", "S1", "EMPLOYEE", List.of(fld));
-        MasterFile mf = new MasterFile("EMPLOYEE", "FOC", List.of(seg));
+        DefineAssignment virtualField = new DefineAssignment("FULLNAME", "FIRSTNAME || LASTNAME", "A30");
+        Segment seg = new Segment("EMPDATA", "S1", "EMPLOYEE", List.of(fld), List.of(virtualField));
+        MasterFile mf = new MasterFile("EMPLOYEE", "FOC", List.of(seg), List.of(), List.of(), List.of());
 
         assertEquals(1, mf.segments().size());
         assertEquals("EMPDATA", mf.segments().get(0).name());
         assertEquals(1, mf.segments().get(0).fields().size());
         assertEquals("LASTNAME", mf.segments().get(0).fields().get(0).name());
+        assertEquals(1, mf.segments().get(0).virtualFields().size());
+        assertEquals("FULLNAME", mf.segments().get(0).virtualFields().get(0).name());
     }
 
     @Test
@@ -177,9 +184,11 @@ class ASGParityTest {
         assertEquals("NODATA", setCmd.parameter());
         assertEquals("MISSING", setCmd.value());
 
-        DefineFile define = new DefineFile("EMPLOYEE", List.of(Map.of("name", "FULLNAME", "expression", "FIRSTNAME || LASTNAME")));
+        DefineAssignment assignment = new DefineAssignment("FULLNAME", "FIRSTNAME || LASTNAME", "A30");
+        DefineFile define = new DefineFile("EMPLOYEE", List.of(assignment));
         assertEquals("EMPLOYEE", define.filename());
         assertEquals(1, define.assignments().size());
+        assertEquals("FULLNAME", define.assignments().get(0).name());
     }
 
     @Test
@@ -219,5 +228,20 @@ class ASGParityTest {
         InExpression inExpr = new InExpression(ident, List.of(new Literal(1), new Literal(2)));
         assertEquals(ident, inExpr.expression());
         assertEquals(2, inExpr.values().size());
+    }
+
+    @Test
+    void testDimensionAndHierarchyNodes() {
+        Dimension dim = new Dimension("GEOGRAPHY");
+        assertEquals("GEOGRAPHY", dim.name());
+
+        Hierarchy hry = new Hierarchy("REGIONAL");
+        assertEquals("REGIONAL", hry.name());
+
+        MasterFile mf = new MasterFile("SALES", "FOC", List.of(), List.of(), List.of(dim), List.of(hry));
+        assertEquals(1, mf.dimensions().size());
+        assertEquals("GEOGRAPHY", mf.dimensions().get(0).name());
+        assertEquals(1, mf.hierarchies().size());
+        assertEquals("REGIONAL", mf.hierarchies().get(0).name());
     }
 }

--- a/src/test/java/com/transpiler/ir/RelationalInstructionTest.java
+++ b/src/test/java/com/transpiler/ir/RelationalInstructionTest.java
@@ -1,6 +1,8 @@
 package com.transpiler.ir;
 
+import com.transpiler.asg.DefineAssignment;
 import org.junit.jupiter.api.Test;
+import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 class RelationalInstructionTest {
@@ -26,11 +28,11 @@ class RelationalInstructionTest {
 
     @Test
     void testDefineInstruction() {
-        java.util.Map<String, String> assignment = java.util.Map.of("NAME", "VAL", "FORMAT", "A10");
-        Define define = new Define("EMP", java.util.List.of(assignment));
+        DefineAssignment assignment = new DefineAssignment("VAL", "EXPR", "A10");
+        Define define = new Define("EMP", List.of(assignment));
         assertEquals("EMP", define.filename());
         assertEquals(1, define.assignments().size());
-        assertEquals("VAL", define.assignments().get(0).get("NAME"));
+        assertEquals("VAL", define.assignments().get(0).name());
     }
 
     @Test


### PR DESCRIPTION
This change implements the remaining data model ASG nodes (DefineAssignment, Dimension, Hierarchy) to achieve full parity with the Python implementation. It also refactors existing nodes (MasterFile, Segment, DefineFile) and the Define IR instruction to use the strongly-typed DefineAssignment record instead of generic Maps. Finally, it granularizes the "Frontend & Semantic Analysis" phase in the JAVA_PORT_ROADMAP.md into smaller, manageable steps. All changes are verified by 56 passing JUnit tests.

Fixes #454

---
*PR created automatically by Jules for task [12387297512211333004](https://jules.google.com/task/12387297512211333004) started by @chatelao*