### PR TITLE
Implement Sort and Summarize Command Visitors in Java ASG Builder

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -69,9 +69,9 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
     - [ ] 3.1.4.1 Verb Commands:
       - [x] 3.1.4.1.1 Basic Verb and Field Selection.
       - [x] 3.1.4.1.2 Prefix Operators.
-    - [ ] 3.1.4.2 Sort Commands:
-      - [ ] 3.1.4.2.1 BY phrase and sort options (NOPRINT, AS, etc.).
-      - [ ] 3.1.4.2.2 ACROSS phrase and ACROSS-TOTAL.
+    - [x] 3.1.4.2 Sort Commands:
+      - [x] 3.1.4.2.1 BY phrase and sort options (NOPRINT, AS, etc.).
+      - [x] 3.1.4.2.2 ACROSS phrase and ACROSS-TOTAL.
     - [ ] 3.1.4.3 Filter Commands:
       - [x] 3.1.4.3.1 WHERE clause and relational expressions.
       - [x] 3.1.4.3.2 WHERE TOTAL (HAVING) clause.

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -4,7 +4,9 @@ import com.transpiler.asg.*;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -35,6 +37,73 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
             }
         }
         return nodes;
+    }
+
+    @Override
+    public Object visitBy_command(WebFocusReportParser.By_commandContext ctx) {
+        String sortType = "BY";
+        Map<String, Object> options = ctx.sort_options() != null ? (Map<String, Object>) visit(ctx.sort_options()) : Map.of();
+        FieldSelection field = (FieldSelection) visit(ctx.field());
+        SummarizeCommand summarize = ctx.summarize_command() != null ? (SummarizeCommand) visit(ctx.summarize_command()) : null;
+        boolean noprint = ctx.NOPRINT() != null;
+        boolean isHierarchy = ctx.HIERARCHY() != null;
+        return new SortCommand(sortType, field, options, summarize, noprint, false, null, isHierarchy);
+    }
+
+    @Override
+    public Object visitAcross_command(WebFocusReportParser.Across_commandContext ctx) {
+        String sortType = "ACROSS";
+        Map<String, Object> options = ctx.sort_options() != null ? (Map<String, Object>) visit(ctx.sort_options()) : Map.of();
+        FieldSelection field = (FieldSelection) visit(ctx.field());
+        boolean acrossTotal = ctx.ACROSS_TOTAL() != null;
+        String totalAs = ctx.as_phrase() != null ? (String) visit(ctx.as_phrase()) : null;
+        boolean noprint = ctx.NOPRINT() != null;
+        return new SortCommand(sortType, field, options, null, noprint, acrossTotal, totalAs, false);
+    }
+
+    @Override
+    public Object visitSort_options(WebFocusReportParser.Sort_optionsContext ctx) {
+        Map<String, Object> options = new HashMap<>();
+        if (ctx.HIGHEST() != null) options.put("order", "HIGHEST");
+        if (ctx.LOWEST() != null) options.put("order", "LOWEST");
+        if (ctx.TOP() != null) options.put("order", "TOP");
+        if (ctx.BOTTOM() != null) options.put("order", "BOTTOM");
+        if (ctx.NUMBER() != null) {
+            options.put("limit", Integer.parseInt(ctx.NUMBER().getText()));
+        }
+        return options;
+    }
+
+    @Override
+    public Object visitSummarize_command(WebFocusReportParser.Summarize_commandContext ctx) {
+        String verb = ctx.getChild(0).getText().toUpperCase();
+        Map<String, Object> options = ctx.summarize_options() != null ? (Map<String, Object>) visit(ctx.summarize_options()) : Map.of();
+
+        FieldSelection fieldNode = ctx.field() != null ? (FieldSelection) visit(ctx.field()) : null;
+        String fieldName = fieldNode != null ? fieldNode.name() : null;
+        String alias = fieldNode != null ? fieldNode.alias() : null;
+
+        if (ctx.as_phrase() != null) {
+            alias = (String) visit(ctx.as_phrase());
+        }
+
+        return new SummarizeCommand(verb, fieldName, alias, options);
+    }
+
+    @Override
+    public Object visitSummarize_options(WebFocusReportParser.Summarize_optionsContext ctx) {
+        Map<String, Object> options = new HashMap<>();
+        if (ctx.ROLL_DOT() != null) {
+            options.put("roll", true);
+        }
+
+        List<String> prefixes = ctx.prefix_operator().stream()
+                .map(p -> p.getText().toUpperCase())
+                .toList();
+        if (!prefixes.isEmpty()) {
+            options.put("prefixes", prefixes);
+        }
+        return options;
     }
 
     @Override

--- a/src/main/java/com/transpiler/asg/SortCommand.java
+++ b/src/main/java/com/transpiler/asg/SortCommand.java
@@ -1,10 +1,41 @@
 package com.transpiler.asg;
 
