### PR TITLE
Implement arithmetic and logical visitors in WebFocusReportASGBuilder

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -50,7 +50,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
   - [x] 3.1.1 Infrastructure: Base visitor skeleton and Start/Request/Table nodes.
   - [ ] 3.1.2 Expressions:
     - [x] 3.1.2.1 Literals, Identifiers, and AmperVars.
-    - [ ] 3.1.2.2 Binary and Unary operations.
+    - [x] 3.1.2.2 Binary and Unary operations.
     - [ ] 3.1.2.3 Function calls and Built-in functions.
     - [ ] 3.1.2.4 Conditional expressions (IfExpression, DecodeExpression).
     - [ ] 3.1.2.5 Set-based expressions (IN, BETWEEN, IS MISSING).

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -145,53 +145,111 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
 
     @Override
     public Object visitDm_logical_expression(WebFocusReportParser.Dm_logical_expressionContext ctx) {
-        if (ctx.getChildCount() == 3 && ctx.getChild(0).getText().equals("(")) {
+        if (ctx.getChildCount() == 1) {
+            return visit(ctx.getChild(0));
+        }
+        if (ctx.getChild(0).getText().equals("(")) {
             return visit(ctx.dm_logical_expression(0));
         }
-        if (ctx.dm_relational_expression() != null && ctx.getChildCount() == 1) {
-            return visit(ctx.dm_relational_expression());
+        if (ctx.getChildCount() == 2) { // NOT case
+            String operator = ctx.getChild(0).getText().toUpperCase();
+            Expression operand = (Expression) visit(ctx.getChild(1));
+            return new UnaryOperation(operator, operand);
         }
-        return null; // NOT, AND, OR not handled yet
+        // Handle binary logical operations (AND, OR)
+        Expression left = (Expression) visit(ctx.getChild(0));
+        String operator = ctx.getChild(1).getText().toUpperCase();
+        Expression right = (Expression) visit(ctx.getChild(2));
+        return new BinaryOperation(left, operator, right);
     }
 
     @Override
     public Object visitDm_relational_expression(WebFocusReportParser.Dm_relational_expressionContext ctx) {
-        if (ctx.dm_concat_expression() != null && ctx.getChildCount() == 1) {
+        if (ctx.getChildCount() == 1) {
             return visit(ctx.dm_concat_expression(0));
         }
-        return null; // MISSING, FROM-TO, IN, etc not handled yet
+
+        // Case: INCLUDES / EXCLUDES
+        if (ctx.INCLUDES() != null || ctx.EXCLUDES() != null) {
+            Expression left = (Expression) visit(ctx.dm_concat_expression(0));
+            String op = ctx.INCLUDES() != null ? "CONTAINS" : "OMITS";
+            List<WebFocusReportParser.Dm_concat_expressionContext> exprs = ctx.dm_concat_expression();
+
+            Expression node = new BinaryOperation(left, op, (Expression) visit(exprs.get(1)));
+            for (int i = 2; i < exprs.size(); i++) {
+                Expression rightExpr = new BinaryOperation(left, op, (Expression) visit(exprs.get(i)));
+                node = new BinaryOperation(node, "AND", rightExpr);
+            }
+            return node;
+        }
+
+        // Case: Relational op with optional OR
+        if (ctx.dm_relational_op() != null) {
+            Expression left = (Expression) visit(ctx.dm_concat_expression(0));
+            String opText = ctx.dm_relational_op().getText().toUpperCase().replace("-", " ");
+            List<WebFocusReportParser.Dm_concat_expressionContext> exprs = ctx.dm_concat_expression();
+
+            Expression node = new BinaryOperation(left, opText, (Expression) visit(exprs.get(1)));
+            for (int i = 2; i < exprs.size(); i++) {
+                Expression rightExpr = new BinaryOperation(left, opText, (Expression) visit(exprs.get(i)));
+                node = new BinaryOperation(node, "OR", rightExpr);
+            }
+            return node;
+        }
+
+        return visit(ctx.getChild(0));
     }
 
     @Override
     public Object visitDm_concat_expression(WebFocusReportParser.Dm_concat_expressionContext ctx) {
-        if (ctx.dm_additive_expression() != null && ctx.getChildCount() == 1) {
-            return visit(ctx.dm_additive_expression(0));
+        if (ctx.getChildCount() == 1) {
+            return visit(ctx.getChild(0));
         }
-        return null; // CONCAT not handled yet
+        Expression left = (Expression) visit(ctx.getChild(0));
+        for (int i = 1; i < ctx.getChildCount(); i += 2) {
+            String operator = ctx.getChild(i).getText();
+            Expression right = (Expression) visit(ctx.getChild(i + 1));
+            left = new BinaryOperation(left, operator, right);
+        }
+        return left;
     }
 
     @Override
     public Object visitDm_additive_expression(WebFocusReportParser.Dm_additive_expressionContext ctx) {
-        if (ctx.dm_multiplicative_expression() != null && ctx.getChildCount() == 1) {
-            return visit(ctx.dm_multiplicative_expression(0));
+        if (ctx.getChildCount() == 1) {
+            return visit(ctx.getChild(0));
         }
-        return null; // ADD, SUB not handled yet
+        Expression left = (Expression) visit(ctx.getChild(0));
+        for (int i = 1; i < ctx.getChildCount(); i += 2) {
+            String operator = ctx.getChild(i).getText();
+            Expression right = (Expression) visit(ctx.getChild(i + 1));
+            left = new BinaryOperation(left, operator, right);
+        }
+        return left;
     }
 
     @Override
     public Object visitDm_multiplicative_expression(WebFocusReportParser.Dm_multiplicative_expressionContext ctx) {
-        if (ctx.dm_unary_expression() != null && ctx.getChildCount() == 1) {
-            return visit(ctx.dm_unary_expression(0));
+        if (ctx.getChildCount() == 1) {
+            return visit(ctx.getChild(0));
         }
-        return null; // MUL, DIV not handled yet
+        Expression left = (Expression) visit(ctx.getChild(0));
+        for (int i = 1; i < ctx.getChildCount(); i += 2) {
+            String operator = ctx.getChild(i).getText();
+            Expression right = (Expression) visit(ctx.getChild(i + 1));
+            left = new BinaryOperation(left, operator, right);
+        }
+        return left;
     }
 
     @Override
     public Object visitDm_unary_expression(WebFocusReportParser.Dm_unary_expressionContext ctx) {
-        if (ctx.dm_primary() != null) {
-            return visit(ctx.dm_primary());
+        if (ctx.getChildCount() == 1) {
+            return visit(ctx.getChild(0));
         }
-        return null; // Unary ops not handled yet
+        String operator = ctx.getChild(0).getText();
+        Expression operand = (Expression) visit(ctx.getChild(1));
+        return new UnaryOperation(operator, operand);
     }
 
     @Override

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -121,6 +121,91 @@ public class WebFocusReportASGBuilderTest {
         assertEquals(123, lit.value());
     }
 
+    @Test
+    public void testArithmeticOperations() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // Addition
+        WebFocusReportParser parser = createParser("1 + 2");
+        BinaryOperation op = (BinaryOperation) builder.visit(parser.dm_expression());
+        assertEquals("+", op.operator());
+        assertEquals(1, ((Literal) op.left()).value());
+        assertEquals(2, ((Literal) op.right()).value());
+
+        // Precedence: 1 + 2 * 3
+        parser = createParser("1 + 2 * 3");
+        op = (BinaryOperation) builder.visit(parser.dm_expression());
+        assertEquals("+", op.operator());
+        assertEquals(1, ((Literal) op.left()).value());
+        BinaryOperation rightOp = (BinaryOperation) op.right();
+        assertEquals("*", rightOp.operator());
+
+        // Unary: -1
+        parser = createParser("-1");
+        UnaryOperation unary = (UnaryOperation) builder.visit(parser.dm_expression());
+        assertEquals("-", unary.operator());
+        assertEquals(1, ((Literal) unary.operand()).value());
+    }
+
+    @Test
+    public void testLogicalOperations() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // AND
+        WebFocusReportParser parser = createParser("A AND B");
+        BinaryOperation op = (BinaryOperation) builder.visit(parser.dm_expression());
+        assertEquals("AND", op.operator());
+        assertEquals("A", ((Identifier) op.left()).name());
+        assertEquals("B", ((Identifier) op.right()).name());
+
+        // NOT
+        parser = createParser("NOT A");
+        UnaryOperation unary = (UnaryOperation) builder.visit(parser.dm_expression());
+        assertEquals("NOT", unary.operator());
+        assertEquals("A", ((Identifier) unary.operand()).name());
+    }
+
+    @Test
+    public void testRelationalOperations() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // EQ
+        WebFocusReportParser parser = createParser("A EQ B");
+        BinaryOperation op = (BinaryOperation) builder.visit(parser.dm_expression());
+        assertEquals("EQ", op.operator());
+
+        // Multiple RHS: A EQ B OR C
+        parser = createParser("A EQ B OR C");
+        op = (BinaryOperation) builder.visit(parser.dm_expression());
+        assertEquals("OR", op.operator());
+        BinaryOperation left = (BinaryOperation) op.left();
+        assertEquals("EQ", left.operator());
+        assertEquals("A", ((Identifier) left.left()).name());
+        assertEquals("B", ((Identifier) left.right()).name());
+        BinaryOperation right = (BinaryOperation) op.right();
+        assertEquals("EQ", right.operator());
+        assertEquals("A", ((Identifier) right.left()).name());
+        assertEquals("C", ((Identifier) right.right()).name());
+    }
+
+    @Test
+    public void testIncludesExcludes() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // INCLUDES
+        WebFocusReportParser parser = createParser("A INCLUDES B AND C");
+        BinaryOperation op = (BinaryOperation) builder.visit(parser.dm_expression());
+        assertEquals("AND", op.operator());
+        BinaryOperation left = (BinaryOperation) op.left();
+        assertEquals("CONTAINS", left.operator());
+        assertEquals("A", ((Identifier) left.left()).name());
+        assertEquals("B", ((Identifier) left.right()).name());
+        BinaryOperation right = (BinaryOperation) op.right();
+        assertEquals("CONTAINS", right.operator());
+        assertEquals("A", ((Identifier) right.left()).name());
+        assertEquals("C", ((Identifier) right.right()).name());
+    }
+
     private WebFocusReportParser createParser(String input) {
         WebFocusReportLexer lexer = new WebFocusReportLexer(CharStreams.fromString(input));
         return new WebFocusReportParser(new CommonTokenStream(lexer));


### PR DESCRIPTION
This PR implements Phase 3.1.2.2 of the `JAVA_PORT_ROADMAP.md`. It adds support for binary and unary operations in the `WebFocusReportASGBuilder`, enabling the transformation of complex expressions into the Abstract Semantic Graph (ASG). Key features include support for logical, relational, and arithmetic operations, as well as handling WebFocus-specific relational shorthands. The changes are verified by a new suite of unit tests.

Fixes #465

---
*PR created automatically by Jules for task [16221038692004483444](https://jules.google.com/task/16221038692004483444) started by @chatelao*