### PR TITLE
Implement Dialogue Manager I/O and Loop commands in Java ASG Builder

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -54,23 +54,28 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
     - [x] 3.1.2.3 Function calls and Built-in functions.
     - [x] 3.1.2.4 Conditional expressions (IfExpression, DecodeExpression).
     - [x] 3.1.2.5 Set-based expressions (IN, BETWEEN, IS MISSING).
-  - [ ] 3.1.3 Dialogue Manager Commands:
+  - [x] 3.1.3 Dialogue Manager Commands:
     - [x] 3.1.3.1 Control Flow (Goto, Label, IfDM).
     - [x] 3.1.3.2 Variables & Defaults (SetDM, DefaultDM).
-    - [ ] 3.1.3.3 Output & I/O:
-      - [ ] 3.1.3.3.1 TypeDM.
+    - [x] 3.1.3.3 Output & I/O:
+      - [x] 3.1.3.3.1 TypeDM.
       - [x] 3.1.3.3.2 HtmlFormDM.
-      - [ ] 3.1.3.3.3 ReadDM.
-      - [ ] 3.1.3.3.4 WriteDM.
+      - [x] 3.1.3.3.3 ReadDM.
+      - [x] 3.1.3.3.4 WriteDM.
       - [x] 3.1.3.3.5 IncludeDM.
-    - [ ] 3.1.3.4 Loops (Repeat).
+    - [x] 3.1.3.4 Loops (Repeat).
     - [x] 3.1.3.5 Execution Control (RunDM, ExitDM).
   - [ ] 3.1.4 Report Commands:
     - [ ] 3.1.4.1 Verb Commands:
       - [x] 3.1.4.1.1 Basic Verb and Field Selection.
       - [x] 3.1.4.1.2 Prefix Operators.
-    - [ ] 3.1.4.2 Sort Commands (BY, ACROSS).
-    - [ ] 3.1.4.3 Filter Commands (WHERE, WHEN).
+    - [ ] 3.1.4.2 Sort Commands:
+      - [ ] 3.1.4.2.1 BY phrase and sort options (NOPRINT, AS, etc.).
+      - [ ] 3.1.4.2.2 ACROSS phrase and ACROSS-TOTAL.
+    - [ ] 3.1.4.3 Filter Commands:
+      - [ ] 3.1.4.3.1 WHERE clause and relational expressions.
+      - [ ] 3.1.4.3.2 WHERE TOTAL (HAVING) clause.
+      - [ ] 3.1.4.3.3 WHEN clause (Dialogue Manager filtering).
     - [ ] 3.1.4.4 Formatting (HEADING, FOOTING, ON ... SUBHEAD/SUBFOOT).
     - [ ] 3.1.4.5 Calculations (COMPUTE, RECAP).
     - [ ] 3.1.4.6 Summarization (SUBTOTAL, SUMMARIZE).

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -416,4 +416,83 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
         }
         return new HtmlFormDM(ctx.qualified_name().getText(), null);
     }
