### PR TITLE
Implement DM -INCLUDE and -HTMLFORM visitors in Java ASG Builder

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -59,10 +59,10 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
     - [x] 3.1.3.2 Variables & Defaults (SetDM, DefaultDM).
     - [ ] 3.1.3.3 Output & I/O:
       - [ ] 3.1.3.3.1 TypeDM.
-      - [ ] 3.1.3.3.2 HtmlFormDM.
+      - [x] 3.1.3.3.2 HtmlFormDM.
       - [ ] 3.1.3.3.3 ReadDM.
       - [ ] 3.1.3.3.4 WriteDM.
-      - [ ] 3.1.3.3.5 IncludeDM.
+      - [x] 3.1.3.3.5 IncludeDM.
     - [ ] 3.1.3.4 Loops (Repeat).
     - [x] 3.1.3.5 Execution Control (RunDM, ExitDM).
   - [ ] 3.1.4 Report Commands:

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -403,4 +403,17 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
     public Object visitDm_exit(WebFocusReportParser.Dm_exitContext ctx) {
         return new ExitDM();
     }
+
+    @Override
+    public Object visitDm_include(WebFocusReportParser.Dm_includeContext ctx) {
+        return new IncludeDM(ctx.qualified_name().getText());
+    }
+
+    @Override
+    public Object visitDm_htmlform(WebFocusReportParser.Dm_htmlformContext ctx) {
+        if (ctx.HTMLFORM_BLOCK() != null) {
+            return new HtmlFormDM(null, ctx.HTMLFORM_BLOCK().getText());
+        }
+        return new HtmlFormDM(ctx.qualified_name().getText(), null);
+    }
 }

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -361,6 +361,31 @@ public class WebFocusReportASGBuilderTest {
         assertNotNull(exitDM);
     }
 
+    @Test
+    public void testIncludeCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+        WebFocusReportParser parser = createParser("-INCLUDE MYFILE;");
+        IncludeDM includeDM = (IncludeDM) builder.visit(parser.dm_command());
+        assertEquals("MYFILE", includeDM.filename());
+    }
+
+    @Test
+    public void testHtmlFormCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // File-based
+        WebFocusReportParser parser = createParser("-HTMLFORM MYFORM;");
+        HtmlFormDM formDM = (HtmlFormDM) builder.visit(parser.dm_command());
+        assertEquals("MYFORM", formDM.filename());
+        assertNull(formDM.content());
+
+        // Block-based
+        parser = createParser("-HTMLFORM BEGIN\n<html><body>Hello</body></html>\n-HTMLFORM END");
+        formDM = (HtmlFormDM) builder.visit(parser.dm_command());
+        assertNull(formDM.filename());
+        assertTrue(formDM.content().contains("<html><body>Hello</body></html>"));
+    }
+
     private WebFocusReportParser createParser(String input) {
         WebFocusReportLexer lexer = new WebFocusReportLexer(CharStreams.fromString(input));
         return new WebFocusReportParser(new CommonTokenStream(lexer));


### PR DESCRIPTION
Implemented `-INCLUDE` and `-HTMLFORM` visitor logic in `WebFocusReportASGBuilder.java` and verified with unit tests. Updated the roadmap to track progress.

Fixes #477

---
*PR created automatically by Jules for task [4125944876875467019](https://jules.google.com/task/4125944876875467019) started by @chatelao*