+import java.util.Map;
+
 /**
  * Represents a sort phrase (BY or ACROSS).
  */
 public record SortCommand(
     String sortType,
-    FieldSelection field
+    FieldSelection field,
+    Map<String, Object> options,
+    SummarizeCommand summarize,
+    boolean noprint,
+    boolean acrossTotal,
+    String totalAs,
+    boolean isHierarchy
 ) implements Command {
+    public SortCommand(
+        String sortType,
+        FieldSelection field,
+        Map<String, Object> options,
+        SummarizeCommand summarize,
+        boolean noprint,
+        boolean acrossTotal,
+        String totalAs,
+        boolean isHierarchy
+    ) {
+        this.sortType = sortType;
+        this.field = field;
+        this.options = options != null ? Map.copyOf(options) : Map.of();
+        this.summarize = summarize;
+        this.noprint = noprint;
+        this.acrossTotal = acrossTotal;
+        this.totalAs = totalAs;
+        this.isHierarchy = isHierarchy;
+    }
+
+    public SortCommand(String sortType, FieldSelection field) {
+        this(sortType, field, Map.of(), null, false, false, null, false);
+    }
 }

--- a/src/main/java/com/transpiler/asg/SummarizeCommand.java
+++ b/src/main/java/com/transpiler/asg/SummarizeCommand.java
@@ -1,0 +1,25 @@
+package com.transpiler.asg;
+
+import java.util.Map;
+
+/**
+ * Represents a summarization command (SUBTOTAL, SUMMARIZE, etc.).
+ */
+public record SummarizeCommand(
+    String verb,
+    String field,
+    String alias,
+    Map<String, Object> options
+) implements Command {
+    public SummarizeCommand(
+        String verb,
+        String field,
+        String alias,
+        Map<String, Object> options
+    ) {
+        this.verb = verb;
+        this.field = field;
+        this.alias = alias;
+        this.options = options != null ? Map.copyOf(options) : Map.of();
+    }
+}

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -500,6 +500,59 @@ public class WebFocusReportASGBuilderTest {
     }
 
     @Test
+    public void testSortCommands() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // BY simple
+        WebFocusReportParser parser = createParser("BY COUNTRY");
+        SortCommand sort = (SortCommand) builder.visit(parser.by_command());
+        assertEquals("BY", sort.sortType());
+        assertEquals("COUNTRY", sort.field().name());
+        assertFalse(sort.noprint());
+
+        // BY HIGHEST 5 with NOPRINT
+        parser = createParser("BY HIGHEST 5 COUNTRY NOPRINT");
+        sort = (SortCommand) builder.visit(parser.by_command());
+        assertEquals("HIGHEST", sort.options().get("order"));
+        assertEquals(5, sort.options().get("limit"));
+        assertTrue(sort.noprint());
+
+        // BY with SUBTOTAL
+        parser = createParser("BY COUNTRY SUBTOTAL SALARY");
+        sort = (SortCommand) builder.visit(parser.by_command());
+        assertNotNull(sort.summarize());
+        assertEquals("SUBTOTAL", sort.summarize().verb());
+        assertEquals("SALARY", sort.summarize().field());
+
+        // ACROSS simple
+        parser = createParser("ACROSS MODEL");
+        sort = (SortCommand) builder.visit(parser.across_command());
+        assertEquals("ACROSS", sort.sortType());
+        assertEquals("MODEL", sort.field().name());
+
+        // ACROSS with ACROSS-TOTAL
+        parser = createParser("ACROSS MODEL ACROSS-TOTAL AS 'Total Model'");
+        sort = (SortCommand) builder.visit(parser.across_command());
+        assertTrue(sort.acrossTotal());
+        assertEquals("Total Model", sort.totalAs());
+    }
+
+    @Test
+    public void testSummarizeCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // SUMMARIZE with ROLL. and prefixes
+        WebFocusReportParser parser = createParser("SUMMARIZE ROLL. AVE. SALARY AS 'Avg Salary'");
+        SummarizeCommand summarize = (SummarizeCommand) builder.visit(parser.summarize_command());
+        assertEquals("SUMMARIZE", summarize.verb());
+        assertEquals("SALARY", summarize.field());
+        assertEquals("Avg Salary", summarize.alias());
+        assertTrue((Boolean) summarize.options().get("roll"));
+        List<String> prefixes = (List<String>) summarize.options().get("prefixes");
+        assertEquals(List.of("AVE"), prefixes);
+    }
+
+    @Test
     public void testWhenCommand() {
         WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
         WebFocusReportParser parser = createParser("WHEN COUNTRY EQ 'USA'");


### PR DESCRIPTION
Implemented Phase 3.1.4.2 of the Java Port Roadmap. This includes porting the ASG building logic for sort commands (BY and ACROSS) and their associated options (NOPRINT, HIGHEST/LOWEST, etc.), as well as the nested summarization phrases (SUBTOTAL, SUMMARIZE). Functional parity was verified with new unit tests and by running the full Maven test suite.

Fixes #494

---
*PR created automatically by Jules for task [10493152828916750477](https://jules.google.com/task/10493152828916750477) started by @chatelao*