+
+    @Override
+    public Object visitDm_type(WebFocusReportParser.Dm_typeContext ctx) {
+        List<Expression> messages = new ArrayList<>();
+        for (var prim : ctx.dm_primary()) {
+            messages.add((Expression) visit(prim));
+        }
+        return new TypeDM(messages);
+    }
+
+    @Override
+    public Object visitDm_read(WebFocusReportParser.Dm_readContext ctx) {
+        String filename = ctx.qualified_name().getText();
+        List<String> variables = new ArrayList<>();
+
+        String currentVar = null;
+        for (int i = 2; i < ctx.getChildCount(); i++) {
+            var child = ctx.getChild(i);
+            if (child instanceof WebFocusReportParser.Amper_varContext) {
+                if (currentVar != null) {
+                    variables.add(currentVar);
+                }
+                currentVar = child.getText();
+            } else if (child instanceof WebFocusReportParser.Format_nameContext) {
+                currentVar += "." + child.getText();
+                variables.add(currentVar);
+                currentVar = null;
+            } else if (child instanceof TerminalNode && child.getText().equals(";")) {
+                if (currentVar != null) {
+                    variables.add(currentVar);
+                }
+                currentVar = null;
+            }
+        }
+        if (currentVar != null) {
+            variables.add(currentVar);
+        }
+        return new ReadDM(filename, variables);
+    }
+
+    @Override
+    public Object visitDm_write(WebFocusReportParser.Dm_writeContext ctx) {
+        String filename = ctx.qualified_name().getText();
+        List<Expression> messages = new ArrayList<>();
+        for (var prim : ctx.dm_primary()) {
+            messages.add((Expression) visit(prim));
+        }
+        return new WriteDM(filename, messages);
+    }
+
+    @Override
+    public Object visitDm_repeat(WebFocusReportParser.Dm_repeatContext ctx) {
+        String label = ctx.NAME().getText();
+        Expression condition = null;
+        String conditionType = null;
+        Expression times = null;
+        String loopVar = null;
+        Expression startVal = null;
+        Expression endVal = null;
+        Expression stepVal = null;
+
+        if (ctx.WHILE() != null) {
+            condition = (Expression) visit(ctx.dm_logical_expression());
+            conditionType = "WHILE";
+        } else if (ctx.UNTIL() != null) {
+            condition = (Expression) visit(ctx.dm_logical_expression());
+            conditionType = "UNTIL";
+        } else if (ctx.TIMES() != null) {
+            times = (Expression) visit(ctx.dm_primary(0));
+        } else if (ctx.FOR() != null) {
+            loopVar = ctx.amper_var().getText();
+            startVal = (Expression) visit(ctx.dm_primary(0));
+            endVal = (Expression) visit(ctx.dm_primary(1));
+            if (ctx.STEP() != null) {
+                stepVal = (Expression) visit(ctx.dm_primary(2));
+            }
+        }
+        return new Repeat(label, condition, conditionType, times, loopVar, startVal, endVal, stepVal);
+    }
 }

--- a/src/main/java/com/transpiler/asg/TypeDM.java
+++ b/src/main/java/com/transpiler/asg/TypeDM.java
@@ -5,7 +5,7 @@ import java.util.List;
 /**
  * Represents a Dialogue Manager -TYPE command.
  */
