### PR TITLE
Implement ASG building for WHERE and WHERE TOTAL clauses

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -73,8 +73,8 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
       - [ ] 3.1.4.2.1 BY phrase and sort options (NOPRINT, AS, etc.).
       - [ ] 3.1.4.2.2 ACROSS phrase and ACROSS-TOTAL.
     - [ ] 3.1.4.3 Filter Commands:
-      - [ ] 3.1.4.3.1 WHERE clause and relational expressions.
-      - [ ] 3.1.4.3.2 WHERE TOTAL (HAVING) clause.
+      - [x] 3.1.4.3.1 WHERE clause and relational expressions.
+      - [x] 3.1.4.3.2 WHERE TOTAL (HAVING) clause.
       - [ ] 3.1.4.3.3 WHEN clause (Dialogue Manager filtering).
     - [ ] 3.1.4.4 Formatting (HEADING, FOOTING, ON ... SUBHEAD/SUBFOOT).
     - [ ] 3.1.4.5 Calculations (COMPUTE, RECAP).

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -37,6 +37,13 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
     }
 
     @Override
+    public Object visitWhere_command(WebFocusReportParser.Where_commandContext ctx) {
+        boolean isTotal = ctx.TOTAL() != null;
+        Expression condition = (Expression) visit(ctx.dm_logical_expression());
+        return new WhereClause(condition, isTotal);
+    }
+
+    @Override
     public Object visitRequest(WebFocusReportParser.RequestContext ctx) {
         String filename = (String) visit(ctx.table_file());
         List<Command> components = new ArrayList<>();

--- a/src/main/java/com/transpiler/asg/WhereClause.java
+++ b/src/main/java/com/transpiler/asg/WhereClause.java
@@ -4,7 +4,7 @@ package com.transpiler.asg;
  * Represents a WHERE clause in a report request.
  */
 public record WhereClause(
-    String condition,
+    Expression condition,
     boolean isTotal
 ) implements Command {
 }

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -420,6 +420,27 @@ public class WebFocusReportASGBuilderTest {
     }
 
     @Test
+    public void testWhereCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // WHERE
+        WebFocusReportParser parser = createParser("WHERE COUNTRY EQ 'USA'");
+        WhereClause where = (WhereClause) builder.visit(parser.where_command());
+        assertFalse(where.isTotal());
+        assertTrue(where.condition() instanceof BinaryOperation);
+        BinaryOperation op = (BinaryOperation) where.condition();
+        assertEquals("EQ", op.operator());
+        assertEquals("COUNTRY", ((Identifier) op.left()).name());
+        assertEquals("USA", ((Literal) op.right()).value());
+
+        // WHERE TOTAL
+        parser = createParser("WHERE TOTAL SALARY GT 50000");
+        where = (WhereClause) builder.visit(parser.where_command());
+        assertTrue(where.isTotal());
+        assertTrue(where.condition() instanceof BinaryOperation);
+    }
+
+    @Test
     public void testRepeatCommand() {
         WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
 

--- a/src/test/java/com/transpiler/asg/ASGParityTest.java
+++ b/src/test/java/com/transpiler/asg/ASGParityTest.java
@@ -21,7 +21,7 @@ class ASGParityTest {
         assertEquals("HOLD", hold.outputType());
         assertEquals("MYHOLD", hold.filename());
 
-        MoreSubRequest moreSub = new MoreSubRequest("FILE2", List.of(new WhereClause("COUNTRY EQ 'USA'", false)));
+        MoreSubRequest moreSub = new MoreSubRequest("FILE2", List.of(new WhereClause(new BinaryOperation(new Identifier("COUNTRY"), "EQ", new Literal("USA")), false)));
         MoreClause more = new MoreClause(List.of(moreSub));
         assertEquals(1, more.subRequests().size());
         assertEquals("FILE2", more.subRequests().get(0).filename());
@@ -150,8 +150,9 @@ class ASGParityTest {
         assertEquals("BY", sort.sortType());
         assertEquals("DEPARTMENT", sort.field().name());
 
-        WhereClause where = new WhereClause("SALARY GT 50000", false);
-        assertEquals("SALARY GT 50000", where.condition());
+        Expression whereCond = new BinaryOperation(new Identifier("SALARY"), "GT", new Literal(50000));
+        WhereClause where = new WhereClause(whereCond, false);
+        assertEquals(whereCond, where.condition());
         assertFalse(where.isTotal());
 
         Heading heading = new Heading("Employee Report", true);


### PR DESCRIPTION
This change implements the visitWhere_command in WebFocusReportASGBuilder to support standard WHERE and WHERE TOTAL (HAVING) clauses in report requests. It also refactors the WhereClause ASG node to use structured Expression nodes instead of raw strings, improving type safety and consistency with the rest of the ASG. Existing tests were updated and new unit tests were added to verify the implementation.

Fixes #482

---
*PR created automatically by Jules for task [8672079323206718687](https://jules.google.com/task/8672079323206718687) started by @chatelao*