### PR TITLE
Implement WHEN clause support in Java ASG Builder

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -75,7 +75,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
     - [ ] 3.1.4.3 Filter Commands:
       - [x] 3.1.4.3.1 WHERE clause and relational expressions.
       - [x] 3.1.4.3.2 WHERE TOTAL (HAVING) clause.
-      - [ ] 3.1.4.3.3 WHEN clause (Dialogue Manager filtering).
+      - [x] 3.1.4.3.3 WHEN clause (Dialogue Manager filtering).
     - [ ] 3.1.4.4 Formatting:
       - [x] 3.1.4.4.1 HEADING and FOOTING.
       - [ ] 3.1.4.4.2 ON ... SUBHEAD/SUBFOOT.

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -45,6 +45,12 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
     }
 
     @Override
+    public Object visitWhen_command(WebFocusReportParser.When_commandContext ctx) {
+        Expression condition = (Expression) visit(ctx.dm_logical_expression());
+        return new WhenCommand(condition);
+    }
+
+    @Override
     public Object visitRequest(WebFocusReportParser.RequestContext ctx) {
         String filename = (String) visit(ctx.table_file());
         List<Command> components = new ArrayList<>();

--- a/src/main/java/com/transpiler/asg/WhenCommand.java
+++ b/src/main/java/com/transpiler/asg/WhenCommand.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a WHEN command in a report request.
+ */
+public record WhenCommand(Expression condition) implements Command {
+}

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -499,6 +499,18 @@ public class WebFocusReportASGBuilderTest {
         assertTrue(footing.centered());
     }
 
+    @Test
+    public void testWhenCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+        WebFocusReportParser parser = createParser("WHEN COUNTRY EQ 'USA'");
+        WhenCommand when = (WhenCommand) builder.visit(parser.when_command());
+        assertTrue(when.condition() instanceof BinaryOperation);
+        BinaryOperation op = (BinaryOperation) when.condition();
+        assertEquals("EQ", op.operator());
+        assertEquals("COUNTRY", ((Identifier) op.left()).name());
+        assertEquals("USA", ((Literal) op.right()).value());
+    }
+
     private WebFocusReportParser createParser(String input) {
         WebFocusReportLexer lexer = new WebFocusReportLexer(CharStreams.fromString(input));
         return new WebFocusReportParser(new CommonTokenStream(lexer));


### PR DESCRIPTION
I have implemented the `WHEN` clause support in the Java ASG Builder, which was a pending step in the `JAVA_PORT_ROADMAP.md` (Phase 3.1.4.3.3).

Key changes:
- Created `src/main/java/com/transpiler/asg/WhenCommand.java`: A new immutable Java record representing the `WHEN` command.
- Modified `src/main/java/com/transpiler/WebFocusReportASGBuilder.java`: Implemented the `visitWhen_command` visitor method to transform the ANTLR4 parse tree node into a `WhenCommand` ASG node.
- Modified `src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java`: Added a new test case `testWhenCommand` to verify correct parsing of `WHEN` clauses with relational expressions.
- Updated `JAVA_PORT_ROADMAP.md`: Marked step 3.1.4.3.3 as complete.

All tests passed successfully, ensuring functional parity for this feature.

Fixes #489

---
*PR created automatically by Jules for task [14432769376578885745](https://jules.google.com/task/14432769376578885745) started by @chatelao*