### PR TITLE
Implement WHEN command in Java ASG Builder

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -75,7 +75,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
     - [ ] 3.1.4.3 Filter Commands:
       - [x] 3.1.4.3.1 WHERE clause and relational expressions.
       - [x] 3.1.4.3.2 WHERE TOTAL (HAVING) clause.
-      - [ ] 3.1.4.3.3 WHEN clause (Dialogue Manager filtering).
+      - [x] 3.1.4.3.3 WHEN clause (Dialogue Manager filtering).
     - [ ] 3.1.4.4 Formatting (HEADING, FOOTING, ON ... SUBHEAD/SUBFOOT).
     - [ ] 3.1.4.5 Calculations (COMPUTE, RECAP).
     - [ ] 3.1.4.6 Summarization (SUBTOTAL, SUMMARIZE).

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -37,6 +37,12 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
     }
 
     @Override
+    public Object visitWhen_command(WebFocusReportParser.When_commandContext ctx) {
+        Expression condition = (Expression) visit(ctx.dm_logical_expression());
+        return new WhenCommand(condition);
+    }
+
+    @Override
     public Object visitWhere_command(WebFocusReportParser.Where_commandContext ctx) {
         boolean isTotal = ctx.TOTAL() != null;
         Expression condition = (Expression) visit(ctx.dm_logical_expression());

--- a/src/main/java/com/transpiler/asg/WhenCommand.java
+++ b/src/main/java/com/transpiler/asg/WhenCommand.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a WHEN command in a report request.
+ */
+public record WhenCommand(Expression condition) implements Command {
+}

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -420,6 +420,18 @@ public class WebFocusReportASGBuilderTest {
     }
 
     @Test
+    public void testWhenCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+        WebFocusReportParser parser = createParser("WHEN COUNTRY EQ 'USA';");
+        WhenCommand when = (WhenCommand) builder.visit(parser.when_command());
+        assertTrue(when.condition() instanceof BinaryOperation);
+        BinaryOperation op = (BinaryOperation) when.condition();
+        assertEquals("EQ", op.operator());
+        assertEquals("COUNTRY", ((Identifier) op.left()).name());
+        assertEquals("USA", ((Literal) op.right()).value());
+    }
+
+    @Test
     public void testWhereCommand() {
         WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
 


### PR DESCRIPTION
This PR implements the `WHEN` command (Dialogue Manager filtering) in the Java port of the WebFOCUS transpiler. 

Key changes include:
- Implementation of the `WhenCommand` ASG node in `src/main/java/com/transpiler/asg/WhenCommand.java`.
- Addition of the `visitWhen_command` visitor method in `src/main/java/com/transpiler/WebFocusReportASGBuilder.java`.
- Verification of the implementation through a new unit test in `src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java`.
- Updating the `JAVA_PORT_ROADMAP.md` to reflect the completion of Phase 3.1.4.3.3.

All 80 Java tests passed successfully.

Fixes #487

---
*PR created automatically by Jules for task [3232398603052824145](https://jules.google.com/task/3232398603052824145) started by @chatelao*