### PR TITLE
Implement Dialogue Manager Variable Command Visitor

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -56,7 +56,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
     - [x] 3.1.2.5 Set-based expressions (IN, BETWEEN, IS MISSING).
   - [ ] 3.1.3 Dialogue Manager Commands:
     - [ ] 3.1.3.1 Control Flow (Goto, Label, IfDM).
-    - [ ] 3.1.3.2 Variables & Defaults (SetDM, DefaultDM).
+    - [x] 3.1.3.2 Variables & Defaults (SetDM, DefaultDM).
     - [ ] 3.1.3.3 Output & I/O (TypeDM, HtmlFormDM, ReadDM, WriteDM, IncludeDM).
     - [ ] 3.1.3.4 Loops (Repeat).
     - [ ] 3.1.3.5 Execution Control (RunDM, ExitDM).

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -355,4 +355,18 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
     public Object visitDm_float(WebFocusReportParser.Dm_floatContext ctx) {
         return new Literal(Double.parseDouble(ctx.getText()));
     }
+
+    @Override
+    public Object visitDm_set(WebFocusReportParser.Dm_setContext ctx) {
+        String variable = ctx.amper_var().getText();
+        Expression expression = (Expression) visit(ctx.dm_expression());
+        return new SetDM(variable, expression);
+    }
+
+    @Override
+    public Object visitDm_default(WebFocusReportParser.Dm_defaultContext ctx) {
+        String variable = ctx.amper_var().getText();
+        Expression expression = (Expression) visit(ctx.dm_expression());
+        return new DefaultDM(variable, expression);
+    }
 }

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -239,6 +239,23 @@ public class WebFocusReportASGBuilderTest {
     }
 
     @Test
+    public void testSetAndDefaultCommands() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // -SET
+        WebFocusReportParser parser = createParser("-SET &VAR = 123;");
+        SetDM setDM = (SetDM) builder.visit(parser.dm_command());
+        assertEquals("&VAR", setDM.variable());
+        assertEquals(123, ((Literal) setDM.expression()).value());
+
+        // -DEFAULT
+        parser = createParser("-DEFAULT &VAR = 'Hello';");
+        DefaultDM defaultDM = (DefaultDM) builder.visit(parser.dm_command());
+        assertEquals("&VAR", defaultDM.variable());
+        assertEquals("Hello", ((Literal) defaultDM.expression()).value());
+    }
+
+    @Test
     public void testSetBasedExpressions() {
         WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
 


### PR DESCRIPTION
This change implements the visitor methods for Dialogue Manager variable commands (`-SET` and `-DEFAULT`) in the `WebFocusReportASGBuilder`. 

Key changes:
- Implemented `visitDm_set` to create `SetDM` ASG nodes.
- Implemented `visitDm_default` to create `DefaultDM` ASG nodes.
- Added a new test `testSetAndDefaultCommands` in `WebFocusReportASGBuilderTest` covering both command types with literal assignments.
- Updated `JAVA_PORT_ROADMAP.md` to mark step 3.1.3.2 (Variables & Defaults) as complete.

All 69 tests in the Java suite passed successfully.

Fixes #471

---
*PR created automatically by Jules for task [5249244200537458113](https://jules.google.com/task/5249244200537458113) started by @chatelao*