### PR TITLE
Implement Set-based expressions in Java ASG Builder

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -53,7 +53,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
     - [x] 3.1.2.2 Binary and Unary operations.
     - [ ] 3.1.2.3 Function calls and Built-in functions.
     - [x] 3.1.2.4 Conditional expressions (IfExpression, DecodeExpression).
-    - [ ] 3.1.2.5 Set-based expressions (IN, BETWEEN, IS MISSING).
+    - [x] 3.1.2.5 Set-based expressions (IN, BETWEEN, IS MISSING).
   - [ ] 3.1.3 Dialogue Manager Commands:
     - [ ] 3.1.3.1 Control Flow (Goto, Label, IfDM).
     - [ ] 3.1.3.2 Variables & Defaults (SetDM, DefaultDM).

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -191,6 +191,47 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
             return visit(ctx.dm_concat_expression(0));
         }
 
+        // Case: MISSING
+        if (ctx.MISSING() != null) {
+            Expression expr = (Expression) visit(ctx.dm_concat_expression(0));
+            boolean inverted = ctx.NE() != null || ctx.is_not_op() != null;
+            return new IsMissingExpression(expr, inverted);
+        }
+
+        // Case: FROM...TO
+        if (ctx.TO() != null) {
+            Expression expr = (Expression) visit(ctx.dm_concat_expression(0));
+            Expression lower = (Expression) visit(ctx.dm_concat_expression(1));
+            Expression upper = (Expression) visit(ctx.dm_concat_expression(2));
+            if (expr == null || lower == null || upper == null) {
+                return null;
+            }
+            Expression node = new BetweenExpression(expr, lower, upper);
+            if (ctx.not_from_op() != null) {
+                return new UnaryOperation("NOT", node);
+            }
+            return node;
+        }
+
+        // Case: IN
+        if (ctx.IN() != null) {
+            Expression expr = (Expression) visit(ctx.dm_concat_expression(0));
+            if (expr == null) return null;
+            if (ctx.FILE() != null) {
+                String filename = ctx.qualified_name().getText();
+                return new InExpression(expr, List.of(), filename);
+            } else {
+                List<Expression> values = new ArrayList<>();
+                for (int i = 1; i < ctx.dm_concat_expression().size(); i++) {
+                    Expression v = (Expression) visit(ctx.dm_concat_expression(i));
+                    if (v != null) {
+                        values.add(v);
+                    }
+                }
+                return new InExpression(expr, values);
+            }
+        }
+
         // Case: INCLUDES / EXCLUDES
         if (ctx.INCLUDES() != null || ctx.EXCLUDES() != null) {
             Expression left = (Expression) visit(ctx.dm_concat_expression(0));

--- a/src/main/java/com/transpiler/asg/InExpression.java
+++ b/src/main/java/com/transpiler/asg/InExpression.java
@@ -5,5 +5,12 @@ import java.util.List;
 /**
  * Represents an IN expression (e.g., field IN (val1, val2)).
  */
-public record InExpression(Expression expression, List<Expression> values) implements Expression {
+public record InExpression(Expression expression, List<Expression> values, String filename) implements Expression {
+    public InExpression {
+        values = List.copyOf(values);
+    }
+
+    public InExpression(Expression expression, List<Expression> values) {
+        this(expression, values, null);
+    }
 }

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -238,6 +238,49 @@ public class WebFocusReportASGBuilderTest {
         assertEquals(30, ((Literal) decodeExpr.defaultValue()).value());
     }
 
+    @Test
+    public void testSetBasedExpressions() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // IS MISSING
+        WebFocusReportParser parser = createParser("A IS MISSING");
+        IsMissingExpression missingExpr = (IsMissingExpression) builder.visit(parser.dm_expression());
+        assertEquals("A", ((Identifier) missingExpr.expression()).name());
+        assertFalse(missingExpr.inverted());
+
+        // IS NOT MISSING
+        parser = createParser("A IS NOT MISSING");
+        missingExpr = (IsMissingExpression) builder.visit(parser.dm_expression());
+        assertTrue(missingExpr.inverted());
+
+        // FROM...TO
+        parser = createParser("A FROM 1 TO 10");
+        BetweenExpression betweenExpr = (BetweenExpression) builder.visit(parser.dm_expression());
+        assertEquals("A", ((Identifier) betweenExpr.expression()).name());
+        assertEquals(1, ((Literal) betweenExpr.lower()).value());
+        assertEquals(10, ((Literal) betweenExpr.upper()).value());
+
+        // NOT FROM...TO
+        parser = createParser("A NOT FROM 1 TO 10");
+        UnaryOperation notBetween = (UnaryOperation) builder.visit(parser.dm_expression());
+        assertEquals("NOT", notBetween.operator());
+        assertTrue(notBetween.operand() instanceof BetweenExpression);
+
+        // IN (list)
+        parser = createParser("A IN (1, 2, 3)");
+        InExpression inExpr = (InExpression) builder.visit(parser.dm_expression());
+        assertEquals("A", ((Identifier) inExpr.expression()).name());
+        assertEquals(3, inExpr.values().size());
+        assertNull(inExpr.filename());
+
+        // IN FILE
+        parser = createParser("A IN FILE CAR");
+        inExpr = (InExpression) builder.visit(parser.dm_expression());
+        assertEquals("A", ((Identifier) inExpr.expression()).name());
+        assertEquals(0, inExpr.values().size());
+        assertEquals("CAR", inExpr.filename());
+    }
+
     private WebFocusReportParser createParser(String input) {
         WebFocusReportLexer lexer = new WebFocusReportLexer(CharStreams.fromString(input));
         return new WebFocusReportParser(new CommonTokenStream(lexer));


### PR DESCRIPTION
This PR implements the visitor logic for set-based expressions (IN, BETWEEN/FROM-TO, IS MISSING) in the Java WebFocusReportASGBuilder. It also updates the InExpression ASG node to support the IN FILE syntax and ensures immutability for its values list. Unit tests have been added to verify the new functionality.

Fixes #469

---
*PR created automatically by Jules for task [6140850107430477232](https://jules.google.com/task/6140850107430477232) started by @chatelao*