### PR TITLE
Include Java 21 in CI/CD workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -52,10 +52,25 @@ jobs:
           export PYTHONPATH=$PYTHONPATH:$(pwd)/src
           python -m unittest discover -v test
 
+  test-java:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run tests with Maven
+        run: mvn test
+
   deploy-docs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    needs: test
+    needs: [test, test-java]
     steps:
       - uses: actions/checkout@v4
 
@@ -67,7 +82,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Install dependencies


### PR DESCRIPTION
This change integrates Java into the CI/CD pipeline by adding a dedicated testing job for the Maven-based Java port. It also updates the documentation deployment job to use JDK 21, ensuring version consistency across the workflow and alignment with the project's Java 21 LTS target.

Fixes #455

---
*PR created automatically by Jules for task [6969609251706614122](https://jules.google.com/task/6969609251706614122) started by @chatelao*