### PR TITLE
Implement FunctionCall support and refine roadmap

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -51,17 +51,24 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
   - [ ] 3.1.2 Expressions:
     - [x] 3.1.2.1 Literals, Identifiers, and AmperVars.
     - [x] 3.1.2.2 Binary and Unary operations.
-    - [ ] 3.1.2.3 Function calls and Built-in functions.
+    - [x] 3.1.2.3 Function calls and Built-in functions.
     - [x] 3.1.2.4 Conditional expressions (IfExpression, DecodeExpression).
     - [x] 3.1.2.5 Set-based expressions (IN, BETWEEN, IS MISSING).
   - [ ] 3.1.3 Dialogue Manager Commands:
     - [x] 3.1.3.1 Control Flow (Goto, Label, IfDM).
     - [x] 3.1.3.2 Variables & Defaults (SetDM, DefaultDM).
-    - [ ] 3.1.3.3 Output & I/O (TypeDM, HtmlFormDM, ReadDM, WriteDM, IncludeDM).
+    - [ ] 3.1.3.3 Output & I/O:
+      - [ ] 3.1.3.3.1 TypeDM.
+      - [ ] 3.1.3.3.2 HtmlFormDM.
+      - [ ] 3.1.3.3.3 ReadDM.
+      - [ ] 3.1.3.3.4 WriteDM.
+      - [ ] 3.1.3.3.5 IncludeDM.
     - [ ] 3.1.3.4 Loops (Repeat).
     - [x] 3.1.3.5 Execution Control (RunDM, ExitDM).
   - [ ] 3.1.4 Report Commands:
-    - [ ] 3.1.4.1 Verb Commands (PRINT, SUM, etc.) and Field Selections.
+    - [ ] 3.1.4.1 Verb Commands:
+      - [x] 3.1.4.1.1 Basic Verb and Field Selection.
+      - [x] 3.1.4.1.2 Prefix Operators.
     - [ ] 3.1.4.2 Sort Commands (BY, ACROSS).
     - [ ] 3.1.4.3 Filter Commands (WHERE, WHEN).
     - [ ] 3.1.4.4 Formatting (HEADING, FOOTING, ON ... SUBHEAD/SUBFOOT).

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -325,7 +325,12 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
         }
         if (ctx.qualified_name() != null) {
             if (ctx.getChildCount() > 1 && ctx.getChild(1).getText().equals("(")) {
-                return null; // FunctionCall not handled yet
+                String functionName = ctx.qualified_name().getText().toUpperCase();
+                List<Expression> arguments = new ArrayList<>();
+                for (var exprCtx : ctx.dm_expression()) {
+                    arguments.add((Expression) visit(exprCtx));
+                }
+                return new FunctionCall(functionName, arguments);
             } else {
                 return new Identifier(ctx.qualified_name().getText());
             }

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -327,6 +327,26 @@ public class WebFocusReportASGBuilderTest {
     }
 
     @Test
+    public void testFunctionCall() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // ABS(HEIGHT)
+        WebFocusReportParser parser = createParser("ABS(HEIGHT)");
+        FunctionCall call = (FunctionCall) builder.visit(parser.dm_expression());
+        assertEquals("ABS", call.functionName());
+        assertEquals(1, call.arguments().size());
+        assertEquals("HEIGHT", ((Identifier) call.arguments().get(0)).name());
+
+        // MAX(1, 2) - testing multiple arguments if supported by grammar
+        parser = createParser("MAX(1, 2)");
+        call = (FunctionCall) builder.visit(parser.dm_expression());
+        assertEquals("MAX", call.functionName());
+        assertEquals(2, call.arguments().size());
+        assertEquals(1, ((Literal) call.arguments().get(0)).value());
+        assertEquals(2, ((Literal) call.arguments().get(1)).value());
+    }
+
+    @Test
     public void testExecutionControlCommands() {
         WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
 


### PR DESCRIPTION
Implemented a modest step in the Java port of the WebFOCUS transpiler by adding support for function calls in the ASG builder. This included updating the visitor to handle function names and arguments, and adding corresponding unit tests. Additionally, I refined the `JAVA_PORT_ROADMAP.md` by breaking down larger, vague tasks (like Output & I/O and Verb Commands) into more specific, actionable sub-tasks, and updating their status to reflect current progress.

Fixes #475

---
*PR created automatically by Jules for task [6015306677911997692](https://jules.google.com/task/6015306677911997692) started by @chatelao*