### PR TITLE
Implement HEADING and FOOTING command visitors in Java ASG Builder

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -76,7 +76,9 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
       - [x] 3.1.4.3.1 WHERE clause and relational expressions.
       - [x] 3.1.4.3.2 WHERE TOTAL (HAVING) clause.
       - [ ] 3.1.4.3.3 WHEN clause (Dialogue Manager filtering).
-    - [ ] 3.1.4.4 Formatting (HEADING, FOOTING, ON ... SUBHEAD/SUBFOOT).
+    - [ ] 3.1.4.4 Formatting:
+      - [x] 3.1.4.4.1 HEADING and FOOTING.
+      - [ ] 3.1.4.4.2 ON ... SUBHEAD/SUBFOOT.
     - [ ] 3.1.4.5 Calculations (COMPUTE, RECAP).
     - [ ] 3.1.4.6 Summarization (SUBTOTAL, SUMMARIZE).
   - [ ] 3.1.5 Advanced Features:

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -5,6 +5,7 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Transforms a WebFocusReport parse tree into an Abstract Semantic Graph (ASG).
@@ -501,5 +502,23 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
             }
         }
         return new Repeat(label, condition, conditionType, times, loopVar, startVal, endVal, stepVal);
+    }
+
+    @Override
+    public Object visitHeading_command(WebFocusReportParser.Heading_commandContext ctx) {
+        boolean centered = ctx.CENTER() != null;
+        String text = ctx.STRING().stream()
+                .map(s -> s.getText().substring(1, s.getText().length() - 1))
+                .collect(Collectors.joining(" "));
+        return new Heading(text, centered);
+    }
+
+    @Override
+    public Object visitFooting_command(WebFocusReportParser.Footing_commandContext ctx) {
+        boolean centered = ctx.CENTER() != null;
+        String text = ctx.STRING().stream()
+                .map(s -> s.getText().substring(1, s.getText().length() - 1))
+                .collect(Collectors.joining(" "));
+        return new Footing(text, centered);
     }
 }

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -465,6 +465,40 @@ public class WebFocusReportASGBuilderTest {
         assertEquals(2, ((Literal) repeat.stepVal()).value());
     }
 
+    @Test
+    public void testHeadingCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // HEADING simple
+        WebFocusReportParser parser = createParser("HEADING \"My Report\"");
+        Heading heading = (Heading) builder.visit(parser.heading_command());
+        assertEquals("My Report", heading.text());
+        assertFalse(heading.centered());
+
+        // HEADING centered with multiple strings
+        parser = createParser("HEADING CENTER \"Line 1\" \"Line 2\"");
+        heading = (Heading) builder.visit(parser.heading_command());
+        assertEquals("Line 1 Line 2", heading.text());
+        assertTrue(heading.centered());
+    }
+
+    @Test
+    public void testFootingCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // FOOTING simple
+        WebFocusReportParser parser = createParser("FOOTING \"End of Report\"");
+        Footing footing = (Footing) builder.visit(parser.footing_command());
+        assertEquals("End of Report", footing.text());
+        assertFalse(footing.centered());
+
+        // FOOTING centered
+        parser = createParser("FOOTING CENTER \"Confidential\"");
+        footing = (Footing) builder.visit(parser.footing_command());
+        assertEquals("Confidential", footing.text());
+        assertTrue(footing.centered());
+    }
+
     private WebFocusReportParser createParser(String input) {
         WebFocusReportLexer lexer = new WebFocusReportLexer(CharStreams.fromString(input));
         return new WebFocusReportParser(new CommonTokenStream(lexer));


### PR DESCRIPTION
This change implements the HEADING and FOOTING report commands in the Java port of the WebFOCUS transpiler. 

Key changes:
1.  **Roadmap Update**: Broken down the "Formatting" task (3.1.4.4) into smaller, more manageable sub-tasks for HEADING/FOOTING and ON ... SUBHEAD/SUBFOOT.
2.  **ASG Builder**: Added `visitHeading_command` and `visitFooting_command` to `WebFocusReportASGBuilder.java`. These visitors extract text from multiple `STRING` tokens, join them with spaces, remove quotes, and handle the `CENTER` flag.
3.  **Testing**: Added `testHeadingCommand` and `testFootingCommand` to `WebFocusReportASGBuilderTest.java` covering various scenarios (simple text, multiple strings, centered).

All existing and new tests pass (81 total).

Fixes #486

---
*PR created automatically by Jules for task [1381282904227901473](https://jules.google.com/task/1381282904227901473) started by @chatelao*