### PR TITLE
Add File Format Support Gap Analysis

### DIFF
--- a/FILE_FORMAT_SUPPORT_GAP.md
+++ b/FILE_FORMAT_SUPPORT_GAP.md
@@ -1,0 +1,10 @@
+# File Format Support Gap Analysis
+
+This document outlines the support status for various WebFOCUS application and metadata file formats within the transpiler.
+
+| File Extension | Format Name | Support Status | Details |
+| :--- | :--- | :--- | :--- |
+| **.fex** | Procedure (FOCEXEC) | **Fully Supported** | Supported via `WebFocusReport.g4` grammar and associated Python (`asg_builder.py`) and Java (`WebFocusReportVisitor`) components. |
+| **.mas** | Master File | **Fully Supported** | Supported via `MasterFile.g4` grammar and `master_file_parser.py`. |
+| **.acx** | Access File | **Unsupported** | No grammar or parser implementation exists for Access Files. These files contain system-specific information and connection parameters which are currently not handled. |
+| **.sty** | StyleSheet | **Partially Supported** | Inline `SET STYLE * ... ENDSTYLE` blocks within `.fex` files are parsed into `StyleBlock` ASG nodes. However, external `.sty` files are not supported and no separate parser exists for them. |


### PR DESCRIPTION
Verified the support status of .fex, .mas, .acx, and .sty file formats in the codebase and documented the findings in FILE_FORMAT_SUPPORT_GAP.md. 

- .fex: Fully supported via WebFocusReport.g4.
- .mas: Fully supported via MasterFile.g4.
- .acx: Unsupported (no parser exists).
- .sty: Partially supported (inline blocks in .fex files are supported, but external files are not).

Fixes #498

---
*PR created automatically by Jules for task [7252833116562444046](https://jules.google.com/task/7252833116562444046) started by @chatelao*