### PR TITLE
Fix missing release artifacts in CI/CD

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,6 +3,7 @@ name: CI/CD
 on:
   push:
     branches: [ "**" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "**" ]
 
@@ -147,7 +148,11 @@ jobs:
 
       - name: Build with PyInstaller
         shell: bash
-        run: pyinstaller cli.spec
+        run: python -m PyInstaller cli.spec
+
+      - name: List dist directory
+        shell: bash
+        run: ls -R dist/
 
       - name: Rename artifact
         shell: bash
@@ -158,5 +163,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/${{ matrix.asset_name }}
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ __pycache__/
 htmlcov/
 docs/
 build/
+dist/
 target/


### PR DESCRIPTION
The compiled installers were not being added to releases because the GitHub Actions workflow (`cicd.yml`) was not configured to trigger on version tags. This PR fixes the trigger, improves the PyInstaller build reliability by using `python -m PyInstaller`, adds debugging logs to verify artifact generation, and ensures the release job fails explicitly if artifacts are missing. It also adds `dist/` to `.gitignore` to prevent accidental commits of binaries.

Fixes #496

---
*PR created automatically by Jules for task [17284131187119760331](https://jules.google.com/task/17284131187119760331) started by @chatelao*