-public record TypeDM(List<String> messages) implements Command {
+public record TypeDM(List<Expression> messages) implements Command {
     public TypeDM {
         messages = List.copyOf(messages);
     }

--- a/src/main/java/com/transpiler/asg/WriteDM.java
+++ b/src/main/java/com/transpiler/asg/WriteDM.java
@@ -5,7 +5,7 @@ import java.util.List;
 /**
  * Represents a Dialogue Manager -WRITE command.
  */
-public record WriteDM(String filename, List<String> messages) implements Command {
+public record WriteDM(String filename, List<Expression> messages) implements Command {
     public WriteDM {
         messages = List.copyOf(messages);
     }

--- a/src/main/java/com/transpiler/ir/Type.java
+++ b/src/main/java/com/transpiler/ir/Type.java
@@ -1,11 +1,12 @@
 package com.transpiler.ir;
 
+import com.transpiler.asg.Expression;
 import java.util.List;
 
 /**
  * Represents a -TYPE message in the IR.
  */
-public record Type(List<String> messages) implements Instruction {
+public record Type(List<Expression> messages) implements Instruction {
     public Type {
         messages = List.copyOf(messages);
     }

--- a/src/main/java/com/transpiler/ir/Write.java
+++ b/src/main/java/com/transpiler/ir/Write.java
@@ -1,11 +1,12 @@
 package com.transpiler.ir;
 
+import com.transpiler.asg.Expression;
 import java.util.List;
 
 /**
  * Represents a -WRITE command in the IR.
  */
-public record Write(String filename, List<String> messages) implements Instruction {
+public record Write(String filename, List<Expression> messages) implements Instruction {
     public Write {
         messages = List.copyOf(messages);
     }

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -386,6 +386,64 @@ public class WebFocusReportASGBuilderTest {
         assertTrue(formDM.content().contains("<html><body>Hello</body></html>"));
     }
 
+    @Test
+    public void testTypeCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+        WebFocusReportParser parser = createParser("-TYPE Hello &VAR World;");
+        TypeDM typeDM = (TypeDM) builder.visit(parser.dm_command());
+        assertEquals(3, typeDM.messages().size());
+        assertEquals("Hello", ((Identifier) typeDM.messages().get(0)).name());
+        assertEquals("&VAR", ((AmperVar) typeDM.messages().get(1)).name());
+        assertEquals("World", ((Identifier) typeDM.messages().get(2)).name());
+    }
+
+    @Test
+    public void testReadCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+        WebFocusReportParser parser = createParser("-READ MYFILE &VAR1.A10 &VAR2;");
+        ReadDM readDM = (ReadDM) builder.visit(parser.dm_command());
+        assertEquals("MYFILE", readDM.filename());
+        assertEquals(2, readDM.variables().size());
+        assertEquals("&VAR1.A10", readDM.variables().get(0));
+        assertEquals("&VAR2", readDM.variables().get(1));
+    }
+
+    @Test
+    public void testWriteCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+        WebFocusReportParser parser = createParser("-WRITE MYFILE 'Result is ' &RESULT;");
+        WriteDM writeDM = (WriteDM) builder.visit(parser.dm_command());
+        assertEquals("MYFILE", writeDM.filename());
+        assertEquals(2, writeDM.messages().size());
+        assertEquals("Result is ", ((Literal) writeDM.messages().get(0)).value());
+        assertEquals("&RESULT", ((AmperVar) writeDM.messages().get(1)).name());
+    }
+
+    @Test
+    public void testRepeatCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // WHILE
+        WebFocusReportParser parser = createParser("-REPEAT MYLOOP WHILE &I LT 10;");
+        Repeat repeat = (Repeat) builder.visit(parser.dm_command());
+        assertEquals("MYLOOP", repeat.label());
+        assertEquals("WHILE", repeat.conditionType());
+        assertTrue(repeat.condition() instanceof BinaryOperation);
+
+        // TIMES
+        parser = createParser("-REPEAT MYLOOP 5 TIMES;");
+        repeat = (Repeat) builder.visit(parser.dm_command());
+        assertEquals(5, ((Literal) repeat.times()).value());
+
+        // FOR
+        parser = createParser("-REPEAT MYLOOP FOR &I FROM 1 TO 10 STEP 2;");
+        repeat = (Repeat) builder.visit(parser.dm_command());
+        assertEquals("&I", repeat.loopVar());
+        assertEquals(1, ((Literal) repeat.startVal()).value());
+        assertEquals(10, ((Literal) repeat.endVal()).value());
+        assertEquals(2, ((Literal) repeat.stepVal()).value());
+    }
+
     private WebFocusReportParser createParser(String input) {
         WebFocusReportLexer lexer = new WebFocusReportLexer(CharStreams.fromString(input));
         return new WebFocusReportParser(new CommonTokenStream(lexer));

--- a/src/test/java/com/transpiler/asg/ASGParityTest.java
+++ b/src/test/java/com/transpiler/asg/ASGParityTest.java
@@ -123,8 +123,8 @@ class ASGParityTest {
         assertEquals("&VAR", setNode.variable());
         assertEquals(new Literal("100"), setNode.expression());
 
-        TypeDM typeNode = new TypeDM(List.of("Hello", "World"));
-        assertEquals(List.of("Hello", "World"), typeNode.messages());
+        TypeDM typeNode = new TypeDM(List.of(new Literal("Hello"), new Literal("World")));
+        assertEquals(List.of(new Literal("Hello"), new Literal("World")), typeNode.messages());
 
         IncludeDM includeNode = new IncludeDM("MYFEX.FEX");
         assertEquals("MYFEX.FEX", includeNode.filename());

--- a/src/test/java/com/transpiler/asg/CommandTest.java
+++ b/src/test/java/com/transpiler/asg/CommandTest.java
@@ -1,6 +1,7 @@
 package com.transpiler.asg;
 
 import org.junit.jupiter.api.Test;
+import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CommandTest {
@@ -73,11 +74,12 @@ class CommandTest {
 
     @Test
     void testWriteDM() {
-        WriteDM writeDM = new WriteDM("LOGFILE", java.util.List.of("Message 1", "Message 2"));
+        List<Expression> messages = List.of(new Literal("Message 1"), new Literal("Message 2"));
+        WriteDM writeDM = new WriteDM("LOGFILE", messages);
 
         assertEquals("LOGFILE", writeDM.filename());
         assertEquals(2, writeDM.messages().size());
-        assertEquals("Message 1", writeDM.messages().get(0));
+        assertEquals(new Literal("Message 1"), writeDM.messages().get(0));
         assertTrue(writeDM instanceof Command);
     }
 

--- a/src/test/java/com/transpiler/ir/ProcedureInstructionTest.java
+++ b/src/test/java/com/transpiler/ir/ProcedureInstructionTest.java
@@ -1,5 +1,7 @@
 package com.transpiler.ir;
 
+import com.transpiler.asg.Expression;
+import com.transpiler.asg.Literal;
 import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
@@ -9,18 +11,18 @@ class ProcedureInstructionTest {
 
     @Test
     void testType() {
-        List<String> messages = List.of("Hello", "World");
+        List<Expression> messages = List.of(new Literal("Hello"), new Literal("World"));
         Type type = new Type(messages);
         assertEquals(messages, type.messages());
 
         // Verify immutability
-        List<String> mutableMessages = new ArrayList<>();
-        mutableMessages.add("Test");
+        List<Expression> mutableMessages = new ArrayList<>();
+        mutableMessages.add(new Literal("Test"));
         Type type2 = new Type(mutableMessages);
-        mutableMessages.add("Changed");
+        mutableMessages.add(new Literal("Changed"));
         assertEquals(1, type2.messages().size());
-        assertEquals("Test", type2.messages().get(0));
-        assertThrows(UnsupportedOperationException.class, () -> type2.messages().add("New"));
+        assertEquals(new Literal("Test"), type2.messages().get(0));
+        assertThrows(UnsupportedOperationException.class, () -> type2.messages().add(new Literal("New")));
     }
 
     @Test
@@ -63,16 +65,16 @@ class ProcedureInstructionTest {
 
     @Test
     void testWrite() {
-        List<String> msgs = List.of("Line 1", "Line 2");
+        List<Expression> msgs = List.of(new Literal("Line 1"), new Literal("Line 2"));
         Write write = new Write("output.txt", msgs);
         assertEquals("output.txt", write.filename());
         assertEquals(msgs, write.messages());
 
         // Verify immutability
-        List<String> mutableMsgs = new ArrayList<>();
-        mutableMsgs.add("m");
+        List<Expression> mutableMsgs = new ArrayList<>();
+        mutableMsgs.add(new Literal("m"));
         Write write2 = new Write("file", mutableMsgs);
-        mutableMsgs.add("m2");
+        mutableMsgs.add(new Literal("m2"));
         assertEquals(1, write2.messages().size());
     }
 }


### PR DESCRIPTION
This change implements the remaining Dialogue Manager commands in the WebFocusReportASGBuilder: -TYPE, -READ, -WRITE, and -REPEAT. It also refines the JAVA_PORT_ROADMAP.md by breaking down Sort and Filter commands into smaller sub-tasks and marking Phase 3.1.3 as complete. Additionally, Type and Write nodes were updated to support List<Expression> for message content.

Fixes #479

---
*PR created automatically by Jules for task [6537590003925456931](https://jules.google.com/task/6537590003925456931) started by @chatelao*