### PR TITLE
Implement DM Control Flow and Execution Control in Java ASG Builder

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -55,11 +55,11 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
     - [x] 3.1.2.4 Conditional expressions (IfExpression, DecodeExpression).
     - [x] 3.1.2.5 Set-based expressions (IN, BETWEEN, IS MISSING).
   - [ ] 3.1.3 Dialogue Manager Commands:
-    - [ ] 3.1.3.1 Control Flow (Goto, Label, IfDM).
+    - [x] 3.1.3.1 Control Flow (Goto, Label, IfDM).
     - [x] 3.1.3.2 Variables & Defaults (SetDM, DefaultDM).
     - [ ] 3.1.3.3 Output & I/O (TypeDM, HtmlFormDM, ReadDM, WriteDM, IncludeDM).
     - [ ] 3.1.3.4 Loops (Repeat).
-    - [ ] 3.1.3.5 Execution Control (RunDM, ExitDM).
+    - [x] 3.1.3.5 Execution Control (RunDM, ExitDM).
   - [ ] 3.1.4 Report Commands:
     - [ ] 3.1.4.1 Verb Commands (PRINT, SUM, etc.) and Field Selections.
     - [ ] 3.1.4.2 Sort Commands (BY, ACROSS).

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -369,4 +369,33 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
         Expression expression = (Expression) visit(ctx.dm_expression());
         return new DefaultDM(variable, expression);
     }
+
+    @Override
+    public Object visitDm_goto(WebFocusReportParser.Dm_gotoContext ctx) {
+        return new Goto(ctx.NAME().getText());
+    }
+
+    @Override
+    public Object visitDm_label(WebFocusReportParser.Dm_labelContext ctx) {
+        // LABEL_DM starts with '-'
+        return new Label(ctx.LABEL_DM().getText().substring(1));
+    }
+
+    @Override
+    public Object visitDm_if(WebFocusReportParser.Dm_ifContext ctx) {
+        Expression condition = (Expression) visit(ctx.dm_logical_expression());
+        String thenTarget = ctx.NAME(0).getText();
+        String elseTarget = ctx.NAME().size() > 1 ? ctx.NAME(1).getText() : null;
+        return new IfDM(condition, thenTarget, elseTarget);
+    }
+
+    @Override
+    public Object visitDm_run(WebFocusReportParser.Dm_runContext ctx) {
+        return new RunDM();
+    }
+
+    @Override
+    public Object visitDm_exit(WebFocusReportParser.Dm_exitContext ctx) {
+        return new ExitDM();
+    }
 }

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -298,6 +298,49 @@ public class WebFocusReportASGBuilderTest {
         assertEquals("CAR", inExpr.filename());
     }
 
+    @Test
+    public void testControlFlowCommands() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // -GOTO
+        WebFocusReportParser parser = createParser("-GOTO TARGET;");
+        Goto gotoNode = (Goto) builder.visit(parser.dm_command());
+        assertEquals("TARGET", gotoNode.target());
+
+        // -LABEL
+        parser = createParser("-TARGET");
+        Label labelNode = (Label) builder.visit(parser.dm_command());
+        assertEquals("TARGET", labelNode.name());
+
+        // -IF
+        parser = createParser("-IF &VAR EQ 1 THEN GOTO TARGET1 ELSE GOTO TARGET2;");
+        IfDM ifDM = (IfDM) builder.visit(parser.dm_command());
+        assertTrue(ifDM.condition() instanceof BinaryOperation);
+        assertEquals("TARGET1", ifDM.thenTarget());
+        assertEquals("TARGET2", ifDM.elseTarget());
+
+        // -IF without ELSE
+        parser = createParser("-IF &VAR EQ 1 THEN GOTO TARGET1;");
+        ifDM = (IfDM) builder.visit(parser.dm_command());
+        assertEquals("TARGET1", ifDM.thenTarget());
+        assertNull(ifDM.elseTarget());
+    }
+
+    @Test
+    public void testExecutionControlCommands() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // -RUN
+        WebFocusReportParser parser = createParser("-RUN;");
+        RunDM runDM = (RunDM) builder.visit(parser.dm_command());
+        assertNotNull(runDM);
+
+        // -EXIT
+        parser = createParser("-EXIT;");
+        ExitDM exitDM = (ExitDM) builder.visit(parser.dm_command());
+        assertNotNull(exitDM);
+    }
+
     private WebFocusReportParser createParser(String input) {
         WebFocusReportLexer lexer = new WebFocusReportLexer(CharStreams.fromString(input));
         return new WebFocusReportParser(new CommonTokenStream(lexer));


### PR DESCRIPTION
Implemented visitor methods for Dialogue Manager control flow (-GOTO, -LABEL, -IF) and execution control (-RUN, -EXIT) commands in `WebFocusReportASGBuilder.java`. Added corresponding unit tests in `WebFocusReportASGBuilderTest.java` and updated `JAVA_PORT_ROADMAP.md` to mark steps 3.1.3.1 and 3.1.3.5 as complete. Verified the changes with `mvn test`, with all 71 tests passing.

Fixes #473

---
*PR created automatically by Jules for task [1860454085078896254](https://jules.google.com/task/1860454085078896254) started by @chatelao*