### PR TITLE
Roadmap Implementation and Cleanup

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -70,7 +70,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
       - [x] 3.1.4.1.1 Basic Verb and Field Selection.
       - [x] 3.1.4.1.2 Prefix Operators.
     - [ ] 3.1.4.2 Sort Commands:
-      - [ ] 3.1.4.2.1 BY phrase and sort options (NOPRINT, AS, etc.).
+      - [ ] 3.1.4.2.1 BY phrase and sort options (NOPRINT, AS).
       - [ ] 3.1.4.2.2 ACROSS phrase and ACROSS-TOTAL.
     - [ ] 3.1.4.3 Filter Commands:
       - [x] 3.1.4.3.1 WHERE clause and relational expressions.
@@ -78,9 +78,14 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
       - [x] 3.1.4.3.3 WHEN clause (Dialogue Manager filtering).
     - [ ] 3.1.4.4 Formatting:
       - [x] 3.1.4.4.1 HEADING and FOOTING.
-      - [ ] 3.1.4.4.2 ON ... SUBHEAD/SUBFOOT.
-    - [ ] 3.1.4.5 Calculations (COMPUTE, RECAP).
-    - [ ] 3.1.4.6 Summarization (SUBTOTAL, SUMMARIZE).
+      - [ ] 3.1.4.4.2 ON field SUBHEAD/SUBFOOT.
+      - [ ] 3.1.4.4.3 ON TABLE SUBHEAD/SUBFOOT.
+    - [ ] 3.1.4.5 Calculations:
+      - [ ] 3.1.4.5.1 COMPUTE command.
+      - [ ] 3.1.4.5.2 RECAP command.
+    - [ ] 3.1.4.6 Summarization:
+      - [ ] 3.1.4.6.1 SUBTOTAL/SUB-TOTAL.
+      - [ ] 3.1.4.6.2 SUMMARIZE/RECOMPUTE.
   - [ ] 3.1.5 Advanced Features:
     - [ ] 3.1.5.1 Compound Layout.
     - [ ] 3.1.5.2 Match File and SubMatch.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # ROADMAP
-- [ ] 0.56 Implement a next, modest, very small, feasible and reasonable `specifications/ROADMAP.md` step (#502)
-- [ ] 0.55 Create roadmap to improve the formating of all markdown files in `specifications` (#500)
+- [x] 0.56 Implement a next, modest, very small, feasible and reasonable `specifications/ROADMAP.md` step (#502) (completed at 2026-06-03 18:30:00)
+- [x] 0.55 Create roadmap to improve the formating of all markdown files in `specifications` (#500) (completed at 2026-06-03 18:30:00)
 - [x] 0.54 Überprüfe ob alle Dateiformate unterstützt werden, wenn nein erstelle die Datei `FILE_FORMAT_SUPPORT_GAP.md` (#498) (completed at 2026-06-03 17:05:25)
 - [x] 0.53 Find out why the compiled installers are not added to the release v1.1 (#496) (completed at 2026-06-03 16:14:52)
 - [ ] 0.52 Implement a next, modest, very small, feasible and reasonable JAVA_PORT_ROADMAP.md step (#494)

--- a/specifications/ROADMAP.md
+++ b/specifications/ROADMAP.md
@@ -1,0 +1,17 @@
+# Specifications Cleanup Roadmap
+
+This document outlines a phased strategic plan for automated cleanup, structural reform, semantic enrichment, and GFM (GitHub Flavored Markdown) compliance of the WebFOCUS documentation located in the `specifications/` directory.
+
+## Phase 1: Automated Cleanup
+- [x] 1.1 Remove form feed characters (`\f`) from all markdown files.
+- [ ] 1.2 Remove orphaned page numbers and headers/footers introduced by PDF-to-Markdown conversion.
+
+## Phase 2: Structural Reform
+- [ ] 2.1 Heading Normalization: Convert plain-text headers to proper Markdown `#` headers.
+- [ ] 2.2 Fenced Code Blocks: Wrap WebFOCUS code examples and ASCII tables in fenced code blocks (```).
+
+## Phase 3: Semantic Enrichment
+- [ ] 3.1 Internal Cross-links: Resolve "on page X" references into internal Markdown links.
+
+## Phase 4: GFM Compliance
+- [ ] 4.1 Table Conversion: Convert ASCII tables to GFM table syntax.

--- a/specifications/creating_reports/creating_reports_00_front_matter.md
+++ b/specifications/creating_reports/creating_reports_00_front_matter.md
@@ -5,7 +5,7 @@ Release 8207
 May 2021
 DN4501639.0521
 
-TIBCO WebFOCUS®Copyright© 2021.TIBCOSoftwareInc.AllRightsReserved. Contents
+TIBCO WebFOCUS®Copyright© 2021.TIBCOSoftwareInc.AllRightsReserved. Contents
 
 1. Creating Reports Overview . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .29
 
@@ -75,7 +75,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  3
 
-Contents
+Contents
 
 Rolling Up Calculations on Summary Rows. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 75
 
@@ -143,7 +143,7 @@ Restricting Sort Field Values by Highest/Lowest Rank . . . . . . . . . . . . . .
 
 4
 
-Contents
+Contents
 
 Sorting and Aggregating Report Columns . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 173
 
@@ -213,7 +213,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  5
 
-Contents
+Contents
 
 Setting Limits on the Number of Records Read . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 258
 
@@ -281,7 +281,7 @@ FORECAST_DOUBLEXP: Using Double Exponential Smoothing. . . . . . . . . . . . . .
 
 6
 
-Contents
+Contents
 
 FORECAST_SEASONAL: Using Triple Exponential Smoothing. . . . . . . . . . . . . . . . . . . . 326
 
@@ -351,7 +351,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  7
 
-Contents
+Contents
 
 Types of Expressions . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 430
 
@@ -419,7 +419,7 @@ Creating a Conditional Expression . . . . . . . . . . . . . . . . . . . . . . . 
 
 8
 
-Contents
+Contents
 
 Saving Your Report Output . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .472
 
@@ -489,7 +489,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  9
 
-Contents
+Contents
 
 Scaling PDF Report Output to Fit the Page Width. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 590
 
@@ -559,7 +559,7 @@ Using XLSX FORMULA With Prefix Operators. . . . . . . . . . . . . . . . . . . . 
 
 10
 
-Contents
+Contents
 
 NODATA With Formulas. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .675
 
@@ -631,7 +631,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  11
 
-Contents
+Contents
 
 PowerPoint PPTX Compound Syntax. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 788
 
@@ -699,7 +699,7 @@ Creating a Compound Report . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 12
 
-Contents
+Contents
 
 Creating a Compound Layout Report With Document Syntax. . . . . . . . . . . . . . . . . . . . . . . . . 877
 
@@ -769,7 +769,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  13
 
-Contents
+Contents
 
 Propagating Missing Values to Reformatted Fields in a Request. . . . . . . . . . . . . . . . . . . . .1054
 
@@ -837,7 +837,7 @@ Displaying Joined Structures . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 14
 
-Contents
+Contents
 
 Clearing Joined Structures . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .1151
 
@@ -907,7 +907,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  15
 
-Contents
+Contents
 
 Data, Report, and Title Styling. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .1212
 
@@ -975,7 +975,7 @@ Working With an External Cascading Style Sheet . . . . . . . . . . . . . . . . .
 
 16
 
-Contents
+Contents
 
 Choosing an External Cascading Style Sheet. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 1303
 
@@ -1045,7 +1045,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  17
 
-Contents
+Contents
 
 Displaying the Total Page Count Within a Sort Group. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 1392
 
@@ -1113,7 +1113,7 @@ Customizing a Column Title . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 18
 
-Contents
+Contents
 
 Customizing a Column Title in a Master File. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 1594
 
@@ -1183,7 +1183,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  19
 
-Contents
+Contents
 
 Alternating Background Color By Wrapped Line . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 1709
 
@@ -1251,7 +1251,7 @@ Basic Date Support for X and Y Axes. . . . . . . . . . . . . . . . . . . . . . .
 
 20
 
-Contents
+Contents
 
 Formatting Dates for Y-Axis Values. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 1781
 
@@ -1321,7 +1321,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  21
 
-Contents
+Contents
 
 Controlling the Creation of Column Reference Numbers. . . . . . . . . . . . . . . . . . . . . . . . . . . . 1840
 
@@ -1389,7 +1389,7 @@ Using SQL Translator Commands . . . . . . . . . . . . . . . . . . . . . . . . . 
 
 22
 
-Contents
+Contents
 
 The SQL SELECT Statement. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .1912
 
@@ -1459,7 +1459,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  23
 
-Contents
+Contents
 
 EDUCFILE Structure Diagram. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 1943
 
@@ -1529,7 +1529,7 @@ LOCATOR Master File. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 24
 
-Contents
+Contents
 
 LOCATOR Structure Diagram. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 1955
 
@@ -1601,7 +1601,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  25
 
-Contents
+Contents
 
 CENTHR Master File. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 1970
 
@@ -1667,7 +1667,7 @@ Listing Field Names, Aliases, and Format Information. . . . . . . . . . . . . . 
 
 26
 
-Legal and Third-Party Notices . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 1997
+Legal and Third-Party Notices . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 1997
 
 Contents
 
@@ -1675,6 +1675,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  27
 
-Contents
+Contents
 
 28

--- a/specifications/creating_reports/creating_reports_01_chapter1.md
+++ b/specifications/creating_reports/creating_reports_01_chapter1.md
@@ -46,7 +46,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  29
 
-Report Types
+Report Types
 
 Indexed data sources, such as ISAM and VSAM.
 
@@ -91,7 +91,7 @@ these concepts. You can display these reports in formats such as HTML, Excel®, 
 
 30
 
-1. Creating Reports Overview
+1. Creating Reports Overview
 
 Financial reports. Specifically designed to handle the task of creating, calculating, and
 presenting financially oriented data, such as balance sheets, consolidations, and budgets.
@@ -137,7 +137,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  31
 
-Developing Your Report Request
+Developing Your Report Request
 
 Drill Through reports. Allow users to create a PDF document that contains a summary
 report plus a detail report, where the detail report contains all the detail data for
@@ -184,7 +184,7 @@ fundamentally tied to how you want to use those fields in your report.
 
 32
 
-1. Creating Reports Overview
+1. Creating Reports Overview
 
 Displaying data. You can display data in your report by listing all the records for a field
 (detailed presentation), or by totaling the records for a field (summary presentation). You
@@ -236,7 +236,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  33
 
-Developing Your Report Request
+Developing Your Report Request
 
 Joining data sources. You can join two or more data sources to create a larger integrated
 data structure from which you can report in a single request.
@@ -286,7 +286,7 @@ command.
 
 34
 
-1. Creating Reports Overview
+1. Creating Reports Overview
 
 If you plan to issue consecutive report requests against the same data source during one
 session, you have the option of using the RUN command. RUN keeps the TABLE facility and
@@ -334,7 +334,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  35
 
 
-Developing Your Report Request
+Developing Your Report Request
 
 The output is:
 
@@ -376,7 +376,7 @@ columns, and recalculates the Percent column.
 
 36
 
-Customizing a Report
+Customizing a Report
 
 1. Creating Reports Overview
 
@@ -418,7 +418,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  37
 
-Selecting a Report Output Destination
+Selecting a Report Output Destination
 
 Selecting a Report Output Destination
 

--- a/specifications/creating_reports/creating_reports_02_chapter2.md
+++ b/specifications/creating_reports/creating_reports_02_chapter2.md
@@ -39,7 +39,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  39
 
-Using Display Commands in a Request
+Using Display Commands in a Request
 
 Syntax:
 
@@ -97,7 +97,7 @@ virtual field name redefines a real field.
 
 40
 
-Displaying Individual Values
+Displaying Individual Values
 
 2. Displaying Report Data
 
@@ -147,7 +147,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  41
 
-Displaying Individual Values
+Displaying Individual Values
 
 LAST_NAME
 ---------
@@ -253,7 +253,7 @@ Data With WebFOCUS Language manual.
 
 
 
-Example:
+Example:
 
 Displaying All Fields
 
@@ -479,7 +479,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Displaying Individual Values
+Displaying Individual Values
 
   19
 
@@ -522,7 +522,7 @@ END
 
 44
 
-The following shows the report output.
+The following shows the report output.
 
 2. Displaying Report Data
 
@@ -543,7 +543,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  45
 
-Displaying Individual Values
+Displaying Individual Values
 
 Example:
 
@@ -556,7 +556,7 @@ CHECK FILE CENTORD PICTURE
 
 46
 
-2. Displaying Report Data
+2. Displaying Report Data
 
 The following shows the structure diagram output.
 
@@ -621,7 +621,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Displaying Individual Values
+Displaying Individual Values
 
 The following shows the command output that adds the numbers that display at the top left of
 each segment, indicating the retrieval order of the segments. A unique segment such as
@@ -630,7 +630,7 @@ SECSEG are unique segments, and are therefore treated as part of their parents.
 
 48
 
-The following shows the retrieval order:
+The following shows the retrieval order:
 
 2. Displaying Report Data
 
@@ -638,7 +638,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  49
 
-Adding Values
+Adding Values
 
 Example:
 
@@ -694,7 +694,7 @@ refers to WRITE and ADD.
 
 50
 
-2. Displaying Report Data
+2. Displaying Report Data
 
 When you use SUM, multiple records are read from the data source, but only one summary line
 is produced. If you use SUM with a non-numeric field—such as an alphanumeric, text, or date
@@ -757,7 +757,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  51
 
-Counting Values
+Counting Values
 
 Counting Values
 
@@ -811,7 +811,7 @@ END
 
 52
 
-The following shows the output of the request indicating that of the 12 EMP_IDs in the data
+The following shows the output of the request indicating that of the 12 EMP_IDs in the data
 source, six are from the MIS department and six are from the PRODUCTION department:
 
 2. Displaying Report Data
@@ -865,7 +865,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  53
 
-Expanding Byte Precision for COUNT and LIST
+Expanding Byte Precision for COUNT and LIST
 
 Example:
 
@@ -912,7 +912,7 @@ Note: You can change the overflow character by issuing the SET OVERFLOWCHAR comm
 
 54
 
-2. Displaying Report Data
+2. Displaying Report Data
 
 Syntax:
 
@@ -983,7 +983,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  55
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 However, an error can occur under the following conditions:
 
@@ -1032,7 +1032,7 @@ END
 
 56
 
-The output is shown in the following image. The prefix operator names are converted to
+The output is shown in the following image. The prefix operator names are converted to
 descriptive text.
 
 2. Displaying Report Data
@@ -1084,7 +1084,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  57
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 To sort by the results of a prefix command, use the phrase BY TOTAL to aggregate and sort
 numeric columns simultaneously. For details, see Sorting Tabular Reports on page 87.
@@ -1138,7 +1138,7 @@ Computes the average value of the field.
 
 58
 
-Prefix
+Prefix
 
 CNT.
 
@@ -1219,7 +1219,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  59
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 Prefix
 
@@ -1285,7 +1285,7 @@ PRODUCTION   20.00
 
 60
 
-Averaging the Sum of Squared Fields
+Averaging the Sum of Squared Fields
 
 The ASQ. prefix computes the average sum of squares, which is a component of the standard
 deviation in statistical analysis (shown as a formula in the following image).
@@ -1338,7 +1338,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  61
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 The following shows the output of the request.
 
@@ -1386,7 +1386,7 @@ lowest value ($9,500.00).
 
 62
 
-2. Displaying Report Data
+2. Displaying Report Data
 
 Calculating Column and Row Percentages
 
@@ -1419,7 +1419,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  63
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 If you set PCFORMAT to OLD, PCT. and RPCT. WILL take the same format as the field, and the
 column may not always total exactly 100 because of the nature of floating-point arithmetic.
@@ -1452,7 +1452,7 @@ decimal places (D, F).
 
 64
 
-2. Displaying Report Data
+2. Displaying Report Data
 
 Producing a Direct Percent of a Count
 
@@ -1498,7 +1498,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  65
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 Note that in a request using the PRINT command and multiple DST operators, you should issue
 the command SET PRINTDST=NEW. For more information, see the Developing Reporting
@@ -1558,7 +1558,7 @@ ED_HRS
 
 66
 
-2. Displaying Report Data
+2. Displaying Report Data
 
 Notice that the count includes records for both employees with the last name SMITH, but
 excludes the second records for values 50.00, 25.00, and .0, resulting in nine unique ED_HRS
@@ -1616,7 +1616,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  67
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 The following error occurs if you use DST. in a MATCH command:
 
@@ -1663,7 +1663,7 @@ set of values.
 
 68
 
-2. Displaying Report Data
+2. Displaying Report Data
 
 For more information on segment types and file design, see the Describing Data With
 WebFOCUS Language manual. If you wish to reorganize the data in the data source or
@@ -1725,7 +1725,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  69
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 If the record is in a segment with values organized from highest to lowest (segment type SH1),
 the first logical record that the FST. prefix operator retrieves is the highest value in the set of
@@ -1772,7 +1772,7 @@ footings, subheads, and subfoots).
 
 70
 
-Example:
+Example:
 
 Counting Values With CNT
 
@@ -1830,7 +1830,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  71
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 The output is:
 
@@ -1882,7 +1882,7 @@ Is a vertical (BY) sort field in the request.
 
 72
 
-Example:
+Example:
 
 Ranking Within Sort Groups
 
@@ -1936,7 +1936,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  73
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 Example:
 
@@ -1993,7 +1993,7 @@ END
 
 74
 
-2. Displaying Report Data
+2. Displaying Report Data
 
 The output is:
 
@@ -2051,7 +2051,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  75
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 ROLL.prefix on a summary line indicates that the prefix operation will be performed on the
 summary values from the next lowest level of summary command.
@@ -2107,7 +2107,7 @@ columns you want to display.
 
 76
 
-Example:
+Example:
 
 Rolling Up an Average Calculation
 
@@ -2166,7 +2166,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  77
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 On the output, the UNITS values for each state are averaged to calculate the subtotal for each
 region, and those region subtotal values are used to calculate the average for the grand total
@@ -2217,7 +2217,7 @@ END
 
 
 
-2. Displaying Report Data
+2. Displaying Report Data
 
 On the output, the detail rows for each date are used to calculate the average for each
 product. Because of the ROLL.AVE. at the region level, the averages for each product are used
@@ -2291,7 +2291,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 Reference: Usage Notes for ROLL.
 
@@ -2334,7 +2334,7 @@ STDS.field
 
 80
 
-2. Displaying Report Data
+2. Displaying Report Data
 
 where:
 
@@ -2385,7 +2385,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  81
 
-Manipulating Display Fields With Prefix Operators
+Manipulating Display Fields With Prefix Operators
 
 where:
 
@@ -2434,7 +2434,7 @@ END
 
 82
 
-The output is shown in the following image.
+The output is shown in the following image.
 
 2. Displaying Report Data
 
@@ -2447,7 +2447,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  83
 
-Displaying Pop-up Field Descriptions for Column Titles
+Displaying Pop-up Field Descriptions for Column Titles
 
 They work in a heading or footing for real or virtual (DEFINE) fields. They work in a display
 command field list on real fields, virtual (DEFINE) fields, and calculated (COMPUTE) values
@@ -2499,7 +2499,7 @@ FIELD=UNITS, ALIAS=E10, FORMAT=I08, TITLE='Unit Sales',
 
 84
 
-2. Displaying Report Data
+2. Displaying Report Data
 
 The code used to create the report is:
 
@@ -2535,7 +2535,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  85
 
-Displaying Pop-up Field Descriptions for Column Titles
+Displaying Pop-up Field Descriptions for Column Titles
 
 ibi_apps/ibi_html
 

--- a/specifications/creating_reports/creating_reports_03_chapter3.md
+++ b/specifications/creating_reports/creating_reports_03_chapter3.md
@@ -68,7 +68,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  87
 
-Sorting Rows
+Sorting Rows
 
 Additional sorting options include:
 
@@ -117,7 +117,7 @@ the BYDISPLAY parameter. For an example, see Controlling Display of Sort Field V
 
 88
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Syntax:
 
@@ -174,7 +174,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  89
 
-Sorting Rows
+Sorting Rows
 
 Each sort field value appears only once in the report. For example, if there are six
 employees in the MIS department, a request that declares
@@ -207,7 +207,7 @@ on. Each successive sort is nested within the previous one.
 
 90
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Example:
 
@@ -270,7 +270,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  91
 
-Sorting Rows
+Sorting Rows
 
 text
 
@@ -318,7 +318,7 @@ HOLD is supported for formats PDF, PS, HTML, DOC, and WP.
 
 92
 
-Example:
+Example:
 
 Displaying a Row Representing Sort Field Values Excluded by a Sort Phrase
 
@@ -375,7 +375,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  93
 
-Sorting Columns
+Sorting Columns
 
 If the BY HIGHEST phrase is changed to BY LOWEST, all values above the top grouping (50
 ED_HRS and above) are included in the Others category:
@@ -422,7 +422,7 @@ Totals and Subtotals on page 367.
 
 94
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Syntax:
 
@@ -472,7 +472,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  95
 
-Sorting Columns
+Sorting Columns
 
 Example:
 
@@ -530,7 +530,7 @@ ON
 
 96
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 OFF
 
@@ -579,7 +579,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  97
 
-Sorting Columns
+Sorting Columns
 
 the field in the heading and the reformatted dollar sales values add report columns to the
 internal matrix, but the ACROSS title Sales is still suppressed.
@@ -603,7 +603,7 @@ The report output is shown in the following image:
 
 98
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 With the setting ACRSVRBTITL=OFF, the field in the heading adds a report column to the
 internal matrix, and the ACROSS title Sales is not suppressed.
@@ -631,7 +631,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  99
 
-Sorting Columns
+Sorting Columns
 
 If you want to display both the ACROSS title and the ACROSS values on one line in the PDF,
 HTML, EXL2K, or XLSX report output, you can issue the SET ACROSSTITLE = SIDE command.
@@ -683,7 +683,7 @@ With BYPANEL=OFF, the ACROSS title is not displayed on subsequent panels.
 
 100
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 WRAP is not supported for ACROSSTITLE with SET ACROSSTITLE=SIDE.
 
@@ -731,7 +731,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  101
 
-Sorting Columns
+Sorting Columns
 
 The ACROSS title Category displays to the left of the ACROSS values Coffee, Food, and Gifts.
 The ACROSS title Product displays to the left of the ACROSS values Espresso, Latte, Biscotti,
@@ -741,7 +741,7 @@ line, and the ACROSS title is aligned with the top line. The following shows pan
 
 102
 
-The following shows panel 2:
+The following shows panel 2:
 
 3. Sorting Tabular Reports
 
@@ -749,7 +749,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  103
 
-Sorting Columns
+Sorting Columns
 
 Example:
 
@@ -790,7 +790,7 @@ END
 
 104
 
-The first panel follows:
+The first panel follows:
 
 3. Sorting Tabular Reports
 
@@ -802,7 +802,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  105
 
-Sorting Columns
+Sorting Columns
 
 Example:
 
@@ -839,7 +839,7 @@ and column titles.
 
 106
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Using Multiple Horizontal (ACROSS) Sort Fields
 
@@ -898,7 +898,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  107
 
-Sorting Columns
+Sorting Columns
 
 ON TABLE SET ACROSSPRT{NORMAL|COMPRESS}
 
@@ -941,7 +941,7 @@ END
 
 108
 
-Each line of the report represents one sale in one region, so at most one column in each row
+Each line of the report represents one sale in one region, so at most one column in each row
 has a non-missing value when ACROSSPRT is set to NORMAL.
 
 3. Sorting Tabular Reports
@@ -989,7 +989,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  109
 
-Sorting Columns
+Sorting Columns
 
 The output is:
 
@@ -1042,7 +1042,7 @@ for ACROSS reports.
 
 110
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Hiding ACROSS columns will not affect items placed in heading elements with spot markers
 or explicit positioning. This means that after ACROSS group columns are hidden, items may
@@ -1089,7 +1089,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  111
 
-Sorting Columns
+Sorting Columns
 
 Example:
 
@@ -1117,7 +1117,7 @@ With SET HIDENULLACRS=OFF, all columns display:
 
 112
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Running the request with SET HIDENULLACRS=ON eliminates the ACROSS groups for cities
 with missing data within each region. For example, the Midwest region has no columns for
@@ -1127,7 +1127,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  113
 
-Sorting Columns
+Sorting Columns
 
 Example:
 
@@ -1174,7 +1174,7 @@ END
 
 114
 
-Running the request with SET HIDENULLACRS=OFF displays the Espresso column and any
+Running the request with SET HIDENULLACRS=OFF displays the Espresso column and any
 other column containing missing values within the Coffee group:
 
 3. Sorting Tabular Reports
@@ -1183,7 +1183,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  115
 
-Sorting Columns
+Sorting Columns
 
 Running the request with SET HIDENULLACRS=ON hides columns with missing data within
 each region. On page 1 (Midwest), both the Capuccino and Espresso columns are hidden,
@@ -1191,7 +1191,7 @@ while on page 2 (Northeast), only the Espresso column is hidden:
 
 116
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Example:
 
@@ -1242,13 +1242,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  117
 
-Sorting Columns
+Sorting Columns
 
 Running the request with SET HIDENULLACRS=OFF displays all of the columns:
 
 118
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Running the request with SET HIDENULLACRS=ON hides the Espresso product and the entire
 Gifts category within each region. On page 1 (Midwest), the Gifts group and the Espresso and
@@ -1274,7 +1274,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  119
 
-Sorting Columns
+Sorting Columns
 
 Grand totals can contain ACROSS columns that have been hidden on some pages within a BY
 field value. Therefore, they are always placed on a new page and presented for all ACROSS
@@ -1291,7 +1291,7 @@ totals are missing.
 
 120
 
-Example:
+Example:
 
 Generating Column Totals and Hiding Null ACROSS Columns
 
@@ -1344,14 +1344,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  121
 
-Sorting Columns
+Sorting Columns
 
 The following shows pages one through three. On page 1, the Espresso and Capuccino
 columns are hidden. On pages 2 and 3, the Espresso column is hidden:
 
 122
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 The following shows pages four and five. On page 4, the Espresso column is hidden. Page 5 is
 the totals page. The Espresso column is hidden since it was hidden on every detail page.
@@ -1378,7 +1378,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  123
 
-Sorting Columns
+Sorting Columns
 
 Example:
 
@@ -1415,7 +1415,7 @@ The request follows:
 
 124
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 SET HIDENULLACRS=OFF
 DEFINE FILE GGSALES
@@ -1467,20 +1467,20 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  125
 
-Sorting Columns
+Sorting Columns
 
 Running the report with SET HIDENULLACRS=OFF shows all columns. A page is generated for
 the West region and subtotals are calculated, even though all of the values are missing:
 
 126
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Creating Reports With TIBCO® WebFOCUS Language
 
  127
 
-Sorting Columns
+Sorting Columns
 
 Running the report with SET HIDENULLACRS=ON, shows:
 
@@ -1499,7 +1499,7 @@ The output is:
 
 128
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Hiding Null ACROSS Columns in an FML Request
 
@@ -1511,7 +1511,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  129
 
-Sorting Columns
+Sorting Columns
 
 Example:
 
@@ -1566,7 +1566,7 @@ END
 
 130
 
-Running the request with SET HIDENULLACRS=OFF generates all columns and a page for all
+Running the request with SET HIDENULLACRS=OFF generates all columns and a page for all
 regions, including the Southeast regions where all values are missing:
 
 3. Sorting Tabular Reports
@@ -1575,14 +1575,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  131
 
-Sorting Columns
+Sorting Columns
 
 Running the request with SET HIDENULLACRS=ON hides column Q4 for the Midwest region, Q2
 for the Northeast region, and the entire page for the Southeast region:
 
 132
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Controlling Display of Sort Field Values
 
@@ -1630,7 +1630,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  133
 
-Controlling Display of Sort Field Values
+Controlling Display of Sort Field Values
 
 Example:
 
@@ -1659,7 +1659,7 @@ The output is shown in the following image.
 
 134
 
-Changing BYDISPLAY to ON or BY displays BY field values on every row, as shown in the
+Changing BYDISPLAY to ON or BY displays BY field values on every row, as shown in the
 following image.
 
 3. Sorting Tabular Reports
@@ -1671,7 +1671,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  135
 
-Reformatting Sort Fields
+Reformatting Sort Fields
 
 Changing BYDISPLAY to ALL displays BY field values on every row and ACROSS field values
 over every column, as shown in the following image.
@@ -1709,7 +1709,7 @@ subheading, subfooting, or summary rows that reference the sort field.
 
 136
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Field-based reformatting (the format is stored in a field) is not supported for sort fields. For
 information on field-based reformatting, see Field-Based Reformatting on page 1736.
@@ -1762,7 +1762,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  137
 
-Manipulating Display Field Values in a Sort Group
+Manipulating Display Field Values in a Sort Group
 
 On the output, the reformatting displays on the BY and ACROSS rows but is not propagated to
 the subheading and subtotal rows:
@@ -1813,7 +1813,7 @@ on an ACROSS phrase.
 
 138
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 You can also use WITHIN TABLE, which allows you to return the original value within a request
 command. The WITHIN TABLE command can also be used when an ACROSS phrase is needed
@@ -1858,7 +1858,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  139
 
-Creating a Matrix Report
+Creating a Matrix Report
 
 The output is:
 
@@ -1884,7 +1884,7 @@ END
 
 140
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 The output is:
 
@@ -1943,7 +1943,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  141
 
-Controlling Collation Sequence
+Controlling Collation Sequence
 
 Syntax:
 
@@ -1995,7 +1995,7 @@ the one for the input record that had the lowest value (collated first).
 
 142
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 When the MIN (or the MAX) value for two or more alphanumeric display fields having a given
 instance of the sort field values is the same by case-insensitive collation, but the two
@@ -2051,7 +2051,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  143
 
-Controlling Collation Sequence
+Controlling Collation Sequence
 
 On the output, the rows with product numbers 1004 and 1005 differ only in the case of the
 letter d in HD. The record with the lowercase d is before the record with the uppercase D. The
@@ -2094,7 +2094,7 @@ END
 
 144
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 In an EBCDIC environment, the records with the lowercase letters sort in front of the records
 with the uppercase letters, so the row with product number 1007 sorts in front of the row with
@@ -2130,7 +2130,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  145
 
-Controlling Collation Sequence
+Controlling Collation Sequence
 
 In an ASCII environment, the records with the uppercase letters sort in front of the records with
 the lowercase letters, so the row with product number 1005 sorts in front of the row with
@@ -2169,7 +2169,7 @@ PRODNAME value and the sort field value for the display is the first one in the 
 
 146
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 The following shows the output in an EBCDIC environment:
 
@@ -2203,7 +2203,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  147
 
-Controlling Collation Sequence
+Controlling Collation Sequence
 
 The following shows the output in an ASCII environment:
 
@@ -2260,7 +2260,7 @@ displayed in the order in which they appeared in the data source:
 
 148
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Product  Product
 Number:  Name:
@@ -2319,7 +2319,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  149
 
-Specifying the Sort Order
+Specifying the Sort Order
 
 You can specify this same ascending order explicitly by including LOWEST in the sort phrase.
 
@@ -2343,7 +2343,7 @@ END
 
 150
 
-The output is:
+The output is:
 
 3. Sorting Tabular Reports
 
@@ -2383,7 +2383,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  151
 
-Specifying the Sort Order
+Specifying the Sort Order
 
 where:
 
@@ -2440,7 +2440,7 @@ quotation marks (').
 
 152
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Any sort field value that you do specify in the BY ROWS OVER phrase is included in the
 report, whether or not there is data.
@@ -2489,7 +2489,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  153
 
-Specifying the Sort Order
+Specifying the Sort Order
 
 value2
 
@@ -2542,7 +2542,7 @@ BEST BANK          STATE              ASSOCIATED         BANK ASSOCIATION
 154
 
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Selecting and Assigning Column Titles to ACROSS Values
 
@@ -2598,7 +2598,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  155
 
-Ranking Sort Field Values
+Ranking Sort Field Values
 
 When you create a HOLD file with SET ASNAMES = ON, the original field name is
 propagated to the output Master File, not the AS name.
@@ -2650,7 +2650,7 @@ and Aggregating Report Columns on page 173.
 
 156
 
-Syntax:
+Syntax:
 
 How to Rank Sort Field Values
 
@@ -2693,7 +2693,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  157
 
-Ranking Sort Field Values
+Ranking Sort Field Values
 
 The output is:
 
@@ -2729,7 +2729,7 @@ sequential integer. This method of assigning rank numbers is called dense.
 
 158
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Some of the relational engines assign rank numbers using a method called sparse. With
 sparse ranking, if multiple data values are assigned the same rank number, the next rank
@@ -2784,7 +2784,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  159
 
-Ranking Sort Field Values
+Ranking Sort Field Values
 
 where:
 
@@ -2826,7 +2826,7 @@ END
 
 160
 
-On the output, six employees are included in rank number 6. With dense ranking, the next rank
+On the output, six employees are included in rank number 6. With dense ranking, the next rank
 number is the next highest integer, 7.
 
 3. Sorting Tabular Reports
@@ -2876,7 +2876,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  161
 
-Ranking Sort Field Values
+Ranking Sort Field Values
 
 Example:
 
@@ -2921,7 +2921,7 @@ $115,000.00  CE    LASTRA           KAREN
 
 162
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Running the same request with SET RANK=SPARSE produces the following output. Since six
 employees have salary $62,500, that value is counted 6 times so that only 12 lines (seven
@@ -2974,7 +2974,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  163
 
-Grouping Numeric Data Into Ranges
+Grouping Numeric Data Into Ranges
 
 The FOR phrase is usually used to produce matrix reports and is part of the Financial Modeling
 Language (FML). However, you can also use it to create columnar reports that group sort field
@@ -3022,7 +3022,7 @@ END
 
 164
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 The output is:
 
@@ -3079,7 +3079,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  165
 
-Grouping Numeric Data Into Ranges
+Grouping Numeric Data Into Ranges
 
 The output is:
 
@@ -3106,7 +3106,7 @@ Is a value that identifies the end of a range.
 
 166
 
-Example:
+Example:
 
 Defining Custom Groups of Data Values
 
@@ -3146,7 +3146,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  167
 
-Grouping Numeric Data Into Ranges
+Grouping Numeric Data Into Ranges
 
 Tiling is calculated within all of the higher-level sort fields in the request, and restarts
 whenever a sort field at a higher level than the tile field value changes.
@@ -3211,7 +3211,7 @@ Sorts the data in descending order so that the highest data values are placed in
 
 168
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 LOWEST
 
@@ -3260,7 +3260,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  169
 
-Grouping Numeric Data Into Ranges
+Grouping Numeric Data Into Ranges
 
 Example:
 
@@ -3294,7 +3294,7 @@ END
 
 170
 
-The output is:
+The output is:
 
 3. Sorting Tabular Reports
 
@@ -3324,7 +3324,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  171
 
-Restricting Sort Field Values by Highest/Lowest Rank
+Restricting Sort Field Values by Highest/Lowest Rank
 
 Reference: Usage Notes for Tiles
 
@@ -3371,7 +3371,7 @@ You can have up to five sort fields with BY HIGHEST or BY LOWEST.
 
 172
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Syntax:
 
@@ -3423,7 +3423,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  173
 
-Sorting and Aggregating Report Columns
+Sorting and Aggregating Report Columns
 
 You can also use the BY TOTAL phrase to sort based on temporary values calculated by the
 COMPUTE command.
@@ -3482,7 +3482,7 @@ END
 
 174
 
-The output is:
+The output is:
 
 3. Sorting Tabular Reports
 
@@ -3521,7 +3521,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  175
 
-Sorting and Aggregating Report Columns
+Sorting and Aggregating Report Columns
 
 The output is:
 
@@ -3555,7 +3555,7 @@ phrase).
 
 176
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Hiding Sort Values
 
@@ -3596,7 +3596,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  177
 
-Sort Performance Considerations
+Sort Performance Considerations
 
 To list the employees in the order in which they were hired, you would sort the report by the
 HIRE_DATE field and hide the sort field occurrence using the NOPRINT phrase.
@@ -3623,7 +3623,7 @@ SET SORTMATRIX = {SMALL|LARGE}
 
 178
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 where:
 
@@ -3668,7 +3668,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  179
 
-Sorting With Multiple Display Commands
+Sorting With Multiple Display Commands
 
 Sorting With Multiple Display Commands
 
@@ -3721,7 +3721,7 @@ current salaries for each employee name.
 
 180
 
-The output is:
+The output is:
 
 3. Sorting Tabular Reports
 
@@ -3767,7 +3767,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  181
 
-Sorting With Multiple Display Commands
+Sorting With Multiple Display Commands
 
 With DUPLICATECOL=ON, the output has separate columns for the grand totals and for the
 departmental totals:
@@ -3802,7 +3802,7 @@ departmental totals, and for each last name:
 
 182
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 With DUPLICATECOL=OFF, the output has one column for each field. The grand totals are on
 the top row of the report, the departmental totals are on additional rows below the grand
@@ -3858,7 +3858,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  183
 
-Sorting With Multiple Display Commands
+Sorting With Multiple Display Commands
 
 SET DUPLICATECOL = OFF
 TABLE FILE EMPLOYEE
@@ -3887,7 +3887,7 @@ has multiple ED_HRS columns).
 
 184
 
-The output is:
+The output is:
 
 3. Sorting Tabular Reports
 
@@ -3909,7 +3909,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  185
 
-Sorting With Multiple Display Commands
+Sorting With Multiple Display Commands
 
 Example:
 
@@ -3935,7 +3935,7 @@ END
 
 186
 
-The partial output is shown in the following image.
+The partial output is shown in the following image.
 
 3. Sorting Tabular Reports
 
@@ -3943,7 +3943,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  187
 
-Improving Efficiency With External Sorts
+Improving Efficiency With External Sorts
 
 Improving Efficiency With External Sorts
 
@@ -3991,7 +3991,7 @@ went through TABLE processing because it was not convertible to TABLEF.
 
 188
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Your input is sorted or almost sorted.
 
@@ -4050,7 +4050,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  189
 
-Improving Efficiency With External Sorts
+Improving Efficiency With External Sorts
 
 SQL
 
@@ -4103,7 +4103,7 @@ directories.
 
 190
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Warning: Any one or more of these work files may become very large. Count on using many
 times the total disk space required by FOCSORT.
@@ -4152,7 +4152,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  191
 
-Improving Efficiency With External Sorts
+Improving Efficiency With External Sorts
 
 Reference: Sort Work Files on IBM i
 
@@ -4206,7 +4206,7 @@ SYNCSORT for SyncSort without messages.
 
 192
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 MVSMSGSS for SyncSort with standard messages.
 
@@ -4266,7 +4266,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  193
 
-Improving Efficiency With External Sorts
+Improving Efficiency With External Sorts
 
 You may also receive one of the following messages:
 
@@ -4317,7 +4317,7 @@ In this case, the return code is yyyyyyyy and it is expressed in hex. The final 
 
 194
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Translate the return code into decimal and follow the instructions for return codes in a TABLE
 request.
@@ -4373,7 +4373,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  195
 
-Improving Efficiency With External Sorts
+Improving Efficiency With External Sorts
 
 OFF disallows aggregation by an external sort.
 
@@ -4430,7 +4430,7 @@ W GERMANY   BMW
 
 196
 
-Note: SUMPREFIX is described in Changing Retrieval Order With Aggregation on page 197.
+Note: SUMPREFIX is described in Changing Retrieval Order With Aggregation on page 197.
 
 3. Sorting Tabular Reports
 
@@ -4485,7 +4485,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  197
 
-Improving Efficiency With External Sorts
+Improving Efficiency With External Sorts
 
 Example:
 
@@ -4519,7 +4519,7 @@ large data sources.
 
 198
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 Syntax:
 
@@ -4573,7 +4573,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  199
 
-Hierarchical Reporting: BY HIERARCHY
+Hierarchical Reporting: BY HIERARCHY
 
 WebFOCUS also supports defining dimension hierarchies in synonyms for non-cube data
 sources that have hierarchical data. Once hierarchical dimensions are defined in a synonym,
@@ -4621,7 +4621,7 @@ Phase 2, screening the retrieved dimension data.
 
 200
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 WHERE criteria are applied to the leaf nodes of the members selected during phase 1.
 Therefore, dimension properties can be used in WHERE tests. These tests can also
@@ -4679,7 +4679,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  201
 
-Hierarchical Reporting: BY HIERARCHY
+Hierarchical Reporting: BY HIERARCHY
 
 Several fields are used to define a parent/child hierarchy. Each has a PROPERTY attribute that
 describes which hierarchy property it represents. Each hierarchy must have a unique identifier
@@ -4732,7 +4732,7 @@ Is the hierarchy field.
 
 202
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 parentalias
 
@@ -4780,7 +4780,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  203
 
-Hierarchical Reporting: BY HIERARCHY
+Hierarchical Reporting: BY HIERARCHY
 
 Example:
 
@@ -4833,7 +4833,7 @@ MATCH GL_ACCOUNT
 204
 
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 DATA
 1000          R.   +  1Profit Before Tax
@@ -4882,7 +4882,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  205
 
-Hierarchical Reporting: BY HIERARCHY
+Hierarchical Reporting: BY HIERARCHY
 
 3310   3300   E7301+  5Salaries-Corp Mgmt                   505.00
 3320   3300   E7302+  5Salaries-Administration              505.00
@@ -4942,7 +4942,7 @@ Is the field name of a measure.
 
 206
 
-3. Sorting Tabular Reports
+3. Sorting Tabular Reports
 
 BY hierarchy_field HIERARCHY
 
@@ -4998,7 +4998,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  207
 
-Hierarchical Reporting: BY HIERARCHY
+Hierarchical Reporting: BY HIERARCHY
 
 byoption
 
@@ -5039,7 +5039,7 @@ END
 
 208
 
-Partial output is shown in the following image. The accounts are indented to show the
+Partial output is shown in the following image. The accounts are indented to show the
 hierarchical relationships:
 
 3. Sorting Tabular Reports
@@ -5048,7 +5048,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  209
 
-Hierarchical Reporting: BY HIERARCHY
+Hierarchical Reporting: BY HIERARCHY
 
 The following is the same request using the GL_ACCOUNT_CAPTION field:
 
@@ -5063,7 +5063,7 @@ END
 
 210
 
-Partial output is shown in the following image:
+Partial output is shown in the following image:
 
 3. Sorting Tabular Reports
 
@@ -5071,7 +5071,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  211
 
-Hierarchical Reporting: BY HIERARCHY
+Hierarchical Reporting: BY HIERARCHY
 
 Example:
 
@@ -5095,7 +5095,7 @@ END
 
 212
 
-The output is shown in the following image:
+The output is shown in the following image:
 
 3. Sorting Tabular Reports
 
@@ -5103,7 +5103,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  213
 
-Hierarchical Reporting: BY HIERARCHY
+Hierarchical Reporting: BY HIERARCHY
 
 Example:
 
@@ -5126,7 +5126,7 @@ END
 
 214
 
-The output is shown in the following image:
+The output is shown in the following image:
 
 3. Sorting Tabular Reports
 
@@ -5134,6 +5134,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  215
 
-Hierarchical Reporting: BY HIERARCHY
+Hierarchical Reporting: BY HIERARCHY
 
 216

--- a/specifications/creating_reports/creating_reports_04_chapter4.md
+++ b/specifications/creating_reports/creating_reports_04_chapter4.md
@@ -62,7 +62,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  217
 
-Choosing a Filtering Method
+Choosing a Filtering Method
 
 For non-FOCUS data sources that have group keys, you can select records based on group
 key values. See Selections Based on Group Key Values on page 257.
@@ -115,7 +115,7 @@ are described in Operators Supported for WHERE and IF Tests on page 236.
 
 218
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 ;
 
@@ -164,7 +164,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  219
 
-Selections Based on Individual Values
+Selections Based on Individual Values
 
 Example:
 
@@ -204,7 +204,7 @@ The output is:
 
 220
 
-For related information, see Using Compound Expressions for Record Selection on page 235.
+For related information, see Using Compound Expressions for Record Selection on page 235.
 
 Controlling Record Selection in Multi-path Data Sources
 
@@ -259,7 +259,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  221
 
-Selections Based on Individual Values
+Selections Based on Individual Values
 
 It lacks any referenced child on a path, but the child is optional.
 
@@ -293,7 +293,7 @@ WHERE criteria that screen on more than one path with the OR operator are not su
 
 222
 
-Example:
+Example:
 
 Retrieving Data From Multiple Paths
 
@@ -324,7 +324,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  223
 
-Selections Based on Individual Values
+Selections Based on Individual Values
 
 The output is:
 
@@ -376,7 +376,7 @@ Same as SIMPLE.
 
 224
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 Request
 
@@ -476,7 +476,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  225
 
-Selection Based on Aggregate Values
+Selection Based on Aggregate Values
 
 Reference: Rules for Determining If a Segment Is Required
 
@@ -531,7 +531,7 @@ defined in a valid expression that evaluates as true or false (that is, a Boolea
 
 226
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 expression). Expressions are described in detail in Using Expressions on page 429.
 Operators that can be used in WHERE expressions (such as, IS and GT) are described
@@ -584,7 +584,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  227
 
-Applying Selection Criteria to the Internal Matrix Prior to COMPUTE Processing
+Applying Selection Criteria to the Internal Matrix Prior to COMPUTE Processing
 
 Now, add a WHERE TOTAL phrase to the request in order to generate a report that lists only
 the departments where the total of the salaries is more than $110,000.
@@ -641,7 +641,7 @@ WHERE_GROUPED expression
 
 228
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 where:
 
@@ -675,13 +675,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  229
 
-Applying Selection Criteria to the Internal Matrix Prior to COMPUTE Processing
+Applying Selection Criteria to the Internal Matrix Prior to COMPUTE Processing
 
 The output is shown in the following image.
 
 230
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 The following version of the request adds a WHERE TOTAL test to select only those months
 where DAYSDELAYED exceeded 200 days.
@@ -703,7 +703,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  231
 
-Applying Selection Criteria to the Internal Matrix Prior to COMPUTE Processing
+Applying Selection Criteria to the Internal Matrix Prior to COMPUTE Processing
 
 The output is shown in the following image. The COMPUTE calculations for CTR and NEWDAYS
 were processed prior to eliminating the rows in which TOTAL DAYSDELAYED were 200 or less,
@@ -714,7 +714,7 @@ the COMPUTE expressions are evaluated. This requires WHERE_GROUPED.
 
 232
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 The following version of the request replaces the WHERE TOTAL test with a WHERE_GROUPED
 test.
@@ -736,7 +736,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  233
 
-Applying Selection Criteria to the Internal Matrix Prior to COMPUTE Processing
+Applying Selection Criteria to the Internal Matrix Prior to COMPUTE Processing
 
 The output is shown in the following image. The COMPUTE calculation for NEWDAYS was
 processed after eliminating the rows in which TOTAL DAYSDELAYED were 200 or less, so its
@@ -757,7 +757,7 @@ part of a WHERE_GROUPED test.
 
 234
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 WHERE_GROUPED can be optimized for SQL data sources by creating a GROUP BY
 fieldname HAVING expression clause, where the expression is the WHERE_GROUPED
@@ -808,7 +808,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  235
 
-Using Operators in Record Selection Tests
+Using Operators in Record Selection Tests
 
 If parentheses are excluded, the logical AND is evaluated before the literal OR.
 
@@ -895,7 +895,7 @@ than the test value.
 Tests for and selects values less
 than the test value.
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 WHERE Operator
 
@@ -989,7 +989,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Using Operators in Record Selection Tests
+Using Operators in Record Selection Tests
 
 WHERE Operator
 
@@ -1062,7 +1062,7 @@ phrase.
 
 
 
-Example:
+Example:
 
 Using Operators to Compare a Field to One or More Values
 
@@ -1116,7 +1116,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  239
 
-Using Operators in Record Selection Tests
+Using Operators in Record Selection Tests
 
 Example 10: The value of CAR must be equal to one of the alphanumeric values in the
 unordered list. Single quotation marks must enclose alphanumeric list values.
@@ -1145,7 +1145,7 @@ END
 
 240
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 The output is shown in the following image. In the selected records, WHOLESALEPR is greater
 than $15.00 if LISTPR is greater than $20.00. WHOLESALEPR is greater than $11.00 if
@@ -1155,7 +1155,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  241
 
-Using Operators in Record Selection Tests
+Using Operators in Record Selection Tests
 
 Example:
 
@@ -1184,7 +1184,7 @@ Select a region from the drop-down list and click Submit. The output for the NE 
 
 242
 
-Types of Record Selection Tests
+Types of Record Selection Tests
 
 4. Selecting Records for Your Report
 
@@ -1241,7 +1241,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  243
 
-Types of Record Selection Tests
+Types of Record Selection Tests
 
 upper
 
@@ -1301,7 +1301,7 @@ ACROSS MONTH FROM 6 TO 10
 
 244
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 Range Tests With GE and LE or GT and LT
 
@@ -1357,7 +1357,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  245
 
-Types of Record Selection Tests
+Types of Record Selection Tests
 
 Example:
 
@@ -1415,7 +1415,7 @@ Are record selection operators. EQ and IS are synonyms.
 
 246
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 Syntax:
 
@@ -1477,7 +1477,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  247
 
-Types of Record Selection Tests
+Types of Record Selection Tests
 
 The output is:
 
@@ -1522,7 +1522,7 @@ WHERE field LIKE 'mask'
 
 248
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 To reject records based on the mask value, use either
 
@@ -1586,7 +1586,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  249
 
-Types of Record Selection Tests
+Types of Record Selection Tests
 
 To reject records based on the mask value, use
 
@@ -1636,7 +1636,7 @@ END
 
 250
 
-The output is:
+The output is:
 
 4. Selecting Records for Your Report
 
@@ -1682,7 +1682,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  251
 
-Types of Record Selection Tests
+Types of Record Selection Tests
 
 Example:
 
@@ -1745,7 +1745,7 @@ handy$man@usa.com, which has a dollar sign.
 
 252
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 handyiman@usa.com, which has the letter i in the same position as the $ character in the
 other email address.
@@ -1792,7 +1792,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  253
 
-Types of Record Selection Tests
+Types of Record Selection Tests
 
 Syntax:
 
@@ -1855,7 +1855,7 @@ The escape character itself can be escaped, thus becoming a normal character in 
 
 254
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 Only one escape character can be used per LIKE phrase in a WHERE phrase.
 
@@ -1910,7 +1910,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  255
 
-Types of Record Selection Tests
+Types of Record Selection Tests
 
 Example:
 
@@ -1969,7 +1969,7 @@ a separate line.
 
 256
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 You can connect the literals you are testing for with ANDs and ORs; however, the ORs are
 changed to ANDs.
@@ -2027,7 +2027,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  257
 
-Setting Limits on the Number of Records Read
+Setting Limits on the Number of Records Read
 
 Example:
 
@@ -2084,7 +2084,7 @@ to be performed. For details, see the appropriate data adapter manual.
 
 258
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 Tip: If an attempt is made to apply the READLIMIT test to a FOCUS data source, the request is
 processed correctly, but the READLIMIT phrase is ignored.
@@ -2147,7 +2147,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  259
 
-Reading Selection Values From a File
+Reading Selection Values From a File
 
 Note that all literals that contain blanks (for example, New York City) and all date and date-
 time literals must be enclosed within single quotation marks.
@@ -2193,7 +2193,7 @@ maintaining the criteria in just one location.
 
 260
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 If the selection values already exist in a data source, you can quickly create a file of
 selection values by generating a report and saving the output in a HOLD or SAVE file. You
@@ -2253,7 +2253,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  261
 
-Reading Selection Values From a File
+Reading Selection Values From a File
 
 file1, file1
 
@@ -2310,7 +2310,7 @@ For WHERE, alphanumeric values with embedded blanks or any mathematical operator
 
 262
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 For WHERE, when a compound WHERE phrase uses IN FILE more than once, the specified
 files must have the same record formats.
@@ -2367,7 +2367,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  263
 
-Reading Selection Values From a File
+Reading Selection Values From a File
 
 TABLE FILE GGPRODS
 BY PRODUCT_ID BY PRODUCT_DESCRIPTION
@@ -2422,7 +2422,7 @@ IF PRODUCT_DESCRIPTION EQ 'B141' or 'B142'
 
 264
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 The output is:
 
@@ -2465,7 +2465,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  265
 
-Assigning Screening Conditions to a File
+Assigning Screening Conditions to a File
 
 Syntax:
 
@@ -2528,7 +2528,7 @@ Cannot be referenced in a DEFINE or TABLE command.
 
 266
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 Support any syntax valid for virtual fields in a DEFINE command.
 
@@ -2583,7 +2583,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  267
 
-Assigning Screening Conditions to a File
+Assigning Screening Conditions to a File
 
 Syntax:
 
@@ -2638,7 +2638,7 @@ SET FILTER = G IN CAR OFF
 
 268
 
-The following commands activate some filters and deactivate others:
+The following commands activate some filters and deactivate others:
 
 4. Selecting Records for Your Report
 
@@ -2692,7 +2692,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  269
 
-Assigning Screening Conditions to a File
+Assigning Screening Conditions to a File
 
 Example:
 
@@ -2748,7 +2748,7 @@ NO FILTERS DEFINED FOR FILE NAMED CAR
 
 270
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 If filters are defined for the CAR data source, the following screen displays:
 
@@ -2798,7 +2798,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  271
 
-Assigning Screening Conditions to a File
+Assigning Screening Conditions to a File
 
 Syntax:
 
@@ -2862,7 +2862,7 @@ END
 
 
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 The output shows that the TABLE request retrieved only the data that satisfies the UNITPR
 filter:
@@ -2918,7 +2918,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-VSAM Record Selection Efficiencies
+VSAM Record Selection Efficiencies
 
 Now, J1 is cleared. The output of the ? FILTER command shows that the YEARS1 filter that
 was created after the JOIN command was issued no longer exists. The UNITPR filter created
@@ -2970,7 +2970,7 @@ a key other than the primary key.
 274
 
 
-4. Selecting Records for Your Report
+4. Selecting Records for Your Report
 
 All benefits and limitations inherent with screening on the primary or partial key are applicable
 to screening on the alternate index or partial alternate index.
@@ -2981,6 +2981,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  275
 
-VSAM Record Selection Efficiencies
+VSAM Record Selection Efficiencies
 
 276

--- a/specifications/creating_reports/creating_reports_05_chapter5.md
+++ b/specifications/creating_reports/creating_reports_05_chapter5.md
@@ -44,7 +44,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  277
 
-What Is a Temporary Field?
+What Is a Temporary Field?
 
 You can specify the expression yourself, or you can use one of the many supplied functions
 that perform specific calculations or manipulations. In addition, you can use expressions and
@@ -66,7 +66,7 @@ values of the fields.
 
 278
 
-Reference: Evaluation of Temporary Fields
+Reference: Evaluation of Temporary Fields
 
 The following illustration shows how a request processes, and when each type of temporary
 field is evaluated:
@@ -94,7 +94,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  279
 
-Defining a Virtual Field
+Defining a Virtual Field
 
 The output is:
 
@@ -141,7 +141,7 @@ Joining Data Sources on page 1069.
 
 280
 
-Reference: Usage Notes for Creating Virtual Fields
+Reference: Usage Notes for Creating Virtual Fields
 
 5. Creating Temporary Fields
 
@@ -189,7 +189,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  281
 
-Defining a Virtual Field
+Defining a Virtual Field
 
 Syntax:
 
@@ -249,7 +249,7 @@ File, which you want to redefine.
 
 282
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 The name can include any combination of letters, digits, and underscores (_), and should
 begin with a letter.
@@ -311,7 +311,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  283
 
-Defining a Virtual Field
+Defining a Virtual Field
 
 REDEFINES qualifier.fieldname
 
@@ -364,7 +364,7 @@ DELIVER_AMT  OPENING_AMT           RATIO
 
 284
 
-Example:
+Example:
 
 Redefining a Field
 
@@ -404,7 +404,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  285
 
-Defining a Virtual Field
+Defining a Virtual Field
 
 Example:
 
@@ -458,7 +458,7 @@ If you want to clear a virtual field for a particular data source, use the CLEAR
 
 286
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 Syntax:
 
@@ -516,7 +516,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  287
 
-Defining a Virtual Field
+Defining a Virtual Field
 
 Clearing a Virtual Field
 
@@ -563,7 +563,7 @@ in the last DEFINE is available for further requests.
 
 288
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 Establishing a Segment Location for a Virtual Field
 
@@ -598,7 +598,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  289
 
-Defining a Virtual Field
+Defining a Virtual Field
 
 For FOCUS data sources, you may be able to increase the retrieval speed with an external
 index on the virtual field. In this case, you can associate the index with a target segment
@@ -639,7 +639,7 @@ Virtual fields are compiled into machine code in order to increase the speed of 
 
 290
 
-Preserving Virtual Fields Using DEFINE FILE SAVE and RETURN
+Preserving Virtual Fields Using DEFINE FILE SAVE and RETURN
 
 5. Creating Temporary Fields
 
@@ -697,7 +697,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  291
 
-Defining a Virtual Field
+Defining a Virtual Field
 
 Applying Dynamically Formatted Virtual Fields to Report Columns
 
@@ -747,7 +747,7 @@ displays with plus signs (++++) on the report output.
 
 292
 
-Syntax:
+Syntax:
 
 How to Define and Apply a Format Field
 
@@ -809,7 +809,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  293
 
-Defining a Virtual Field
+Defining a Virtual Field
 
 Reference: Usage Notes for Field-Based Reformatting
 
@@ -861,7 +861,7 @@ END
 
 294
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 TABLE FILE GGSALES
 SUM DOLLARS2/MYFORMAT AS 'Dynamic' DOLLARS2/P10.2 AS 'Specific'
@@ -903,7 +903,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  295
 
-Defining a Virtual Field
+Defining a Virtual Field
 
 Constant DEFINE fields must be assigned a segment location using the WITH phrase.
 
@@ -957,7 +957,7 @@ FOR FETCH ONLY;
 
 
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 Creating a Calculated Value
 
@@ -1001,7 +1001,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  297
 
-Creating a Calculated Value
+Creating a Calculated Value
 
 Syntax:
 
@@ -1058,7 +1058,7 @@ STATE. State name.
 
 298
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 expression
 
@@ -1108,7 +1108,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  299
 
-Creating a Calculated Value
+Creating a Calculated Value
 
 Example:
 
@@ -1165,7 +1165,7 @@ Numbers on page 302.
 300
 
 
-Example:
+Example:
 
 Using Positional Column Referencing
 
@@ -1222,7 +1222,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  301
 
-Assigning Column Reference Numbers
+Assigning Column Reference Numbers
 
 Example:
 
@@ -1274,7 +1274,7 @@ for the columns that are used in your report, use the CNOTATION column notation 
 
 302
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 Because column numbers refer to columns in the internal matrix, they are assigned after
 retrieval and aggregation of data are completed. Columns created and displayed in a report are
@@ -1330,7 +1330,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  303
 
-Assigning Column Reference Numbers
+Assigning Column Reference Numbers
 
 Example:
 
@@ -1385,7 +1385,7 @@ END
 304
 
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 The output is:
 
@@ -1450,7 +1450,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  305
 
 
-Assigning Column Reference Numbers
+Assigning Column Reference Numbers
 
 CASH ON HAND
 
@@ -1544,7 +1544,7 @@ INVENTORY
 
 306
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 --------
 
@@ -1604,7 +1604,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  307
 
-Assigning Column Reference Numbers
+Assigning Column Reference Numbers
 
 Example:
 
@@ -1633,7 +1633,7 @@ The output is:
 
 308
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 Example:
 
@@ -1684,7 +1684,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  309
 
-Assigning Column Reference Numbers
+Assigning Column Reference Numbers
 
 SET CNOTATION = ALL
 TABLE FILE VIDEOTRK
@@ -1738,7 +1738,7 @@ C1 is QUANTITY with format D7.2.
 
 310
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 C2 is TRANSCODE.
 
@@ -1791,7 +1791,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  311
 
-Assigning Column Reference Numbers
+Assigning Column Reference Numbers
 
 Example:
 
@@ -1854,7 +1854,7 @@ BY fields are not assigned column numbers.
 
 
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 ACROSS columns are assigned column numbers.
 
@@ -1907,7 +1907,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  313
 
-Using FORECAST in a COMPUTE Command
+Using FORECAST in a COMPUTE Command
 
 Double exponential smoothing (FORECAST_DOUBLEXP). Accounts for the tendency of
 data to either increase or decrease over time without repeating. For details, see
@@ -1956,7 +1956,7 @@ should be spaced evenly in order to get meaningful results.
 
 314
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 The use of column notation is not supported in the FORECAST expression. Column notation
 continues to be supported as before outside of this expression. The process of generating
@@ -2006,7 +2006,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  315
 
-Using FORECAST in a COMPUTE Command
+Using FORECAST in a COMPUTE Command
 
 The first complete moving average occurs at the nth data point because the calculation
 requires n values. This is called the lag. The moving average values for the lag rows are
@@ -2059,7 +2059,7 @@ months.
 
 316
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 npredict
 
@@ -2100,7 +2100,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  317
 
-Using FORECAST in a COMPUTE Command
+Using FORECAST in a COMPUTE Command
 
 The output is:
 
@@ -2114,7 +2114,7 @@ The first MOVAVE value (801,123.0) is equal to the first DOLLARS value.
 
 318
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 The second MOVAVE value (741,731.5) is the mean of DOLLARS values one and two:
 (801,123 + 682,340) /2.
@@ -2162,7 +2162,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  319
 
-Using FORECAST in a COMPUTE Command
+Using FORECAST in a COMPUTE Command
 
 The output is shown in the following image:
 
@@ -2182,7 +2182,7 @@ Is the newest value.
 
 320
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 n
 
@@ -2242,7 +2242,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  321
 
-Using FORECAST in a COMPUTE Command
+Using FORECAST in a COMPUTE Command
 
 For date fields, the minimal component in the format determines how the number is
 interpreted. For example, if the format is YMD, MDY, or DMY, an interval value of 2 is
@@ -2288,7 +2288,7 @@ END
 
 322
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 The output is shown in the following image:
 
@@ -2349,7 +2349,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  323
 
-Using FORECAST in a COMPUTE Command
+Using FORECAST in a COMPUTE Command
 
 The third EXPAVE value (753,404.8) is calculated as follows:
 
@@ -2399,7 +2399,7 @@ interval, npredict, npoint1, npoint2)
 
 324
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 where:
 
@@ -2459,7 +2459,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  325
 
-Using FORECAST in a COMPUTE Command
+Using FORECAST in a COMPUTE Command
 
 g=2/(1+npoint2)
 
@@ -2494,7 +2494,7 @@ using three equations with three constants.
 326
 
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 For triple exponential smoothing you, need to know the number of data points in each time
 period (designated as L in the following equations). To account for the seasonality, a seasonal
@@ -2546,7 +2546,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  327
 
-Using FORECAST in a COMPUTE Command
+Using FORECAST in a COMPUTE Command
 
 The three constants must be chosen carefully. The best results are usually obtained by
 choosing the constants to minimize the mean-squared error (MSE) between the data values
@@ -2603,7 +2603,7 @@ to the same format as the sort field.
 
 328
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 For date fields, the minimal component in the format determines how the number is
 interpreted. For example, if the format is YMD, MDY, or DMY, an interval value of 2 is
@@ -2650,7 +2650,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  329
 
-Using FORECAST in a COMPUTE Command
+Using FORECAST in a COMPUTE Command
 
 Example:
 
@@ -2675,7 +2675,7 @@ generated.
 
 330
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 FORECAST_LINEAR: Using a Linear Regression Equation
 
@@ -2729,7 +2729,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  331
 
-Using FORECAST in a COMPUTE Command
+Using FORECAST in a COMPUTE Command
 
 Syntax:
 
@@ -2781,7 +2781,7 @@ supported with a non-recursive FORECAST.
 
 332
 
-Example:
+Example:
 
 Calculating a New Linear Regression Field
 
@@ -2817,7 +2817,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  333
 
-Using FORECAST in a COMPUTE Command
+Using FORECAST in a COMPUTE Command
 
 TRANSDATE is the independent variable (x) and QUANTITY is the dependent variable (y).
 The equation is used to calculate QUANTITY FORECAST trend and predicted values.
@@ -2844,7 +2844,7 @@ display zero. You can also propagate this field to a HOLD file.
 
 334
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 Example:
 
@@ -2877,7 +2877,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  335
 
-Calculating Trends and Predicting Values With FORECAST
+Calculating Trends and Predicting Values With FORECAST
 
 Calculating Trends and Predicting Values With FORECAST
 
@@ -2922,7 +2922,7 @@ always reliable, and many factors determine how accurate a prediction will be.
 
 336
 
-FORECAST Processing
+FORECAST Processing
 
 5. Creating Temporary Fields
 
@@ -2973,7 +2973,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  337
 
-Calculating Trends and Predicting Values With FORECAST
+Calculating Trends and Predicting Values With FORECAST
 
 DOUBLEXP calculation
 
@@ -3032,7 +3032,7 @@ months.
 
 338
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 npredict
 
@@ -3090,7 +3090,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  339
 
-Calculating Trends and Predicting Values With FORECAST
+Calculating Trends and Predicting Values With FORECAST
 
 In a recursive FORECAST request, specify the options when the field is first referenced
 in the report request.
@@ -3138,7 +3138,7 @@ MISSING attribute.
 
 340
 
-Using a Simple Moving Average
+Using a Simple Moving Average
 
 5. Creating Temporary Fields
 
@@ -3186,7 +3186,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  341
 
-Calculating Trends and Predicting Values With FORECAST
+Calculating Trends and Predicting Values With FORECAST
 
 The output is:
 
@@ -3200,7 +3200,7 @@ The first MOVAVE value (801,123.0) is equal to the first DOLLARS value.
 
 342
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 The second MOVAVE value (741,731.5) is the mean of DOLLARS values one and two:
 (801,123 + 682,340) /2.
@@ -3245,13 +3245,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  343
 
-Calculating Trends and Predicting Values With FORECAST
+Calculating Trends and Predicting Values With FORECAST
 
 The output is:
 
 344
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 Using Single Exponential Smoothing
 
@@ -3309,7 +3309,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  345
 
-Calculating Trends and Predicting Values With FORECAST
+Calculating Trends and Predicting Values With FORECAST
 
 The output is:
 
@@ -3324,7 +3324,7 @@ The first EXPAVE value (801,123.0) is the same as the first DOLLARS value.
 
 346
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 The second EXPAVE value (741,731.5) is calculated as follows. Note that because of
 rounding and the number of decimal places used, the value derived in this sample
@@ -3375,7 +3375,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  347
 
-Calculating Trends and Predicting Values With FORECAST
+Calculating Trends and Predicting Values With FORECAST
 
 These two equations are solved to derive the smoothed average. The first smoothed average is
 set to the first data value. The first trend component is set to zero. For choosing the two
@@ -3416,7 +3416,7 @@ The output is:
 348
 
 
-Using Triple Exponential Smoothing
+Using Triple Exponential Smoothing
 
 5. Creating Temporary Fields
 
@@ -3470,7 +3470,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  349
 
-Calculating Trends and Predicting Values With FORECAST
+Calculating Trends and Predicting Values With FORECAST
 
 3. Then, the initial periodicity factor is given by the following formula, where N is the number
 of full periods available in the data, L is the number of points per period and n is a point
@@ -3512,7 +3512,7 @@ END
 
 350
 
-In the output, npredict is 3. Therefore, three periods (nine points, nperiod * npredict) are
+In the output, npredict is 3. Therefore, three periods (nine points, nperiod * npredict) are
 generated.
 
 5. Creating Temporary Fields
@@ -3543,7 +3543,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  351
 
-Calculating Trends and Predicting Values With FORECAST
+Calculating Trends and Predicting Values With FORECAST
 
 b
 
@@ -3583,7 +3583,7 @@ END
 
 352
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 The output is:
 
@@ -3651,7 +3651,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  353
 
-Calculating Trends and Predicting Values With FORECAST
+Calculating Trends and Predicting Values With FORECAST
 
 DEALER_COST
 
@@ -3709,7 +3709,7 @@ END
 
 354
 
-The output is shown in the following image.
+The output is shown in the following image.
 
 5. Creating Temporary Fields
 
@@ -3739,7 +3739,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  355
 
-Calculating Trends and Predicting Values With FORECAST
+Calculating Trends and Predicting Values With FORECAST
 
 The output is shown in the following image.
 
@@ -3799,7 +3799,7 @@ DEALER_COST  DATA_ROW  PREDICT             MPG          FORMPG
 
 356
 
-Calculating Trends and Predicting Values With Multivariate REGRESS
+Calculating Trends and Predicting Values With Multivariate REGRESS
 
 5. Creating Temporary Fields
 
@@ -3853,7 +3853,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  357
 
-Calculating Trends and Predicting Values With Multivariate REGRESS
+Calculating Trends and Predicting Values With Multivariate REGRESS
 
 x1, x2, x3
 
@@ -3904,7 +3904,7 @@ Fields with missing values cannot be used in the regression.
 
 358
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 Larger amounts of data produce more useful results.
 
@@ -3936,7 +3936,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  359
 
-Using Text Fields in DEFINE and COMPUTE
+Using Text Fields in DEFINE and COMPUTE
 
 The output is:
 
@@ -3950,7 +3950,7 @@ Note: COMPUTE commands in Maintain do not support text fields.
 
 360
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 Example:
 
@@ -4001,7 +4001,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  361
 
 
-Creating Temporary Fields Independent of a Master File
+Creating Temporary Fields Independent of a Master File
 
 Syntax:
 
@@ -4056,7 +4056,7 @@ by an AS phrase.
 
 362
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 description
 
@@ -4112,7 +4112,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  363
 
-Creating Temporary Fields Independent of a Master File
+Creating Temporary Fields Independent of a Master File
 
 TABLE FILE MOVIES
  PRINT TITLE LISTPR IN 35 WHOLESALEPR AND
@@ -4254,7 +4254,7 @@ AFTER, THE
 
 
 
-5. Creating Temporary Fields
+5. Creating Temporary Fields
 
 PSYCHO
 
@@ -4344,7 +4344,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Creating Temporary Fields Independent of a Master File
+Creating Temporary Fields Independent of a Master File
 
 Syntax:
 

--- a/specifications/creating_reports/creating_reports_06_chapter6.md
+++ b/specifications/creating_reports/creating_reports_06_chapter6.md
@@ -47,7 +47,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  367
 
-Calculating Row and Column Totals
+Calculating Row and Column Totals
 
 Note that when producing totals in a report, if one field is summed, the format of the row total
 is the same as the format of the field. For example, if the format of the CURR_SAL field is
@@ -106,7 +106,7 @@ ON TABLE ROW-TOTAL [alignment][/format] [AS 'name']
 
 368
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 Example:
 
@@ -155,7 +155,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  369
 
 
-Calculating Row and Column Totals
+Calculating Row and Column Totals
 
 The output is:
 
@@ -207,7 +207,7 @@ TOTAL                     $108,002.00      $114,282.00      $222,284.00
 
 
 
-Example:
+Example:
 
 Including Calculated Values in Row and Column Totals
 
@@ -264,7 +264,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  371
 
 
-Calculating Row and Column Totals
+Calculating Row and Column Totals
 
 When you specify a row total with ACROSS, the row total is calculated separately for each
 column in each ACROSS group. For example, in the following request the row total has a
@@ -320,7 +320,7 @@ San Francisco      312500   3870258    314725  3916863   627225  7787121
 
 372
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 If the different display commands do not all specify the same number of fields, some columns
 will not be represented in the row total. For example, in the following request, the second SUM
@@ -371,7 +371,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  373
 
-Calculating Row and Column Totals
+Calculating Row and Column Totals
 
 Producing Row Totals for Horizontal (ACROSS) Sort Field Values
 
@@ -433,7 +433,7 @@ The output is:
 
 374
 
-Reference: Usage Notes for ACROSS-TOTAL
+Reference: Usage Notes for ACROSS-TOTAL
 
 Stacking headings in ACROSS-TOTAL is not supported.
 
@@ -486,7 +486,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  375
 
-Including Section Totals and a Grand Total
+Including Section Totals and a Grand Total
 
 You can use prefix operators with SUBTOTAL, SUB-TOTAL, SUMMARIZE, and RECOMPUTE. For
 details, see Manipulating Summary Values With Prefix Operators on page 388. In addition, you
@@ -549,7 +549,7 @@ TOTAL                                 $18,436.45
 
 
 
-Including Subtotals
+Including Subtotals
 
 6. Including Totals and Subtotals
 
@@ -611,7 +611,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  377
 
-Including Subtotals
+Including Subtotals
 
 You can use the asterisk (*) wildcard character instead of a field list to indicate that all
 fields, numeric and alphanumeric, should be included on the summary lines.
@@ -669,7 +669,7 @@ END
 
 378
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 The output is:
 
@@ -713,7 +713,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  379
 
-Including Subtotals
+Including Subtotals
 
 On the output, the grand total line comes first, then the subtotal for the MIS department
 followed by the detail lines for the MIS department, followed by the subtotal for the
@@ -767,7 +767,7 @@ displayed field columns.
 
 380
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 If a report request has multiple BY phrases, with SUBTOTAL/SUMMARIZE/RECOMPUTE/
 SUB-TOTAL at several levels, and MULTILINES or MULTI-LINES is specified at any one of
@@ -822,7 +822,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  381
 
-Including Subtotals
+Including Subtotals
 
 Example:
 
@@ -880,7 +880,7 @@ TOTAL                                 $41,521.18      $461,210.75
 
 382
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 Recalculating Values for Subtotal Rows
 
@@ -942,7 +942,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  383
 
-Recalculating Values for Subtotal Rows
+Recalculating Values for Subtotal Rows
 
 You can use the asterisk (*) wildcard character instead of a field list to indicate that all
 fields, numeric and alphanumeric, should be included on the summary lines. You can
@@ -994,7 +994,7 @@ PAY_DATE  DEPARTMENT  BANK_ACCT          GROSS          DED_AMT  DG_RATIO
 
 384
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 The last portion of the output is:
 
@@ -1040,7 +1040,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  385
 
-Summarizing Alphanumeric Columns
+Summarizing Alphanumeric Columns
 
 The first portion of the output is:
 
@@ -1093,7 +1093,7 @@ wildcard character to display all fields on the summary lines.
 
 386
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 The alphanumeric value displayed on a SUBTOTAL or SUB-TOTAL line is either the first,
 minimum, maximum, or last alphanumeric value within the sort group, depending on the value
@@ -1148,7 +1148,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  387
 
-Manipulating Summary Values With Prefix Operators
+Manipulating Summary Values With Prefix Operators
 
 On the output, the alphanumeric formula is recomputed using the summed numeric fields.
 However, the product value is taken from the first product within each sort value, as that field
@@ -1199,7 +1199,7 @@ the summary command.
 
 388
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 Prefix operations on summary lines are performed on the retrieved, selected, and summed
 values that become the detail lines in the report. Unlike field-based prefix operations, they are
@@ -1253,7 +1253,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  389
 
-Manipulating Summary Values With Prefix Operators
+Manipulating Summary Values With Prefix Operators
 
 SUM. (means LST. if SUMPREFIX=LST or FST. if SUMPREFIX=FST)
 
@@ -1317,7 +1317,7 @@ is applied to fieldm. Only the fields specified are populated with values on the
 
 390
 
-summary row. Each prefix operator must be separated by a blank space from the
+summary row. Each prefix operator must be separated by a blank space from the
 following field name. For example:
 
 6. Including Totals and Subtotals
@@ -1370,7 +1370,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  391
 
-Manipulating Summary Values With Prefix Operators
+Manipulating Summary Values With Prefix Operators
 
 Notice that the subtotal row for each rating contains a value only in the LISTPR column, and
 the subtotal row for each category contains a value only in the COPIES column. The grand total
@@ -1428,7 +1428,7 @@ TOTAL                 33   31.91
 
 392
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 Example:
 
@@ -1454,7 +1454,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  393
 
-Manipulating Summary Values With Prefix Operators
+Manipulating Summary Values With Prefix Operators
 
 The output is exactly the same as in the previous request, except for the grand total line:
 
@@ -1516,7 +1516,7 @@ TABLE FILE GGSALES
 
 394
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 On the report output, the summary for each region displays the maximum of the state
 maximum values and the minimum of the state minimum values. The summary for the entire
@@ -1544,7 +1544,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  395
 
-Manipulating Summary Values With Prefix Operators
+Manipulating Summary Values With Prefix Operators
 
 The output is:
 
@@ -1592,7 +1592,7 @@ END
 
 396
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 The output is:
 
@@ -1649,7 +1649,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  397
 
-Manipulating Summary Values With Prefix Operators
+Manipulating Summary Values With Prefix Operators
 
 When SUBTOTAL and RECOMPUTE are the only summary commands used in the request, a
 grand total line is produced only if it is explicitly specified in the request using the ON TABLE
@@ -1703,7 +1703,7 @@ SUMMARIZE commands are totaled.
 
 398
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 A summary command with a list of field names populates only those columns on the
 associated summary line.
@@ -1756,7 +1756,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  399
 
-Manipulating Summary Values With Prefix Operators
+Manipulating Summary Values With Prefix Operators
 
 Running the request with SUMMARYLINES=NEW subtotals COPIES only for the RATING sort
 break and subtotals LISTPR only for the CATEGORY sort break but propagates both to the
@@ -1796,7 +1796,7 @@ TOTAL                                   54.49
 
 400
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 Example:
 
@@ -1850,7 +1850,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  401
 
-Manipulating Summary Values With Prefix Operators
+Manipulating Summary Values With Prefix Operators
 
 The grand total line displays a column total only for the WHOLESALEPR column because of the
 ON TABLE SUBTOTAL command:
@@ -1902,7 +1902,7 @@ be specified for the recomputed report column without affecting the calculated v
 
 402
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 All fields used in the COMPUTE command must be displayed by the RECOMPUTE or
 SUMMARIZE command in order to be populated. If any field used in the expression is not
@@ -1946,7 +1946,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  403
 
-Manipulating Summary Values With Prefix Operators
+Manipulating Summary Values With Prefix Operators
 
 The following request uses prefix operators in the RECOMPUTE command to calculate the
 maximum DOLLARS and the minimum BUDDOLLARS and then recompute DIFF. No matter
@@ -2001,7 +2001,7 @@ END
 
 404
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 The output is:
 
@@ -2062,7 +2062,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  405
 
 
-Manipulating Summary Values With Prefix Operators
+Manipulating Summary Values With Prefix Operators
 
 In the following report output, some of the values have been manually italicized or bolded for
 clarity:
@@ -2079,7 +2079,7 @@ the DOLLARS column of summary lines for the YEAR sort field.
 
 406
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 Subtotal values in boldface are minimums within their sort groups generated by the
 command ON REGION SUB-TOTAL MIN. This is the last summary command, and therefore
@@ -2094,7 +2094,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  407
 
-Combinations of Summary Commands
+Combinations of Summary Commands
 
 If you have multiple summary commands for the same sort field, the following message
 displays and the last summary command specified in the request is used:
@@ -2140,7 +2140,7 @@ command.
 
 408
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 Example:
 
@@ -2199,7 +2199,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  409
 
-Combinations of Summary Commands
+Combinations of Summary Commands
 
 You can change the operation performed at the grand total level by adding the following
 command to the request:
@@ -2236,7 +2236,7 @@ END
 
 410
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 The output is:
 
@@ -2293,7 +2293,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  411
 
-Combinations of Summary Commands
+Combinations of Summary Commands
 
 On the output:
 
@@ -2342,7 +2342,7 @@ END
 
 412
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 SUB-TOTAL propagates to all of the columns that would otherwise be unpopulated. The grand
 total line inherits the RECOMPUTE command for the fields listed in its field list, and the SUB-
@@ -2397,7 +2397,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  413
 
-Producing Summary Columns for Horizontal Sort Fields
+Producing Summary Columns for Horizontal Sort Fields
 
 ACROSS acrossfield
 
@@ -2454,7 +2454,7 @@ higher-level ACROSS field changes value).
 
 414
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 Different operations from two ON phrases for the same sort break display in the same
 summary column, and allow a mixture of operations on summary columns.
@@ -2505,7 +2505,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  415
 
-Producing Summary Columns for Horizontal Sort Fields
+Producing Summary Columns for Horizontal Sort Fields
 
 If an ACROSS field has an ACROSS-TOTAL phrase and a summary command with a
 prefix operator, the prefix operator is applied, not the ACROSS-TOTAL.
@@ -2539,7 +2539,7 @@ END
 
 416
 
-The output is:
+The output is:
 
 6. Including Totals and Subtotals
 
@@ -2563,7 +2563,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  417
 
-Producing Summary Columns for Horizontal Sort Fields
+Producing Summary Columns for Horizontal Sort Fields
 
 The output shows that only the rows with the UNITS values are subtotaled.
 
@@ -2613,7 +2613,7 @@ Gifts category.
 
 418
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 PAGE   1.1
 
@@ -2671,7 +2671,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  419
 
-Producing Summary Columns for Horizontal Sort Fields
+Producing Summary Columns for Horizontal Sort Fields
 
 The summary column, which has a value just for the DOLLARS row. Note that for ACROSS,
 the summary column for REGION appears only after the higher-level ACROSS field,
@@ -2715,7 +2715,7 @@ DOLLARS.
 
 420
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 SET BYPANEL = ON
 TABLE FILE GGSALES
@@ -2764,7 +2764,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  421
 
-Performing Calculations at Sort Field Breaks
+Performing Calculations at Sort Field Breaks
 
 Syntax:
 
@@ -2816,7 +2816,7 @@ must be display fields or sort control fields.
 
 422
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 Each RECAP value displays on a separate line. However, if the request contains a RECAP
 command and SUBFOOT text, the RECAP value displays only in the SUBFOOT text and must
@@ -2856,7 +2856,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  423
 
-Performing Calculations at Sort Field Breaks
+Performing Calculations at Sort Field Breaks
 
 The output is:
 
@@ -2909,7 +2909,7 @@ END
 
 424
 
-6. Including Totals and Subtotals
+6. Including Totals and Subtotals
 
 The output is:
 
@@ -2965,7 +2965,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  425
 
-Suppressing Grand Totals
+Suppressing Grand Totals
 
 Example:
 
@@ -2985,7 +2985,7 @@ END
 
 426
 
-The output is:
+The output is:
 
 6. Including Totals and Subtotals
 
@@ -3000,7 +3000,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  427
 
-Conditionally Displaying Summary Lines and Text
+Conditionally Displaying Summary Lines and Text
 
 Example:
 

--- a/specifications/creating_reports/creating_reports_07_chapter7.md
+++ b/specifications/creating_reports/creating_reports_07_chapter7.md
@@ -46,7 +46,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  429
 
-Types of Expressions
+Types of Expressions
 
 The commands that support expressions, and their basic syntax, are summarized here. For
 complete syntax with an explanation, see the applicable documentation.
@@ -100,7 +100,7 @@ follows:
 
 430
 
-7. Using Expressions
+7. Using Expressions
 
 COMPUTE BONUS/D12.2 = CURR_SAL * 0.05 ;
 
@@ -148,7 +148,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  431
 
-Creating a Numeric Expression
+Creating a Numeric Expression
 
 Expressions and Field Formats
 
@@ -205,7 +205,7 @@ Two numeric constants or fields joined by an arithmetic operator. For example:
 
 432
 
-7. Using Expressions
+7. Using Expressions
 
 COMPUTE BONUS/D12.2 = CURR_SAL * 0.05 ;
 
@@ -259,7 +259,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  433
 
-Creating a Numeric Expression
+Creating a Numeric Expression
 
 In a DEFINE command, use the following:
 
@@ -319,7 +319,7 @@ WHERE RCOST LT EXPN(8E+03)
 
 434
 
-Reference: Arithmetic Operators
+Reference: Arithmetic Operators
 
 The following list shows the arithmetic operators you can use in an expression:
 
@@ -383,7 +383,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  435
 
-Creating a Numeric Expression
+Creating a Numeric Expression
 
 Example:
 
@@ -443,7 +443,7 @@ END
 
 436
 
-The output is shown in the following image. Where there are more than 10 copies, the
+The output is shown in the following image. Where there are more than 10 copies, the
 NEWPRICE equals LISTPR, otherwise NEWPRICE is $25.00 greater than LISTPR.
 
 7. Using Expressions
@@ -486,7 +486,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  437
 
-Creating a Numeric Expression
+Creating a Numeric Expression
 
 Operation
 
@@ -562,7 +562,7 @@ Character (alphanumeric and text)
 
 438
 
-7. Using Expressions
+7. Using Expressions
 
 For example, if a 16-byte packed-decimal operand is used in an expression, all other operands
 are converted to 16-byte packed-decimal format for evaluation. On the other hand, if an
@@ -617,7 +617,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  439
 
-Creating a Date Expression
+Creating a Date Expression
 
 COMPUTE DIFF/I4 = YMD (HIRE_DATE,FST.DAT_INC);
 
@@ -671,7 +671,7 @@ YM, YYM, MYY, and MY
 
 440
 
-7. Using Expressions
+7. Using Expressions
 
 Format
 
@@ -743,7 +743,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  441
 
-Creating a Date Expression
+Creating a Date Expression
 
 Example:
 
@@ -801,7 +801,7 @@ are simply accepted.
 
 442
 
-7. Using Expressions
+7. Using Expressions
 
 Returned Field Format Selection
 
@@ -852,7 +852,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  443
 
-Creating a Date Expression
+Creating a Date Expression
 
 Extracting a Date Component
 
@@ -904,7 +904,7 @@ COMPUTE DAYS_LATE/I4 = DATE_PAID - DUE_DATE;
 
 444
 
-7. Using Expressions
+7. Using Expressions
 
 Example:
 
@@ -959,7 +959,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  445
 
-Creating a Date-Time Expression
+Creating a Date-Time Expression
 
 Recognition and use of date or date-time constants.
 
@@ -1011,7 +1011,7 @@ END
 
 446
 
-The output is shown in the following image. The original date-time field has a non-zero time
+The output is shown in the following image. The original date-time field has a non-zero time
 component. When assigned to the date field, the time component is removed. When that date
 is assigned to the second date-time field, a zero time component is added.
 
@@ -1021,7 +1021,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  447
 
-Creating a Date-Time Expression
+Creating a Date-Time Expression
 
 Example:
 
@@ -1057,7 +1057,7 @@ END
 
 448
 
-7. Using Expressions
+7. Using Expressions
 
 The output is shown in the following image. When a date value is compared to a date-time
 value, the date is converted to a date-time value with the time component set to zero, and
@@ -1086,7 +1086,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  449
 
-Creating a Date-Time Expression
+Creating a Date-Time Expression
 
 Specifying a Date-Time Value
 
@@ -1140,7 +1140,7 @@ represented using nine decimal digits.
 
 450
 
-7. Using Expressions
+7. Using Expressions
 
 date_string
 
@@ -1192,7 +1192,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  451
 
-Creating a Date-Time Expression
+Creating a Date-Time Expression
 
 In each date format, two-digit years are interpreted using the [F]DEFCENT and [F]YRTHRESH
 settings.
@@ -1255,7 +1255,7 @@ contains both the date (as eight characters) and time (in the format hour:minute
 452
 
 
-7. Using Expressions
+7. Using Expressions
 
 Because the transaction file contains the dates in numeric string format, the DATEFORMAT
 setting is not used, and the dates are entered in YMD order.
@@ -1318,7 +1318,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  453
 
-Creating a Date-Time Expression
+Creating a Date-Time Expression
 
 Example:
 
@@ -1380,7 +1380,7 @@ Any two date-time values can be compared, even if their lengths do not match.
 
 454
 
-7. Using Expressions
+7. Using Expressions
 
 If a date-time field supports missing values, fields that contain the missing value have a
 greater value than any date-time field can have. Therefore, in order to exclude missing values
@@ -1435,7 +1435,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  455
 
-Creating a Character Expression
+Creating a Character Expression
 
 The missing value is not included in the report output:
 
@@ -1493,7 +1493,7 @@ END
 
 456
 
-7. Using Expressions
+7. Using Expressions
 
 A text field.
 
@@ -1538,7 +1538,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  457
 
-Creating a Character Expression
+Creating a Character Expression
 
 Example:
 
@@ -1602,7 +1602,7 @@ BANNING, J.
 
 458
 
-7. Using Expressions
+7. Using Expressions
 
 The request evaluates the expressions as follows:
 
@@ -1645,7 +1645,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  459
 
-Creating a Variable Length Character Expression
+Creating a Variable Length Character Expression
 
 The output is shown in the following image. If MOVIECODE contains the characters 'DIS',
 NEWCODE is generated by concatenating the characters 'NEY;', otherwise NEWCODE is
@@ -1666,7 +1666,7 @@ required to strip them, AnV format is not recommended for use in non-relational 
 
 460
 
-Using Concatenation With AnV Fields
+Using Concatenation With AnV Fields
 
 7. Using Expressions
 
@@ -1726,7 +1726,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  461
 
-Creating a Variable Length Character Expression
+Creating a Variable Length Character Expression
 
 Expression
 
@@ -1785,7 +1785,7 @@ Result
 
 TRUE
 
-7. Using Expressions
+7. Using Expressions
 
 Expression
 
@@ -1856,7 +1856,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  463
 
-Creating a Variable Length Character Expression
+Creating a Variable Length Character Expression
 
 Using the Assignment Operator With AnV Fields
 
@@ -1900,7 +1900,7 @@ error is generated if the result is longer than n.
 
 464
 
-7. Using Expressions
+7. Using Expressions
 
 Creating a Logical Expression
 
@@ -1965,7 +1965,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  465
 
-Creating a Logical Expression
+Creating a Logical Expression
 
 Operator
 
@@ -2034,7 +2034,7 @@ constants).
 
 466
 
-7. Using Expressions
+7. Using Expressions
 
 logical_expression
 
@@ -2093,7 +2093,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  467
 
-Creating a Conditional Expression
+Creating a Conditional Expression
 
 Example:
 
@@ -2152,7 +2152,7 @@ END
 
 
 
-7. Using Expressions
+7. Using Expressions
 
 The output is:
 
@@ -2177,6 +2177,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  469
 
-Creating a Conditional Expression
+Creating a Conditional Expression
 
 470

--- a/specifications/creating_reports/creating_reports_08_chapter8.md
+++ b/specifications/creating_reports/creating_reports_08_chapter8.md
@@ -62,7 +62,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  471
 
-Saving Your Report Output
+Saving Your Report Output
 
 Saving Your Report Output
 
@@ -111,7 +111,7 @@ For details, see the Developing Reporting Applications manual.
 
 472
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 When you create a HOLD file using the syntax ON TABLE HOLD AS name, the name can contain
 up to the maximum number of characters supported by your operating system. For information,
@@ -162,7 +162,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  473
 
-Creating a HOLD File
+Creating a HOLD File
 
 Syntax:
 
@@ -223,7 +223,7 @@ LOTUS, SYLK
 
 474
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 To use in a database application, choose: COMMA, COM, COMT, DB2, DATREC, DFIX,
 FOCUS, INGRES, REDBRICK, SQL, SQLDBC, SQLORA, SQLINF, SQLMSS, SQLSYB,
@@ -277,7 +277,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  475
 
-Creating a HOLD File
+Creating a HOLD File
 
 PERSISTENCE
 
@@ -336,7 +336,7 @@ The following message appears:
 
 476
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 NUMBER OF RECORDS IN TABLE=  12 LINES=     12
 
@@ -393,7 +393,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  477
 
 
-Creating a HOLD File
+Creating a HOLD File
 
 The output is:
 
@@ -472,7 +472,7 @@ END
 
 478
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 The output is:
 
@@ -531,7 +531,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  479
 
 
-Holding Report Output in FOCUS Format
+Holding Report Output in FOCUS Format
 
 Syntax:
 
@@ -580,7 +580,7 @@ command while in the same Hot Screen session.
 
 480
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Reference: Operating System Notes for HOLD Files in FOCUS Format
 
@@ -629,7 +629,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  481
 
-Holding Report Output in FOCUS Format
+Holding Report Output in FOCUS Format
 
 Example:
 
@@ -678,7 +678,7 @@ FILE=X2, SUFFIX=FOC
 
 482
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Example:
 
@@ -715,7 +715,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  483
 
-Controlling Attributes in HOLD Master Files
+Controlling Attributes in HOLD Master Files
 
 Example:
 
@@ -768,7 +768,7 @@ explicitly non-displaying fields. See Controlling Fields in a HOLD Master File o
 
 484
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 The SET HOLDATTR command propagates TITLE and ACCEPT attributes used in the original
 Master File to the HOLD Master File. See Controlling Attributes in the HOLD Master File on
@@ -827,7 +827,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  485
 
-Controlling Attributes in HOLD Master Files
+Controlling Attributes in HOLD Master Files
 
 Reference: Usage Notes for Controlling Field Names in HOLD Files
 
@@ -876,7 +876,7 @@ following produces the field name PLACE in the HOLD Master File:
 
 486
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 PRINT COUNTRY AS 'PLACE,OF,ORIGIN'
 
@@ -932,7 +932,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  487
 
-Controlling Attributes in HOLD Master Files
+Controlling Attributes in HOLD Master Files
 
 The request produces the following Master File:
 
@@ -990,7 +990,7 @@ FILE=HOLD4, SUFFIX=FIX
 
 488
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Example:
 
@@ -1049,7 +1049,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  489
 
-Controlling Attributes in HOLD Master Files
+Controlling Attributes in HOLD Master Files
 
 The following is the Master File for the HOLD file in relational format:
 
@@ -1105,7 +1105,7 @@ fields explicitly or implicitly) are not included in the HOLD file.
 
 490
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 ALL
 
@@ -1173,7 +1173,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Controlling Attributes in HOLD Master Files
+Controlling Attributes in HOLD Master Files
 
 COUNTRY
 
@@ -1262,7 +1262,7 @@ D12.2
 
 
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Example:
 
@@ -1302,7 +1302,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  493
 
-Controlling Attributes in HOLD Master Files
+Controlling Attributes in HOLD Master Files
 
 Running the request with SET HOLDLIST=ALLKEYS generates the following HOLD Master File.
 Note that the DOLLARS and UNITS fields are included twice, once with the original format,
@@ -1355,7 +1355,7 @@ FILENAME=HOLD, SUFFIX=FOC     , $
 
 494
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Controlling Attributes in the HOLD Master File
 
@@ -1419,7 +1419,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  495
 
-Keyed Retrieval From HOLD Files
+Keyed Retrieval From HOLD Files
 
 Using SET HOLDATTR=FOCUS, the following request
 
@@ -1465,7 +1465,7 @@ File with SEGTYPE=S1. Using BY HIGHEST field creates a Master with SEGTYPE=SH1.
 
 496
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Syntax:
 
@@ -1520,7 +1520,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  497
 
 
-Saving and Retrieving HOLD Files
+Saving and Retrieving HOLD Files
 
 In using this feature, keep in mind that when adding unsorted records to a sorted HOLD file,
 records that are out of sequence are not retrieved. For example, suppose that a sorted file
@@ -1578,7 +1578,7 @@ Specifies the application name for HOLD Master Files.
 
 498
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 path_to_directory
 
@@ -1637,7 +1637,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  499
 
-Using DBMS Temporary Tables as HOLD Files
+Using DBMS Temporary Tables as HOLD Files
 
 Alternatively, you can issue the TABLE request against the HOLD file using a two-part name
 (application name and Master File name):
@@ -1688,7 +1688,7 @@ except for those for which NOPRINT is specified.
 
 500
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 The temporary table that you create from your report will be the same data source type (that is,
 the same DBMS) as the data source from which you reported. If the data source from which
@@ -1742,7 +1742,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  501
 
-Using DBMS Temporary Tables as HOLD Files
+Using DBMS Temporary Tables as HOLD Files
 
 persistValue
 
@@ -1778,7 +1778,7 @@ Master File and Access File), is generated automatically.
 
 502
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Reference: Temporary Table Properties for SAME_DB Persistence Values
 
@@ -1847,7 +1847,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  503
 
-Using DBMS Temporary Tables as HOLD Files
+Using DBMS Temporary Tables as HOLD Files
 
 DBMS
 
@@ -1913,7 +1913,7 @@ the definition of a regular table.
 
 504
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 DBMS
 
@@ -1982,7 +1982,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  505
 
-Creating SAVE and SAVB Files
+Creating SAVE and SAVB Files
 
 Creating SAVE and SAVB Files
 
@@ -2041,7 +2041,7 @@ HTML, HTMTABLE, DHTML
 
 506
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 To use in a text document:
 
@@ -2084,7 +2084,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  507
 
-Creating SAVE and SAVB Files
+Creating SAVE and SAVB Files
 
 Syntax:
 
@@ -2140,7 +2140,7 @@ A description of the BINARY file is appears after the records are retrieved.
 
 508
 
-The output is:
+The output is:
 
 8. Saving and Reusing Your Report Output
 
@@ -2184,7 +2184,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  509
 
-Creating a PCHOLD File
+Creating a PCHOLD File
 
 default format. You must specify a format when using PCHOLD. The output is saved
 with a Master File. For details about the behavior of PCHOLD, see Creating a HOLD
@@ -2237,7 +2237,7 @@ For details about all available formats, see Choosing Output File Formats on pag
 
 510
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 DATASET name.ext
 
@@ -2379,7 +2379,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  511
 
-Choosing Output File Formats
+Choosing Output File Formats
 
 Reference: FORMAT AHTML
 
@@ -2432,7 +2432,7 @@ Reporting Applications manual.
 
 512
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Use: For display in a text document. For further reporting in FOCUS, WebFOCUS, or App Studio.
 As a transaction file for modifying a data source.
@@ -2486,7 +2486,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  513
 
-Choosing Output File Formats
+Choosing Output File Formats
 
 Use: For further reporting in FOCUS, WebFOCUS, or App Studio. As a transaction file for
 modifying a data source.
@@ -2539,7 +2539,7 @@ example, if you input Joe "Smitty" Smith, the output is Joe ""Smitty"" Smith.
 
 514
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 The extension for this format is CSV. A Master File is created for this format type when the
 command used to create the output file is HOLD. The SUFFIX in the generated Master File is
@@ -2587,7 +2587,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  515
 
-Choosing Output File Formats
+Choosing Output File Formats
 
 Note:
 
@@ -2638,7 +2638,7 @@ Available in: WebFOCUS, App Studio, FOCUS.
 
 516
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Reference: FORMAT DBASE
 
@@ -2691,7 +2691,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  517
 
-Choosing Output File Formats
+Choosing Output File Formats
 
 Note:
 
@@ -2745,7 +2745,7 @@ Supported with the commands: HOLD, PCHOLD, SAVE.
 
 518
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 The PCHOLD variation transfers the data from a web server to a browser.
 
@@ -2799,7 +2799,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  519
 
-Choosing Output File Formats
+Choosing Output File Formats
 
 For Internet Explorer, the PCHOLD variation launches Excel 2000 in the browser. For details,
 and for information about working with EXL2K files, see Choosing a Display Format on page
@@ -2849,7 +2849,7 @@ Available in: FOCUS, WebFOCUS, App Studio.
 
 520
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Reference: FORMAT FLEX
 
@@ -2903,7 +2903,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  521
 
-Choosing Output File Formats
+Choosing Output File Formats
 
 For details see Creating a Graph on page 1743.
 
@@ -2956,7 +2956,7 @@ create tables.
 
 522
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Use: For further processing in a database application.
 
@@ -3010,7 +3010,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  523
 
-Choosing Output File Formats
+Choosing Output File Formats
 
 Supported with the commands: ON GRAPH PCHOLD, ON GRAPH HOLD.
 
@@ -3058,7 +3058,7 @@ footings.
 
 524
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 PDF format does not support OLAP reports since Java applets cannot be embedded inside PDF
 documents. However, an OLAP report can drill down to a PDF-formatted report. PDF does not
@@ -3121,7 +3121,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  525
 
-Choosing Output File Formats
+Choosing Output File Formats
 
 Use: For combining multiple reports into a single PDF file, also known as a compound report.
 For complete details, see Laying Out the Report Page on page 1331.
@@ -3175,7 +3175,7 @@ create tables.
 
 526
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Use: For further processing in a database application.
 
@@ -3229,7 +3229,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  527
 
-Choosing Output File Formats
+Choosing Output File Formats
 
 Supported with the command: HOLD.
 
@@ -3282,7 +3282,7 @@ Supported with the command: HOLD.
 
 528
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Available in: WebFOCUS, App Studio, FOCUS.
 
@@ -3325,7 +3325,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  529
 
-Choosing Output File Formats
+Choosing Output File Formats
 
 Reference: FORMAT TAB
 
@@ -3376,7 +3376,7 @@ quotes.
 
 530
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Note:
 
@@ -3440,7 +3440,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  531
 
-Choosing Output File Formats
+Choosing Output File Formats
 
 Supported with the command: HOLD, SAVE, PCHOLD
 
@@ -3494,7 +3494,7 @@ the heading.
 
 532
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Tip: HOLD FORMAT WP does not change the number of lines per page. In order to do so, issue
 one or a combination of the commands SET PRINT=OFFLINE, SET SCREEN=PAPER, or SET
@@ -3547,7 +3547,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  533
 
-Merging Data Into an Existing Data Source With ON TABLE MERGE
+Merging Data Into an Existing Data Source With ON TABLE MERGE
 
 Note: When using an HTML Autoprompt page (select Run in new Window option), BI Portal, or
 an HTML page created with HTML canvas, browsers running in Standards Mode displaying
@@ -3594,7 +3594,7 @@ Write Adapter that enables WebFOCUS to update it.
 
 534
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Supported Merge Phrases
 
@@ -3642,7 +3642,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  535
 
-Merging Data Into an Existing Data Source With ON TABLE MERGE
+Merging Data Into an Existing Data Source With ON TABLE MERGE
 
 Non-Optimized request. If for any reason, the request cannot be optimized, for example if
 the target and source are from different databases or use different connections, or, if the
@@ -3677,7 +3677,7 @@ The following image shows an example of the messages displayed for a non-optimiz
 
 536
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 If not all records were processed and you want to know which records were rejected, you must
 either enable traces or look in the Session Log.
@@ -3734,7 +3734,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  537
 
 
-Merging Data Into an Existing Data Source With ON TABLE MERGE
+Merging Data Into an Existing Data Source With ON TABLE MERGE
 
 matching_expression2
 
@@ -3773,7 +3773,7 @@ reference these fields.
 
 538
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Example:
 
@@ -3834,14 +3834,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Merging Data Into an Existing Data Source With ON TABLE MERGE
+Merging Data Into an Existing Data Source With ON TABLE MERGE
 
 The following image of the last page of the output shows the updated values in the existing
 records, and the inserted records (the last two rows).
 
 540
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Example:
 
@@ -3886,7 +3886,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  541
 
 
-Merging Data Into an Existing Data Source With ON TABLE MERGE
+Merging Data Into an Existing Data Source With ON TABLE MERGE
 
 The following image shows the appended record (the last row).
 
@@ -3911,7 +3911,7 @@ The output is shown in the following image.
 
 542
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 The following ON TABLE MERGE request deletes records where the source product number
 matches the target product number and the plant is 'LA'.
@@ -3952,7 +3952,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  543
 
-Merging Data Into an Existing Data Source With ON TABLE MERGE
+Merging Data Into an Existing Data Source With ON TABLE MERGE
 
 The generated Master File shows the duplicate field names and unique alias names.
 
@@ -3993,7 +3993,7 @@ tables use the same adapter and connection:
 
 544
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 TABLE FILE dminv
 PRINT
@@ -4050,7 +4050,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  545
 
 
-Merging Data Into an Existing Data Source With ON TABLE MERGE
+Merging Data Into an Existing Data Source With ON TABLE MERGE
 
 MERGE INTO dmrpts AS T3
   USING ( SELECT
@@ -4099,7 +4099,7 @@ WHEN NOT MATCHED THEN INSERT (
 
 546
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Example:
 
@@ -4158,7 +4158,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  547
 
-Using Text Fields in Output Files
+Using Text Fields in Output Files
 
 In environments that support FIXFORM, due to limitations in the use of text fields with
 FIXFORM, the following restriction applies:
@@ -4247,7 +4247,7 @@ FOR VICE PRES OF SALES AND MARKETING.
 
 548
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 NAMA40
 
@@ -4324,7 +4324,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  549
 
-Creating a Delimited Sequential File
+Creating a Delimited Sequential File
 
 delimiter
 
@@ -4372,7 +4372,7 @@ enclosure option in order to have the PRESERVESPACE setting respected.
 
 550
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 rdelimiter
 
@@ -4415,7 +4415,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  551
 
-Creating a Delimited Sequential File
+Creating a Delimited Sequential File
 
 Example:
 
@@ -4468,7 +4468,7 @@ SEGNAME=PIPE1, DELIMITER=|, ENCLOSURE=", HEADER=NO, $
 
 552
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 In the delimited file that is created, each data value is separated from the next by a pipe
 character, and alphanumeric values are enclosed within double quotation marks:
@@ -4525,7 +4525,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  553
 
-Creating a Delimited Sequential File
+Creating a Delimited Sequential File
 
 As the tab character is not printable, the TAB1 Access File specifies the delimiter using its
 hexadecimal value.
@@ -4572,7 +4572,7 @@ SEGNAME=DFIX1, DELIMITER=',', HEADER=NO, PRESERVESPACE=YES, $
 
 554
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 In the DFIX1 file, the alphanumeric fields contain all of the blank spaces that existed in the
 original file:
@@ -4621,7 +4621,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  555
 
-Creating a Delimited Sequential File
+Creating a Delimited Sequential File
 
 Creating the same file with PRESERVESPACE NO removes the trailing blank spaces:
 
@@ -4680,7 +4680,7 @@ sequence:
 
 556
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 24: hexadecimal value for dollar sign ($).
 
@@ -4736,7 +4736,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  557
 
-Saving Report Output in INTERNAL Format
+Saving Report Output in INTERNAL Format
 
 Example: Missing Data in the HOLD File
 
@@ -4783,7 +4783,7 @@ Specify HOLD FORMAT INTERNAL for the report output.
 558
 
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Syntax:
 
@@ -4824,7 +4824,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  559
 
-Saving Report Output in INTERNAL Format
+Saving Report Output in INTERNAL Format
 
 Reference: Usage Notes for Suppressing Padded Fields in HOLD Files
 
@@ -4877,7 +4877,7 @@ END
 
 560
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 The request creates the following Master File:
 
@@ -4935,7 +4935,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  561
 
-Creating A Subquery or Sequential File With HOLD FORMAT SQL_SCRIPT
+Creating A Subquery or Sequential File With HOLD FORMAT SQL_SCRIPT
 
 Note: Once you have the .sql file and its accompanying Master File, you can customize the .sql
 file using global Dialogue Manager variables. You must declare these global variables in the
@@ -4992,7 +4992,7 @@ T3."BUSINESS_REGION",    T3."STATE_PROV_CODE_ISO_3166_2"
 
 562
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 The retail_script.mas Master File follows:
 
@@ -5052,7 +5052,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  563
 
-Creating a Structured HOLD File
+Creating a Structured HOLD File
 
 Other HOLD formats capture data from the original sources and may retain some implicit
 structural elements from the request itself. However, they do not propagate most of the
@@ -5103,7 +5103,7 @@ the request.
 
 564
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 *
 
@@ -5169,7 +5169,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  565
 
-Creating a Structured HOLD File
+Creating a Structured HOLD File
 
 ALL
 
@@ -5218,7 +5218,7 @@ sequential numbers assigned in top to bottom, left to right order.
 
 566
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Following are the first several records in the HOLD file:
 
@@ -5277,7 +5277,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  567
 
-Creating a Structured HOLD File
+Creating a Structured HOLD File
 
 This request produces the following Master File:
 
@@ -5325,7 +5325,7 @@ PRODUCTION       $29,700.00  BANNING          JOHN        A17         .00
 
 568
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Example:
 
@@ -5380,7 +5380,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  569
 
-Creating a Structured HOLD File
+Creating a Structured HOLD File
 
 A GROUP field if referenced explicitly or when all of its members are referenced in the
 request.
@@ -5424,7 +5424,7 @@ fields as any other TABLE request.
 
 570
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 Structural Notes
 
@@ -5478,7 +5478,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  571
 
-Creating a Structured HOLD File
+Creating a Structured HOLD File
 
 FOR fields are included.
 
@@ -5527,7 +5527,7 @@ used to preserve multipath structures.
 
 572
 
-8. Saving and Reusing Your Report Output
+8. Saving and Reusing Your Report Output
 
 All reconstituted FOCUS segments are SEGTYPE=S0, as neither KEY nor INDEX information
 is retained. An INDEX can be reinserted using REBUILD INDEX.
@@ -5536,6 +5536,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  573
 
-Creating a Structured HOLD File
+Creating a Structured HOLD File
 
 574

--- a/specifications/creating_reports/creating_reports_09_chapter9.md
+++ b/specifications/creating_reports/creating_reports_09_chapter9.md
@@ -46,7 +46,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  575
 
-Report Display Formats
+Report Display Formats
 
 Report Display Formats
 
@@ -98,7 +98,7 @@ Can be one of the following:
 
 576
 
-DOC
+DOC
 
 EXCEL
 
@@ -167,7 +167,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  577
 
-Report Display Formats
+Report Display Formats
 
 WP
 
@@ -226,7 +226,7 @@ worksheet.
 
 578
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 PostScript (PS)
 
@@ -269,7 +269,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  579
 
-Preserving Leading and Internal Blanks in Report Output
+Preserving Leading and Internal Blanks in Report Output
 
 Syntax:
 
@@ -324,7 +324,7 @@ END
 
 580
 
-With SHOWBLANKS OFF, these additional blanks are removed:
+With SHOWBLANKS OFF, these additional blanks are removed:
 
 9. Choosing a Display Format
 
@@ -358,7 +358,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  581
 
-Using Web Display Format: HTML
+Using Web Display Format: HTML
 
 HTML display format requires that the SET command's STYLESHEET parameter be set to any
 value except OFF. Appropriate values include ON (the default), the name of a StyleSheet file, or
@@ -417,7 +417,7 @@ server.
 
 582
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 SET JSURL=/ibi_apps/ibi_html/killmenu.js
 TABLE FILE CENTORD
@@ -468,7 +468,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  583
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 The output looks like this:
 
@@ -498,7 +498,7 @@ Display Format on page 585.
 
 584
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 PS (PostScript format), a print-oriented page description language, is most often used to send
 a report directly to a printer. While used less frequently as an online display format, you can
@@ -547,7 +547,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  585
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Syntax:
 
@@ -602,7 +602,7 @@ transparent GIF.
 
 586
 
-Z-INDEX=TOP
+Z-INDEX=TOP
 
 OPACITY=n
 
@@ -651,7 +651,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  587
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 TABLE FILE GGSALES
 SUM
@@ -693,7 +693,7 @@ END
 
 588
 
-The output is:
+The output is:
 
 9. Choosing a Display Format
 
@@ -701,7 +701,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  589
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Features Supported
 
@@ -752,7 +752,7 @@ page 1/panel 2.
 
 590
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 You can scale the output to fit across the width of the page using the PAGE-SCALE StyleSheet
 attribute or the PAGE-SCALE SET parameter.
@@ -810,7 +810,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  591
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Note: The image displayed in the subheading is distributed with WebFOCUS. The path to the
 image is dependent on your platform and installation options. The path in the request uses the
@@ -818,7 +818,7 @@ default installation directory on Windows.
 
 592
 
-The output is too wide for the page and is paneled. Page 1.1 has the columns that fit across
+The output is too wide for the page and is paneled. Page 1.1 has the columns that fit across
 the width of the page, as shown in the following image.
 
 9. Choosing a Display Format
@@ -827,13 +827,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  593
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Page 1.2 has the remaining columns, as shown in the following image.
 
 594
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 The following version of the request uses page scaling.
 
@@ -878,14 +878,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  595
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 The output is shown in the following image. All of the columns fit across the width of the page,
 with no paneling.
 
 596
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Aligning a PDF Report Within a Page
 
@@ -928,7 +928,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  597
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 The output is:
 
@@ -962,7 +962,7 @@ END
 
 598
 
-The output is:
+The output is:
 
 9. Choosing a Display Format
 
@@ -998,7 +998,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  599
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 The output is:
 
@@ -1031,7 +1031,7 @@ page headings and footings, as many as there are available, are tagged as <H2>.
 
 600
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 A USEASTITLES StyleSheet attribute that places and aligns custom column titles in a
 heading.
@@ -1089,7 +1089,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  601
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 TABLE FILE GGSALES
 SUM
@@ -1126,7 +1126,7 @@ Heading tags <H1> and <H2> and are automatically generated by WebFOCUS.
 
 602
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Column Titles
 
@@ -1137,7 +1137,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  603
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Data Cells
 
@@ -1145,7 +1145,7 @@ Row tags <TR> and header cell tags <TH> are generated by WebFOCUS.
 
 604
 
-The output is:
+The output is:
 
 9. Choosing a Display Format
 
@@ -1166,7 +1166,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  605
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 USEASTITLES=ON can only be set for the entire HEADING. HEADALIGN=BODY must also be set
 for the HEADING.
@@ -1195,7 +1195,7 @@ Note that the HEADALIGN=BODY attribute is also in bold.
 
 606
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 TABLE FILE GGSALES
 SUM
@@ -1243,7 +1243,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  607
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 WebFOCUS generates the following tags when the USEASTITLES attribute is used.
 
@@ -1254,7 +1254,7 @@ Heading, the column titles are also tagged as header cells <TH>.
 
 608
 
-The output is:
+The output is:
 
 9. Choosing a Display Format
 
@@ -1271,7 +1271,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  609
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Note:
 
@@ -1314,7 +1314,7 @@ the main document heading in the PDF output.
 
 610
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 SET ACCESSPDF = 508
 COMPOUND LAYOUT PCHOLD FORMAT PDF
@@ -1376,7 +1376,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  611
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 SET COMPONENT=report2
 TABLE FILE GGSALES
@@ -1406,7 +1406,7 @@ The report output, with bookmarks, is shown below.
 
 612
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Notice that the hierarchy tree in the Bookmarks pane has two levels for each report and is
 determined with the BYTOC attribute. The title for each report in the Bookmarks tree is
@@ -1420,13 +1420,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  613
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Page 1
 
 614
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Page 2
 
@@ -1436,7 +1436,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  615
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Adding Descriptive Text to an Image
 
@@ -1470,7 +1470,7 @@ image.
 
 616
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 TABLE FILE GGSALES
 SUM
@@ -1512,7 +1512,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  617
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Describing Drill Down Information
 
@@ -1571,7 +1571,7 @@ END
 
 618
 
-Note the ALT attribute and associated text in BOLD.
+Note the ALT attribute and associated text in BOLD.
 
 The report is:
 
@@ -1587,7 +1587,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  619
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Note:
 
@@ -1638,7 +1638,7 @@ output on your monitor before printing it using PostScript.
 
 620
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 To display a PostScript report, a computer must have a third-party PostScript application
 installed, such as GSview (a graphical interface for Ghostscript).
@@ -1696,7 +1696,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  621
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Note: If you send a job to a printer that does not have the requested paper size loaded, the
 printer may stop and instruct its operator to load the specified paper. To ensure control over
@@ -1740,7 +1740,7 @@ landscape mode.
 
 622
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 SET PSPAGESETUP=ON
 TABLE FILE CAR
@@ -1796,7 +1796,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  623
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 The Euro character displays in PDF output because the Adobe Symbol character set
 includes the Euro character.
@@ -1846,7 +1846,7 @@ must use the AFM file.
 
 624
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 WebFOCUS Font Map files. These configuration files map the name of a font to the
 appropriate font metrics and font files (AFM, PFB (or PFA), or OTF). The mapping determines
@@ -1895,7 +1895,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  625
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Tip:
 
@@ -1947,7 +1947,7 @@ following section, How to Add Fonts to the Font Map on page 628.
 
 626
 
-Procedure: How to Configure Type 1 PostScript Fonts on z/OS Under PDS Deployment
+Procedure: How to Configure Type 1 PostScript Fonts on z/OS Under PDS Deployment
 
 9. Choosing a Display Format
 
@@ -2001,7 +2001,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  627
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Syntax:
 
@@ -2059,7 +2059,7 @@ A more complete description of XML syntax can be found here:
 
 628
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 http://en.wikipedia.org/wiki/Xml
 
@@ -2112,7 +2112,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  629
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 The actual names of the fonts may vary. Some fonts may be called "oblique" rather than
 "italic", or "heavy" rather than "bold". However, the font map and StyleSheet always use
@@ -2150,7 +2150,7 @@ specified for DHTML. If no <when> is specified, the font will be available for a
 
 630
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 The following is a complete example of a user font map:
 
@@ -2204,7 +2204,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  631
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Reference: The WebFOCUS Default Font Map
 
@@ -2257,7 +2257,7 @@ to be designated as the default.
 
 632
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 b. Copy the entire entry into the appropriate format area within fontuser.xml.
 
@@ -2311,7 +2311,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  633
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Embedding TrueType Fonts Into WebFOCUS PDF Reports Generated in Windows
 
@@ -2363,7 +2363,7 @@ Note that home is the other directory directly under drive:\ibi\srv82.
 
 634
 
-For each of the supported fonts, you will need to copy the following font files. You will also
+For each of the supported fonts, you will need to copy the following font files. You will also
 need to know the metrics file name associated with each font file:
 
 9. Choosing a Display Format
@@ -2468,7 +2468,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  635
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 Tahoma
 
@@ -2577,7 +2577,7 @@ information on editing font map syntax, see How to Add Fonts to the Font Map on 
 
 636
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 The following shows a user font map file with the Arial Unicode MS font added:
 
@@ -2639,7 +2639,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  637
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 <family name="Times New Roman">
     <font style="normal"
@@ -2689,7 +2689,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 638
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Example:
 
@@ -2738,13 +2738,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  639
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 The output is:
 
 640
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Note: Except for OpenType fonts, in order to reduce the size of a generated PDF document,
 only the subset of used characters of a font are included into the PDF document.
@@ -2764,7 +2764,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  641
 
-Using Print Display Formats: PDF, PS
+Using Print Display Formats: PDF, PS
 
 The end of each PDF file has a table containing the byte offset, including line termination
 characters, of each PDF object in the file. The offsets indicate that each line is terminated by
@@ -2811,7 +2811,7 @@ be a valid PDF file on the Windows machine.
 
 642
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 SPACE
 
@@ -2870,7 +2870,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  643
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 If you issue the SET PAGE = OFF command, or include TABPAGENO in a heading or footing,
 WP will indicate page breaks by including the character "1" in the first column at each
@@ -2920,7 +2920,7 @@ Online.
 
 644
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 For information on the differences in features available in Excel Online and in Microsoft
 Office 2013, see Office Online Service Description.
@@ -2968,7 +2968,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  645
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Unlike the HTML-based (EXL2K) format, which removes all blanks, XLSX, by default, retains
 leading, internal, and trailing blanks in cells within the worksheet. For more information on
@@ -3017,7 +3017,7 @@ For a procedure. Issue the SET EXCELSERVURL command within the procedure.
 
 646
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 For the entire environment. Edit the IBIF_excelservurl variable in the WebFOCUS
 Administration Console by selecting:
@@ -3060,7 +3060,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  647
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Syntax:
 
@@ -3098,7 +3098,7 @@ To open XLSX workbooks, Excel 2013, 2010, or 2007 must be installed on the deskt
 
 648
 
-Reference: Opening XLSX Report Output in Excel 2000/2003
+Reference: Opening XLSX Report Output in Excel 2000/2003
 
 9. Choosing a Display Format
 
@@ -3132,7 +3132,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  649
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Save As Option enabled (YES). When the WebFOCUS Redirection Save As option is
 enabled, the WebFOCUS Client sends the report output to the user as a file with the
@@ -3174,7 +3174,7 @@ window box.
 
 650
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 In Windows 7, Microsoft removed the desktop settings that support opening worksheets in
 the browser. This means that to change this behavior, you can no longer simply navigate to
@@ -3225,7 +3225,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  651
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Displaying Formatted Numeric Values in XLSX Report Output
 
@@ -3280,7 +3280,7 @@ END
 
 652
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 In the resulting worksheet, notice that cell C2 containing the DOLLAR value for Midwest Coffee
 presents the value with the WebFOCUS format D12.2, which presents the comma (,) and two
@@ -3311,7 +3311,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  653
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Notice the fixed numeric format defined for the BUDDOLLARS column (Column C) presents the
 local currency symbol in a fixed position within each cell, regardless of the size of the data
@@ -3338,7 +3338,7 @@ use the punctuation rules defined by the regional settings of the desktop.
 
 654
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 In languages that use Continental Decimal Notation, the currency definitions designate that a
 comma (,) is used as the decimal separator, and a period (.) is used as the thousands
@@ -3375,7 +3375,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  655
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 The output is:
 
@@ -3399,7 +3399,7 @@ END
 
 656
 
-The report footer is not part of the data table, as shown in the following image:
+The report footer is not part of the data table, as shown in the following image:
 
 9. Choosing a Display Format
 
@@ -3421,7 +3421,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  657
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Example:
 
@@ -3496,7 +3496,7 @@ sorting or date calculations in an Excel formula.
 
 658
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 The following table shows how WebFOCUS date formats are represented in XLSX. The table
 shows how the value is preserved in the cell and how the display is generated using the format
@@ -3565,7 +3565,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  659
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Example:
 
@@ -3620,7 +3620,7 @@ open the Format Cells dialog box.
 
 660
 
-The output is:
+The output is:
 
 9. Choosing a Display Format
 
@@ -3669,7 +3669,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  661
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 The output is:
 
@@ -3716,7 +3716,7 @@ END
 
 662
 
-The output is:
+The output is:
 
 9. Choosing a Display Format
 
@@ -3781,7 +3781,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  663
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 COMPUTE will generate the formula, except when the COMPUTE is equal to a single
 variable. In that case, the constant is placed and not the formula.
@@ -3832,7 +3832,7 @@ results may be different.
 
 664
 
-XLSX FORMULA is not supported with the following WebFOCUS commands and phrases:
+XLSX FORMULA is not supported with the following WebFOCUS commands and phrases:
 
 9. Choosing a Display Format
 
@@ -3889,7 +3889,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  665
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Example:
 
@@ -3920,7 +3920,7 @@ The output is:
 
 666
 
-WebFOCUS can translate any total (subtotal, row total, or column total) to an Excel formula.
+WebFOCUS can translate any total (subtotal, row total, or column total) to an Excel formula.
 For related information, see Translation Support for FORMAT XLSX FORMULA on page 664.
 
 Example:
@@ -3964,7 +3964,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  667
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 The formula for the calculated values is generated by translating the internal form of the
 WebFOCUS expression (PROFIT/D12.2MC = BUDDOLLARS - DOLLARS;) into an Excel formula.
@@ -3997,7 +3997,7 @@ D8=SUM(D4:D7).
 
 668
 
-Example:
+Example:
 
 Generating a Native Excel Formula for a Function
 
@@ -4036,7 +4036,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  669
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Example:
 
@@ -4066,7 +4066,7 @@ END
 
 670
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 The output shows that the formula is subtracting a data value that is not displayed on the
 worksheet. It is actually the BUDDOLLARS value from the current hardcoded value, since there
@@ -4080,7 +4080,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  671
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 The formula generated with the new SUM command contains cell references for both fields
 used in the calculation.
@@ -4106,7 +4106,7 @@ SUM.
 
 672
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Prefix Operator
 
@@ -4168,7 +4168,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  673
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 TABLE FILE GGSALES
 SUM UNITS DOLLARS/I8MC BUDDOLLARS/I8MC
@@ -4210,7 +4210,7 @@ END
 
 674
 
-The output shows that the prefix operators were not passed to Excel as formulas. They were
+The output shows that the prefix operators were not passed to Excel as formulas. They were
 passed as data values.
 
 9. Choosing a Display Format
@@ -4229,7 +4229,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  675
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 SET NODATA=''
 TABLE FILE GGSALES
@@ -4282,7 +4282,7 @@ WRAP is not supported for Date format fields.
 
 676
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Syntax:
 
@@ -4342,7 +4342,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  677
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 value
 
@@ -4400,7 +4400,7 @@ END
 
 678
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 where:
 
@@ -4426,7 +4426,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  679
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Synchronizing WebFOCUS Page Breaks With Excel Page Breaks
 
@@ -4461,7 +4461,7 @@ END
 
 680
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Using Print Preview in Excel, output for pages 1 and 2 for the Midwest Region are shown in the
 following images. The default Excel page breaks are synchronized with the page breaks
@@ -4474,13 +4474,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  681
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Page 2 Output
 
 682
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 To repeat the page heading and column titles on each printed page, use the BY_field PAGE-
 BREAK phrase in combination with the XLSXPAGETITLES=ON StyleSheet attribute, as shown in
@@ -4511,7 +4511,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  683
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Using Print Preview in Excel, output for pages 1 and 2 for the Midwest Region are shown in the
 following images. Notice that the page heading and column titles are repeated on each printed
@@ -4521,7 +4521,7 @@ Page 1 Output
 
 684
 
-Page 2 Output
+Page 2 Output
 
 9. Choosing a Display Format
 
@@ -4532,7 +4532,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  685
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Preserving Leading and Internal Blanks in Report Output
 
@@ -4595,7 +4595,7 @@ ON TABLE SET SHOWBLANKS {OFF|ON}
 
 686
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 where:
 
@@ -4651,7 +4651,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  687
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 SET SHOWBLANKS = OFF with HEADALIGN=BODY (no leading blanks or trailing blanks)
 
@@ -4660,7 +4660,7 @@ heading items)
 
 688
 
-SET SHOWBLANKS = ON with HEADALIGN=BODY (leading blanks and trailing blanks)
+SET SHOWBLANKS = ON with HEADALIGN=BODY (leading blanks and trailing blanks)
 
 9. Choosing a Display Format
 
@@ -4671,7 +4671,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  689
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Support for Drill Downs With XLSX Report Output
 
@@ -4719,7 +4719,7 @@ WebFOCUS Release 7.7.x because anonymous drill-down access was permitted.
 
 690
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 The following options are available to allow the feature in WebFOCUS Release 8.x:
 
@@ -4775,7 +4775,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  691
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 where:
 
@@ -4825,7 +4825,7 @@ Supported image formats include .gif and .jpg.
 
 692
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Usage Considerations
 
@@ -4877,7 +4877,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  693
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 file
 
@@ -4933,7 +4933,7 @@ WHERE CATEGORY NE 'Gifts'
 
 694
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 ON CATEGORY SUBHEAD
 " "
@@ -4978,7 +4978,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  695
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 In the following request, since the referenced images are not part of the existing GGSALES
 table, the image files (.gif) are being built in the DEFINE and then referenced in the TABLE
@@ -5000,7 +5000,7 @@ may need to add a space to maintain the structure of the string.
 
 696
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 APP PATH IBISAMP
 SET HTMLARCHIVE=ON
@@ -5037,7 +5037,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  697
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 TABLE FILE GGSALES
 SUM DOLLARS/D12CM AS 'Dollars'
@@ -5082,7 +5082,7 @@ END
 
 698
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 SET COMPONENT='chart1'
 ENGINE INT CACHE SET ON
@@ -5140,13 +5140,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  699
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 The output is shown in the following images.
 
 700
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Example:
 
@@ -5185,7 +5185,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  701
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 The output is:
 
@@ -5215,7 +5215,7 @@ TYPE={PAGEHEADER|PAGEFOOTER},OBJECT=IMAGE,
 
 702
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 To place text in XLSX Workbook headers and footers, the syntax is:
 
@@ -5273,7 +5273,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  703
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Example:
 
@@ -5306,7 +5306,7 @@ END
 
 704
 
-The first page of output has the image ibilogo.gif in the left area of the header and the image
+The first page of output has the image ibilogo.gif in the left area of the header and the image
 webfocus1.gif in the center area of the footer.
 
 9. Choosing a Display Format
@@ -5315,7 +5315,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  705
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 The second page of output has the image ibilogo.gif in the right area of the header and the
 image webfocus1.gif in the center area of the footer.
@@ -5338,7 +5338,7 @@ BLOB image fields are not supported in this release.
 
 706
 
-Reference: Displaying Watermarks on XLSX Report Output
+Reference: Displaying Watermarks on XLSX Report Output
 
 9. Choosing a Display Format
 
@@ -5388,7 +5388,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  707
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 The first page of the generated worksheet shows the watermark image beneath the data. This
 image is displayed on every page of the worksheet.
@@ -5411,7 +5411,7 @@ Workbook (.xlsx)
 
 708
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Template File Type
 
@@ -5467,7 +5467,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  709
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Syntax:
 
@@ -5517,7 +5517,7 @@ instance of the report for each value of the first BY field in the WebFOCUS repo
 
 710
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Syntax:
 
@@ -5565,7 +5565,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  711
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 The output is:
 
@@ -5592,7 +5592,7 @@ allow Excel to maintain both sheets.
 
 712
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 By default, WebFOCUS sort processing is case-sensitive, so the same field value with different
 casing is considered to be two different values when used as a sort (BY) field. In an Excel
@@ -5624,7 +5624,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  713
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Syntax:
 
@@ -5679,7 +5679,7 @@ special consideration is made to retain groupings within a given sheet.
 
 714
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 If ROWOVERFLOW=PBON, the page headings and footings and column titles display within
 the worksheet when a WebFOCUS command causes a page break.
@@ -5736,7 +5736,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  715
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 -* ****Subfoot****
 ON REGION SUBFOOT
@@ -5765,7 +5765,7 @@ report heading, page heading, column titles, and first subhead.
 
 716
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Note that the TITLETEXT attribute in the StyleSheet specified the name EXLOVER, so the three
 worksheets were generated with the names EXLOVER1, EXLOVER2, and EXLOVER3. If there
@@ -5780,7 +5780,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  717
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Example:
 
@@ -5825,7 +5825,7 @@ END
 
 718
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 The report heading displays on the first worksheet only, the page heading, footing, and column
 titles display on each worksheet and at each WebFOCUS page break (each time the product
@@ -5841,7 +5841,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  719
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 You can use standard Compound Layout syntax to generate XLSX compound workbooks. By
 default, each of the component reports from the compound report is placed in a new Excel
@@ -5869,7 +5869,7 @@ unique.
 
 720
 
-Example:
+Example:
 
 Compound Excel Report including Table of Contents (BYTOC)
 
@@ -5915,7 +5915,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  721
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 SET COMPONENT=R2
 TABLE FILE GGSALES
@@ -5964,7 +5964,7 @@ END
 
 722
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 SET COMPONENT=R4
 TABLE FILE GGSALES
@@ -5997,7 +5997,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  723
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Report 2: BYTOC Reports by Region
 
@@ -6005,7 +6005,7 @@ The following image is tiled to show multiple worksheet reports, one for each re
 
 724
 
-Report 3: Sales Summary Report by Category
+Report 3: Sales Summary Report by Category
 
 9. Choosing a Display Format
 
@@ -6013,7 +6013,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  725
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Report 4: Sales Detail Report by Category
 
@@ -6036,7 +6036,7 @@ worksheet.
 
 726
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 When used with the HOLD or PCHOLD syntax, the compound report keywords OPEN,
 CLOSE, and NOBREAK must appear immediately after FORMAT XLSX. For example, you can
@@ -6086,7 +6086,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  727
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 Example:
 
@@ -6132,7 +6132,7 @@ END
 
 728
 
-The output is:
+The output is:
 
 9. Choosing a Display Format
 
@@ -6175,7 +6175,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  729
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 TABLE FILE GGSALES
 HEADING
@@ -6208,7 +6208,7 @@ END
 
 730
 
-Report output is displayed in two separate tabs.
+Report output is displayed in two separate tabs.
 
 9. Choosing a Display Format
 
@@ -6226,7 +6226,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  731
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 COMPOUND LAYOUT PCHOLD FORMAT XLSX FORMULA
 UNITS=IN, $
@@ -6283,7 +6283,7 @@ ENDSTYLE
 
 732
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Note:
 
@@ -6340,14 +6340,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  733
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 The first worksheet, PivotTablewithChart, contains an empty pivot table and pivot chart. It also
 contains an empty PivotTableFieldList. The first worksheet is shown in the following image.
 
 734
 
-The second worksheet, Source Data, contains one column called FieldsToBeAdded, for which
+The second worksheet, Source Data, contains one column called FieldsToBeAdded, for which
 there is initially no data. The second worksheet is shown in the following image.
 
 9. Choosing a Display Format
@@ -6362,13 +6362,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  735
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 First Worksheet
 
 736
 
-Second Worksheet
+Second Worksheet
 
 9. Choosing a Display Format
 
@@ -6383,7 +6383,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  737
 
-Saving Report Output in Excel XLSX Format
+Saving Report Output in Excel XLSX Format
 
 To start building a pivot report and pivot chart, you can select the check boxes for the desired
 fields in the PivotTableFieldList. For example, selecting the check boxes for Product, Unit
@@ -6416,7 +6416,7 @@ WebFOCUS XLSX Format Supported Features Roadmap, located at the following link:
 
 738
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 https://techsupport.informationbuilders.com/tech/wbf/wbf_rln_formatXLSX_support.html
 
@@ -6470,7 +6470,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  739
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 Example:
 
@@ -6514,7 +6514,7 @@ Microsoft Office 2013/2010/2007.
 
 740
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Microsoft Office 2000/2003 with the Microsoft Office Compatibility Pack.
 
@@ -6555,7 +6555,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  741
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 Building the .pptx Presentation File
 
@@ -6608,7 +6608,7 @@ In the WebFOCUS Administration Console:
 
 742
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 IBIF_excelservurl = http://servername:8080/ibi_apps
 
@@ -6663,7 +6663,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  743
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 Opening PPTX Report Output
 
@@ -6707,7 +6707,7 @@ directly from PowerPoint 2000/2003.
 
 744
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Save As Option enabled (YES). When the WebFOCUS Redirection Save As option is
 enabled, the WebFOCUS Client sends the report output to the user as a file with the
@@ -6756,7 +6756,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  745
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 In Windows 7, Microsoft removed the desktop settings that support opening worksheets in
 the browser. This means that to change this behavior, you can no longer simply navigate to
@@ -6808,7 +6808,7 @@ Enables you to group elements together in a PPTX report.
 
 746
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 OFF
 
@@ -6852,7 +6852,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  747
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 The output is:
 
@@ -6866,7 +6866,7 @@ in the grouping.
 
 748
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 SET HTMLARCHIVE=ON
 SET PPTXGRAPHTYPE=PNG
@@ -6917,7 +6917,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  749
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 SET COMPONENT='chart2'
 SET PAGE-NUM=NOLEAD
@@ -6968,7 +6968,7 @@ COMPOUND END
 
 750
 
-The output is:
+The output is:
 
 9. Choosing a Display Format
 
@@ -6992,7 +6992,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  751
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 Font Properties
 
@@ -7048,7 +7048,7 @@ Center Justification:
 
 752
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Full Justification:
 
@@ -7094,7 +7094,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  753
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 Ordered (Number or Letter) List
 
@@ -7149,7 +7149,7 @@ No other attributes are supported in the anchor markup tag.
 
 754
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Page Numbering
 
@@ -7193,7 +7193,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  755
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 Example:
 
@@ -7252,7 +7252,7 @@ The markup for this formatting is:
 
 756
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 <b><font face="Arial" size=12>This paragraph is triple-spaced
 (LINESPACING=MULTIPLE(3)):</font></b>
@@ -7274,7 +7274,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  757
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 Example:
 
@@ -7305,7 +7305,7 @@ END
 
 758
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 SET COMPONENT=HEADER
 TABLE FILE GGSALES
@@ -7353,7 +7353,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  759
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 The first page of output is:
 
@@ -7361,7 +7361,7 @@ The second page of output has the same drawing objects:
 
 760
 
-Example:
+Example:
 
 Vertically Aligning Text Markup in PPTX Report Output
 
@@ -7410,7 +7410,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  761
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 Display Unordered Lists With Bullets, Discs, Squares, and Circles
 
@@ -7466,7 +7466,7 @@ COMPOUND END
 
 762
 
-The output is:
+The output is:
 
 9. Choosing a Display Format
 
@@ -7507,7 +7507,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  763
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 The output is:
 
@@ -7532,7 +7532,7 @@ well as better integration with the styling within slide backgrounds.
 
 764
 
-Syntax:
+Syntax:
 
 How to Insert Images Into WebFOCUS PPTX Reports
 
@@ -7576,7 +7576,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  765
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 TABLE FILE EMPDATA
 SUM
@@ -7612,7 +7612,7 @@ $
 
 766
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 TYPE=REPORT,
   GRID=OFF,
@@ -7656,7 +7656,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  767
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 TYPE=SUBHEAD,
   BACKCOLOR=RGB(246 246 246),
@@ -7711,7 +7711,7 @@ END
 
 768
 
-The output is:
+The output is:
 
 9. Choosing a Display Format
 
@@ -7725,7 +7725,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  769
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 APP PATH IBISAMP IBIDEMO
 TABLE FILE GGSALES
@@ -7766,7 +7766,7 @@ $
 
 770
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 TYPE=TITLE,
      COLOR=RGB(51 51 51),
@@ -7808,7 +7808,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  771
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 The report output is as follows:
 
@@ -7829,7 +7829,7 @@ SET PPTXGRAPHTYPE={PNG|PNG_NOSCALE|JPEG}
 
 772
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 where:
 
@@ -7889,7 +7889,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  773
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 SET COMPONENT='report1'
 TABLE FILE GGSALES
@@ -7929,7 +7929,7 @@ ON GRAPH SET STYLE *
 
 774
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 *GRAPH_SCRIPT
 setPieDepth(0);
@@ -7970,7 +7970,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  775
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 SET PPTXGRAPHTYPE=PNG
 
@@ -8013,7 +8013,7 @@ ON GRAPH SET STYLE *
 
 776
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 *GRAPH_SCRIPT
 setPieDepth(0);
@@ -8041,7 +8041,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  777
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 Drill Down From Microsoft PowerPoint
 
@@ -8089,7 +8089,7 @@ The following request places a reference to an external URL on the grand total l
 
 778
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 TABLE FILE GGSALES
 SUM
@@ -8114,7 +8114,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  779
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 TYPE=REPORT,
   OBJECT=STATUS-AREA,
@@ -8172,7 +8172,7 @@ END
 
 780
 
-The output is:
+The output is:
 
 9. Choosing a Display Format
 
@@ -8210,7 +8210,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  781
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 Note: For more information on working with active content in macro-enabled templates, see the
 Microsoft webpage: https://support.office.com/en-nz/article/Enable-or-disable-macros-in-Office-
@@ -8264,7 +8264,7 @@ $
 
 782
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 TYPE=TITLE,
   COLOR=RGB(51 51 51),
@@ -8298,7 +8298,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  783
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 -* Replace Slide #2
 TABLE FILE GGSALES
@@ -8338,7 +8338,7 @@ $
 
 784
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 TYPE=DATA,
   BORDER-TOP=LIGHT,
@@ -8388,7 +8388,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  785
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 TYPE=REPORT,
   GRID=OFF,
@@ -8438,7 +8438,7 @@ END
 
 786
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 -* Replace Slide #4
 TABLE FILE GGSALES
@@ -8488,7 +8488,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  787
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 $
 TYPE=DATA,
@@ -8521,7 +8521,7 @@ charts.
 
 788
 
-Example:
+Example:
 
 Generating a Compound Document
 
@@ -8565,7 +8565,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  789
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 ON GRAPH SET UNITS &WF_STYLE_UNITS
 ON GRAPH SET HAXIS &WF_STYLE_WIDTH
@@ -8619,7 +8619,7 @@ END
 
 790
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 SET COMPONENT='report1'
 TABLE FILE IBISAMP/GGSALES
@@ -8667,7 +8667,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  791
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 TYPE=TITLE,
   COLOR=RGB(51 51 51),
@@ -8695,7 +8695,7 @@ The resulting Compound Document output is:
 
 792
 
-Coordinated Compound Layout Reports
+Coordinated Compound Layout Reports
 
 9. Choosing a Display Format
 
@@ -8738,7 +8738,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  793
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 SET HTMLARCHIVE=ON
 *-HOLD_SOURCE
@@ -8770,7 +8770,7 @@ ON TABLE SET STYLE *
 
 794
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 TYPE=REPORT,
   GRID=OFF,
@@ -8818,7 +8818,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  795
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 TYPE=REPORT,
   GRID=OFF,
@@ -8869,7 +8869,7 @@ AS 'TOTAL FOR'
 
 796
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 ON TABLE SET ASNAMES ON
 ON TABLE NOTOTAL
@@ -8926,7 +8926,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  797
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 The output is:
 
@@ -8957,7 +8957,7 @@ END
 
 798
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Adding Images to a Compound Request
 
@@ -9008,7 +9008,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  799
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 SET COMPONENT='ppt_template'
 TABLE FILE SYSCOLUM
@@ -9055,7 +9055,7 @@ $
 
 800
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 TYPE=REPORT,
   GRID=OFF,
@@ -9106,7 +9106,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  801
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 TYPE=SUBFOOT,
   SIZE=9,
@@ -9126,7 +9126,7 @@ The output is:
 
 802
 
-Template Masters and Slide Layouts
+Template Masters and Slide Layouts
 
 9. Choosing a Display Format
 
@@ -9163,7 +9163,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  803
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 A context menu displays all Slide Layouts with labels, as shown in the following image.
 
@@ -9172,7 +9172,7 @@ click the Slide Master button, as shown in the following image.
 
 804
 
-The Master View opens to show the Slide Master and its associated Slide Layouts, as shown
+The Master View opens to show the Slide Master and its associated Slide Layouts, as shown
 in the following image.
 
 9. Choosing a Display Format
@@ -9181,7 +9181,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  805
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 The following image shows the Slide Master view of the template used in this example. It
 contains two Slide Masters: (1) Trek and (2) Oriel. Within each Master, the image displays the
@@ -9191,7 +9191,7 @@ Layout suffixes.
 
 806
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Syntax:
 
@@ -9244,7 +9244,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  807
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 OBJECT=STRING, NAME='pl2_text2', TEXT='Sales By Region',
 POSITION=(0.5 0.325), MARKUP=ON, WRAP=ON, DIMENSION=(4.146 0.609),
@@ -9293,7 +9293,7 @@ END
 
 808
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 SET COMPONENT='report1'
 -INCLUDE GG_RPT1
@@ -9346,7 +9346,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  809
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 -*gg_rpt2.fex
 TABLE FILE GGSALES
@@ -9396,7 +9396,7 @@ setPlace(true);
 
 810
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 INCLUDE = warm,$
 TYPE=REPORT, TITLETEXT=&WF_TITLE.QUOTEDSTRING, $
@@ -9452,7 +9452,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  811
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 *GRAPH_SCRIPT
 setPieDepth(0);
@@ -9503,7 +9503,7 @@ END
 
 812
 
-The output is:
+The output is:
 
 9. Choosing a Display Format
 
@@ -9511,7 +9511,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  813
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 Merging WebFOCUS Content With PowerPoint Template Content
 
@@ -9538,7 +9538,7 @@ content shown in the image below. The name of the PowerPoint template is my_temp
 
 814
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 Merge Procedure
 
@@ -9571,7 +9571,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  815
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 Example:
 
@@ -9603,7 +9603,7 @@ The output is:
 
 816
 
-9. Choosing a Display Format
+9. Choosing a Display Format
 
 ReportCaster Distribution and ReportCaster Bursting
 
@@ -9644,6 +9644,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  817
 
-Saving Report Output in PPTX Format
+Saving Report Output in PPTX Format
 
 818

--- a/specifications/creating_reports/creating_reports_10_chapter10.md
+++ b/specifications/creating_reports/creating_reports_10_chapter10.md
@@ -57,7 +57,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  819
 
-Linking to Another Report
+Linking to Another Report
 
 The links you create can be dynamic. With a dynamic link, your selection passes the value of
 the selected report component to the linked report (procedure, URL, or JavaScript function).
@@ -114,7 +114,7 @@ page 1249.
 
 820
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 fex
 
@@ -162,7 +162,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  821
 
-Linking to Another Report
+Linking to Another Report
 
 Procedure: How to Determine a WebFOCUS File Name
 
@@ -184,7 +184,7 @@ the request.
 
 822
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 The main report is:
 
@@ -243,7 +243,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  823
 
-Linking to Another Report
+Linking to Another Report
 
 The first page of output for the main report follows. If you select Sales By Product for Store
 R1020, the value R1020 is passed to the PRDSALES procedure. If you select Sales By Date for
@@ -299,7 +299,7 @@ Thermos
 
 824
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Linking to a URL
 
@@ -355,7 +355,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  825
 
-Linking to a URL
+Linking to a URL
 
 If the URL refers to a WebFOCUS Servlet program that takes parameters, the URL must
 end with a question mark (?).
@@ -405,7 +405,7 @@ END
 
 826
 
-The output is:
+The output is:
 
 10. Linking a Report to Other Resources
 
@@ -431,7 +431,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  827
 
-Linking to a URL
+Linking to a URL
 
 The main procedure is:
 
@@ -468,7 +468,7 @@ END
 
 828
 
-The output of the main report is:
+The output of the main report is:
 
 10. Linking a Report to Other Resources
 
@@ -476,7 +476,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  829
 
-Linking to a URL
+Linking to a URL
 
 If you click the region Northeast, the output is:
 
@@ -503,7 +503,7 @@ TYPE = type, HYPERLINK-COLOR = color
 
 830
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 where:
 
@@ -545,7 +545,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  831
 
-Linking to a URL
+Linking to a URL
 
 TABLE FILE GGSALES
 SUM DOLLARS/D12CM UNITS/D12C
@@ -579,7 +579,7 @@ declaration of the style sheet.
 
 832
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 For compound reports, set the HYPERLINK-COLOR attribute using the TYPE=REPORT
 declaration of the style sheet of the first component report (excluding anything on the Page
@@ -633,7 +633,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  833
 
-Linking to a JavaScript Function
+Linking to a JavaScript Function
 
 The maximum length of a JAVASCRIPT=function argument, including any associated
 parameters, is 2400 characters and can span more than one line. If you split a single
@@ -677,7 +677,7 @@ The report request (which contains the inline StyleSheet) is:
 
 834
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 TABLE FILE GGORDER
 SUM PRODUCT_ID
@@ -719,7 +719,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  835
 
-Linking to a Maintain Data Procedure
+Linking to a Maintain Data Procedure
 
 When you execute the report procedure, the following report displays in the web browser. If you
 select a Product Code link, the JavaScript function ShowItem executes, and displays the value
@@ -742,7 +742,7 @@ not display a user interface.
 
 836
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 If it is a JavaScript drilldown, it uses the parent.IbComposer_drillMntdata function.
 
@@ -805,7 +805,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  837
 
-Linking to a Maintain Data Procedure
+Linking to a Maintain Data Procedure
 
 MAINTAIN FILE ggprods
 module import(mntuws FOCCOMP)
@@ -838,7 +838,7 @@ IWC.getAppCGIValue function to retrieve the correct value.
 
 838
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Form 1 in the Maintain Data procedure ggupd1 opens and you can update the unit price for
 that product:
@@ -880,7 +880,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  839
 
-Linking to a Maintain Data Procedure
+Linking to a Maintain Data Procedure
 
 rptcol
 
@@ -910,7 +910,7 @@ $
 
 840
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 The following is the Maintain code needed in order to pass these values from the report. The
 Maintain procedure is named Request2.
@@ -919,7 +919,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  841
 
-Multi-Drill Feature With Cascading Menus and User-Defined Styling
+Multi-Drill Feature With Cascading Menus and User-Defined Styling
 
 When the report and the Maintain form are placed on the same HTML page, clicking one of the
 links in the report passes the values to the Maintain form, as shown in the following image.
@@ -955,7 +955,7 @@ Use keystrokes to navigate to the link in the report.
 
 842
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Open the cascading menu item and then press Enter to view the item.
 
@@ -1011,7 +1011,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  843
 
-Multi-Drill Feature With Cascading Menus and User-Defined Styling
+Multi-Drill Feature With Cascading Menus and User-Defined Styling
 
 hover_backcolor
 
@@ -1079,7 +1079,7 @@ Double line
 
 3D ridge
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Style
 
@@ -1134,7 +1134,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  845
 
-Multi-Drill Feature With Cascading Menus and User-Defined Styling
+Multi-Drill Feature With Cascading Menus and User-Defined Styling
 
 The exception to this rule will be parent items containing children entries linked with the
 NAME/PARENT pairing. In this instance, the action will be to present the children in the
@@ -1189,7 +1189,7 @@ TYPE=type, [subtype], FOCEXEC=fex[(parameters...)], [TARGET=frame,]
 
 846
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 URL=url string
 
@@ -1245,7 +1245,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  847
 
-Multi-Drill Feature With Cascading Menus and User-Defined Styling
+Multi-Drill Feature With Cascading Menus and User-Defined Styling
 
 A WebFOCUS compiled Maintain Data procedure. The StyleSheet attribute is URL with the
 keyword MNTCON RUN. For details on the syntax, see Linking to a Maintain Data Procedure
@@ -1271,7 +1271,7 @@ FONT=TAHOMA, GRID=OFF,$
 
 848
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 TYPE=DATA,COLUMN=B2,
   DRILLMENUITEM='Sales Details', NAME=menu2,
@@ -1326,19 +1326,19 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  849
 
-Multi-Drill Feature With Cascading Menus and User-Defined Styling
+Multi-Drill Feature With Cascading Menus and User-Defined Styling
 
 This code generates a menu structure that looks like the following images.
 
 850
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Creating Reports With TIBCO® WebFOCUS Language
 
  851
 
-Multi-Drill Feature With Cascading Menus and User-Defined Styling
+Multi-Drill Feature With Cascading Menus and User-Defined Styling
 
 To apply custom styling to the menus, add the following syntax to the StyleSheet:
 
@@ -1349,7 +1349,7 @@ The menu structure will now look like the following images.
 
 852
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Reference: Usage Notes for Multi-Drill Menus
 
@@ -1397,7 +1397,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  853
 
-Creating Parameters
+Creating Parameters
 
 .
 .
@@ -1431,7 +1431,7 @@ to.
 
 854
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Parameters are useful when you want to create a dynamic link. For example, your first report is
 a summary report that lists the total number of products ordered by a company on a specific
@@ -1489,7 +1489,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  855
 
-Creating Parameters
+Creating Parameters
 
 Note: The usual use of an amper variable is to pass a constant value. If the amper
 variable corresponds to an alphanumeric field, the amper variable would have to be
@@ -1544,7 +1544,7 @@ END
 
 856
 
-The output for the main report is:
+The output for the main report is:
 
 10. Linking a Report to Other Resources
 
@@ -1608,7 +1608,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  857
 
-Creating Parameters
+Creating Parameters
 
 FAR EAST
 
@@ -1692,7 +1692,7 @@ Drill-down report (SALES):
 
 858
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 TABLE FILE GGSALES
 ON TABLE SET PAGE-NUM OFF
@@ -1721,7 +1721,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  859
 
-Creating Parameters
+Creating Parameters
 
 Main report:
 
@@ -1756,7 +1756,7 @@ When the main report request is run, the following prompt opens:
 
 860
 
-Enter MIS and click Submit. The output is:
+Enter MIS and click Submit. The output is:
 
 10. Linking a Report to Other Resources
 
@@ -1800,7 +1800,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  861
 
-Creating Parameters
+Creating Parameters
 
 Example:
 
@@ -1853,7 +1853,7 @@ END
 
 862
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 When you run the drill-down request with DRILLMETHOD=POST and select a category, for
 example, Coffee, the parameters and values are not included in the URL, as shown in the
@@ -1889,7 +1889,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  863
 
-Creating Parameters
+Creating Parameters
 
 Drill-down report (REPORT2):
 
@@ -1910,7 +1910,7 @@ When the main report request is run, the following prompt opens:
 
 864
 
-Enter MIS and click Submit. The output is:
+Enter MIS and click Submit. The output is:
 
 10. Linking a Report to Other Resources
 
@@ -1955,7 +1955,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  865
 
-Linking With Conditions
+Linking With Conditions
 
 To specify a conditional link to a URL use:
 
@@ -2015,7 +2015,7 @@ marks.
 
 866
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 frame
 
@@ -2064,7 +2064,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  867
 
-Linking From a Graphic Image
+Linking From a Graphic Image
 
 DEPARTMENT
 
@@ -2137,7 +2137,7 @@ TYPE=type, [subtype], IMAGE=image, JAVASCRIPT=function
 
 868
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 where:
 
@@ -2195,7 +2195,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  869
 
-Linking From a Graphic Image
+Linking From a Graphic Image
 
 url
 
@@ -2254,7 +2254,7 @@ Drill-down report (IMAGE-D):
 
 870
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 TABLE FILE EMPDATA
 PRINT SALARY
@@ -2278,7 +2278,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  871
 
-Specifying a Base URL
+Specifying a Base URL
 
 CE
 
@@ -2334,7 +2334,7 @@ For more details on specifying URLs, see Navigating Within an HTML Report on pag
 
 872
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Syntax:
 
@@ -2390,7 +2390,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  873
 
-Specifying a Target Frame
+Specifying a Target Frame
 
 There are two ways to specify a target frame. You can specify:
 
@@ -2443,7 +2443,7 @@ report components.
 
 874
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 fex
 
@@ -2497,7 +2497,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  875
 
-Creating a Compound Report
+Creating a Compound Report
 
 Example:
 
@@ -2549,7 +2549,7 @@ for the Compound Layout report.
 
 876
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 In a Coordinated Compound Layout report, if at least one component contains data for a
 specific sort field value, a page is generated for that value even though some of the
@@ -2599,7 +2599,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  877
 
-Creating a Compound Report
+Creating a Compound Report
 
 The compound layout block consists of SECTION, PAGELAYOUT, and COMPONENT
 declarations. The general structure of the compound layout block of syntax is:
@@ -2647,7 +2647,7 @@ SECTION=section-name, LAYOUT=ON, [MERGE=ON|OFF,]
 
 878
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 where:
 
@@ -2709,7 +2709,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  879
 
-Creating a Compound Report
+Creating a Compound Report
 
 The PAGELAYOUT=ALL syntax specifies a component that appears on every page. This
 is useful for components that generate page headers or footers.
@@ -2760,7 +2760,7 @@ END
 
 880
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Note that the recommended way to create a design theme with repeating text and images
 on a page master is to place drawing objects on the page master. For information, see How
@@ -2804,7 +2804,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  881
 
-Creating a Compound Report
+Creating a Compound Report
 
 The COMPONENT syntax appears as:
 
@@ -2859,7 +2859,7 @@ overflows its initial bounding box.
 
 882
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 OVERFLOW-POSITION and OVERFLOW-DIMENSION are supported for flowing components,
 as well. For example:
@@ -2913,7 +2913,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  883
 
-Creating a Compound Report
+Creating a Compound Report
 
 Can be one of the following:
 
@@ -2947,7 +2947,7 @@ Enter the following syntax in the Text Editor.
 
 884
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 SET PAGE-NUM=OFF
 COMPOUND LAYOUT PCHOLD FORMAT PDF
@@ -3003,7 +3003,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  885
 
-Creating a Compound Report
+Creating a Compound Report
 
 The first page of output is:
 
@@ -3035,7 +3035,7 @@ END
 
 886
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 SET COMPONENT=Sales
 GRAPH FILE GGSALES
@@ -3081,7 +3081,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  887
 
-Creating a Compound Report
+Creating a Compound Report
 
 TABLE FILE GGSALES
 "Percent of Sales by Product in <REGION"
@@ -3118,7 +3118,7 @@ COMPOUND END
 
 888
 
-The first page of output is:
+The first page of output is:
 
 10. Linking a Report to Other Resources
 
@@ -3152,7 +3152,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  889
 
-Creating a Compound Report
+Creating a Compound Report
 
 We will use components R1 and R2 from the previous example. If you did not already do so,
 save them as REPORT1.FEX and REPORT2.FEX. Enter the following syntax as the R3 report
@@ -3197,7 +3197,7 @@ COMPOUND END
 
 890
 
-Page 1 of the output is:
+Page 1 of the output is:
 
 10. Linking a Report to Other Resources
 
@@ -3207,7 +3207,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  891
 
-Creating a Compound Report
+Creating a Compound Report
 
 Example:
 
@@ -3260,7 +3260,7 @@ END
 
 892
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 SET COMPONENT=R2
 TABLE FILE GGSALES
@@ -3293,13 +3293,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  893
 
-Creating a Compound Report
+Creating a Compound Report
 
 The first page of output is:
 
 894
 
-The second page of output is:
+The second page of output is:
 
 10. Linking a Report to Other Resources
 
@@ -3326,7 +3326,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  895
 
-Creating a Compound Report
+Creating a Compound Report
 
 OBJECT=LINE, POSITION=(1 1), ENDPOINT=(8 1),
         BORDER=HEAVY, BORDER-COLOR=RED, BORDER-STYLE=DASHED, $
@@ -3377,7 +3377,7 @@ OFF},] [FONT=f,] [SIZE=sz,] [STYLE=st,] [COLOR=c,]
 
 896
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 where:
 
@@ -3442,7 +3442,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  897
 
-Creating a Compound Report
+Creating a Compound Report
 
 LINESPACING=type(value)
 
@@ -3509,7 +3509,7 @@ any textual object in a report. For example:
 
 898
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 OBJECT=STRING, POSITION=(1 1), TEXT='Hello world!',
         FONT=TIMES, SIZE=12, STYLE=BOLD, COLOR=RED, $
@@ -3532,7 +3532,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  899
 
-Creating a Compound Report
+Creating a Compound Report
 
 Example:
 
@@ -3580,7 +3580,7 @@ COMPOUND END
 
 900
 
-The first page of output is:
+The first page of output is:
 
 10. Linking a Report to Other Resources
 
@@ -3617,7 +3617,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  901
 
-Creating a Compound Report
+Creating a Compound Report
 
 For example:
 
@@ -3672,7 +3672,7 @@ Vertical Alignment
 
 902
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Top Alignment:
 
@@ -3726,7 +3726,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  903
 
-Creating a Compound Report
+Creating a Compound Report
 
 By default, Arabic numerals (type=1) are used for the ordering of the list. You can specify the
 following types of order:
@@ -3783,7 +3783,7 @@ MARKUP=OFF.
 
 904
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 MARKUP=OFF, TEXT='Page <ibi-page-number/> of <ibi-total-pages/> of Sales
 Report', $
@@ -3809,7 +3809,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  905
 
-Creating a Compound Report
+Creating a Compound Report
 
 Example:
 
@@ -3868,7 +3868,7 @@ The markup for this formatting is:
 
 906
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 <b><font face="Arial" size=12>This paragraph is triple-spaced
 (LINESPACING=MULTIPLE(3)):</font></b>
@@ -3890,7 +3890,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  907
 
-Creating a Compound Report
+Creating a Compound Report
 
 Example:
 
@@ -3921,7 +3921,7 @@ END
 
 908
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 SET COMPONENT=HEADER
 TABLE FILE GGSALES
@@ -3973,13 +3973,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  909
 
-Creating a Compound Report
+Creating a Compound Report
 
 The first page of output is:
 
 910
 
-The second page of output has the same drawing objects:
+The second page of output has the same drawing objects:
 
 10. Linking a Report to Other Resources
 
@@ -3997,7 +3997,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  911
 
-Creating a Compound Report
+Creating a Compound Report
 
 In the right box, the text is aligned vertically at the bottom.
 
@@ -4042,7 +4042,7 @@ components segmented to display the data that corresponds to that sort field val
 
 912
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 A Coordinated Compound Layout report page is generated in the designated page layout for
 every sort field value found in at least one of the component reports, presenting the
@@ -4094,7 +4094,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  913
 
-Creating a Compound Report
+Creating a Compound Report
 
 To demonstrate how this works we will first build a set of data files: a header file containing
 contact information for the selected set of stores, and transaction files for each inventory
@@ -4163,7 +4163,7 @@ END
 
 914
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 The following procedure creates the data source GGHDR:
 
@@ -4221,7 +4221,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  915
 
-Creating a Compound Report
+Creating a Compound Report
 
 The following procedure creates the data source GG3:
 
@@ -4280,7 +4280,7 @@ END
 
 916
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 The following procedure, GGRPT1.FEX, creates the second report component for the
 Coordinated Compound Layout report. For the same store code value in the header report, it
@@ -4326,7 +4326,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  917
 
-Creating a Compound Report
+Creating a Compound Report
 
 The following procedure, GGRPT2.FEX, creates the third report component for the Coordinated
 Compound Layout report. For the same store code value in the header report, it displays data
@@ -4370,7 +4370,7 @@ END
 
 918
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 The following procedure, GGRPT3.FEX, creates the final report component for the Coordinated
 Compound Layout report. For the same store code value in the header report, it displays data
@@ -4416,7 +4416,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  919
 
-Creating a Compound Report
+Creating a Compound Report
 
 Example:
 
@@ -4428,7 +4428,7 @@ in the following diagram:
 
 920
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 The Coordinated Compound Layout syntax is:
 
@@ -4466,14 +4466,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  921
 
-Creating a Compound Report
+Creating a Compound Report
 
 On the first page of the PDF output file, all components have data and appear on the report
 output:
 
 922
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 On the second page, report GGRPT2.FEX did not retrieve any data for the store in the header.
 Therefore, the Coffee component is missing. Note that because Component 3 and 4 are
@@ -4485,7 +4485,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  923
 
-Creating a Compound Report
+Creating a Compound Report
 
 On page 5, the header report did not retrieve any data for a store code value present in the
 other three components. A page is still generated for this store code. Since the second
@@ -4500,7 +4500,7 @@ compound report.
 
 924
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 In PPTX, the Table of Contents can be presented as a Table of Contents page placed at the
 beginning of the document. In PDF, the Table of Contents can be presented as either PDF
@@ -4552,7 +4552,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  925
 
-Creating a Compound Report
+Creating a Compound Report
 
 Note: If the Table of Contents overflows to more than one page at run time, the remaining
 content is executed with the same size and dimensions as the first page until the entire TOC
@@ -4612,7 +4612,7 @@ COMPOUND END
 
 926
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 The output shows that each component report is at Table of Contents level 1 and has two
 levels of sort fields under it, as shown in the following image. For the Sales by Product report,
@@ -4624,7 +4624,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  927
 
-Creating a Compound Report
+Creating a Compound Report
 
 From PowerPoint presentation view, clicking any entry on the Table of Contents page opens the
 page containing that entry. For example, clicking the Sales by Region Southeast entry displays
@@ -4632,7 +4632,7 @@ the following page.
 
 928
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Syntax:
 
@@ -4697,7 +4697,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  929
 
-Creating a Compound Report
+Creating a Compound Report
 
 font='font2', color={color|RGB(rgb)},size=sz2,
 
@@ -4756,7 +4756,7 @@ the selected data element on the page.
 
 930
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Reports used for headings or footings on overflow pages (DisplayOn=OVERFLOW-ONLY)
 should not be included in any TOC or BYTOC entries. These components will generate
@@ -4812,7 +4812,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  931
 
-Creating a Compound Report
+Creating a Compound Report
 
 SET COMPONENT=report1
 TABLE FILE GGSALES
@@ -4847,7 +4847,7 @@ COMPOUND END
 
 932
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 The output shows that each component reports is at Table of Contents level 1 and has two
 levels of sort fields under it. For the Sales by Product report, the BY fields are Category and
@@ -4858,7 +4858,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  933
 
-Creating a Compound Report
+Creating a Compound Report
 
 Clicking any entry on the Table of Contents page or in the bookmarks pane opens the page
 containing that entry. For example, clicking the Sales by Region/Southeast entry opens the
@@ -4884,7 +4884,7 @@ Compound Reports, see Creating a Compound Excel Report Using EXL2K on page 943.
 
 934
 
-Syntax:
+Syntax:
 
 How to Display Compound Reports
 
@@ -4937,7 +4937,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  935
 
-Creating a Compound Report
+Creating a Compound Report
 
 Note:
 
@@ -4985,7 +4985,7 @@ END
 
 936
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Report 2:
 
@@ -5019,7 +5019,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  937
 
-Creating a Compound Report
+Creating a Compound Report
 
 The output displays as a PDF report. Because the syntax for reports 1 and 2 contain the
 NOBREAK command, the three reports appear on a single page. (Without NOBREAK, each
@@ -5041,7 +5041,7 @@ For details on saving a graph as an image file, see Creating a Graph on page 174
 
 938
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 To embed a graphic in a compound report, you must identify the image file in the StyleSheet
 declaration of the report in which you want to include it, along with size and position
@@ -5093,7 +5093,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  939
 
-Creating a Compound Report
+Creating a Compound Report
 
 Report 2:
 
@@ -5124,7 +5124,7 @@ END
 
 940
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Report 3:
 
@@ -5160,13 +5160,13 @@ Creating Reports With TIBCO® WebFOCUS Language
  941
 
 
-Creating a Compound Report
+Creating a Compound Report
 
 The output is:
 
 942
 
-Creating a Compound Excel Report Using EXL2K
+Creating a Compound Excel Report Using EXL2K
 
 10. Linking a Report to Other Resources
 
@@ -5219,7 +5219,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  943
 
-Creating a Compound Report
+Creating a Compound Report
 
 ON TABLE HOLD AS MYHOLD FORMAT EXL2K OPEN NOBREAK
 
@@ -5268,7 +5268,7 @@ there would be no way to remove them.
 
 944
 
-Example:
+Example:
 
 Creating a Simple Compound Report Using EXL2K
 
@@ -5318,13 +5318,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  945
 
-Creating a Compound Report
+Creating a Compound Report
 
 The output for each tab in the Excel worksheet is:
 
 946
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Example:
 
@@ -5348,7 +5348,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  947
 
-Creating a Compound Report
+Creating a Compound Report
 
 TABLE FILE CAR
 HEADING
@@ -5389,7 +5389,7 @@ END
 
 948
 
-The output for each tab in the Excel worksheet is:
+The output for each tab in the Excel worksheet is:
 
 10. Linking a Report to Other Resources
 
@@ -5397,11 +5397,11 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  949
 
-Creating a Compound Report
+Creating a Compound Report
 
 950
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Example:
 
@@ -5459,7 +5459,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  951
 
-Creating a Compound Report
+Creating a Compound Report
 
 TABLE FILE GGSALES
 HEADING
@@ -5479,7 +5479,7 @@ END
 
 952
 
-The output is:
+The output is:
 
 10. Linking a Report to Other Resources
 
@@ -5487,7 +5487,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  953
 
-Creating a PDF Compound Report With Drill Through Links
+Creating a PDF Compound Report With Drill Through Links
 
 Creating a PDF Compound Report With Drill Through Links
 
@@ -5538,7 +5538,7 @@ You can format the reports using a WebFOCUS StyleSheet.
 
 954
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 You can indicate a hyperlink by color, font, underlining, and so forth.
 
@@ -5589,7 +5589,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  955
 
-Creating a PDF Compound Report With Drill Through Links
+Creating a PDF Compound Report With Drill Through Links
 
 Procedure: How to Create a Drill Through in a PDF Compound Report
 
@@ -5651,7 +5651,7 @@ Links to the first Drill Through report in the sequence.
 
 956
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 link_fields
 
@@ -5712,7 +5712,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  957
 
-Creating a PDF Compound Report With Drill Through Links
+Creating a PDF Compound Report With Drill Through Links
 
 Note: The double parentheses around the DRILLMAP values are required.
 
@@ -5761,7 +5761,7 @@ Drill Through is only supported for reports (TABLE).
 
 958
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Sample Drill Through PDF Compound Reports
 
@@ -5785,7 +5785,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  959
 
-Creating a PDF Compound Report With Drill Through Links
+Creating a PDF Compound Report With Drill Through Links
 
 Example:
 
@@ -5815,7 +5815,7 @@ END
 
 960
 
-Example:
+Example:
 
 Connecting the Reports With Hyperlinks (Step 3)
 
@@ -5866,7 +5866,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  961
 
-Creating a PDF Compound Report With Drill Through Links
+Creating a PDF Compound Report With Drill Through Links
 
 The detail report:
 
@@ -5924,7 +5924,7 @@ attributes to the COMPONENT declarations.
 
 962
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Add SET COMPONENT commands and the two reports.
 
@@ -5965,7 +5965,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  963
 
-Creating a PDF Compound Report With Drill Through Links
+Creating a PDF Compound Report With Drill Through Links
 
 -* Add report2 code and SET COMPONENT command
 SET COMPONENT='REPORT2'
@@ -6008,7 +6008,7 @@ intervening page breaks.
 
 964
 
-This example uses the OPEN and CLOSE options on the PCHOLD FORMAT PDF command:
+This example uses the OPEN and CLOSE options on the PCHOLD FORMAT PDF command:
 
 10. Linking a Report to Other Resources
 
@@ -6046,7 +6046,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  965
 
-Creating a PDF Compound Report With Drill Through Links
+Creating a PDF Compound Report With Drill Through Links
 
 Example:
 
@@ -6062,7 +6062,7 @@ Click the hyperlink Return to Summary to return to the first page (summary repor
 
 966
 
-10. Linking a Report to Other Resources
+10. Linking a Report to Other Resources
 
 Reference: Guidelines on Links For FIRST
 
@@ -6114,7 +6114,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  967
 
-Creating a PDF Compound Report With Drill Through Links
+Creating a PDF Compound Report With Drill Through Links
 
 The link fields in the source and target reports must have the same internal (actual) format:
 the stopped data type and internal length must be identical. Formatting options, such as

--- a/specifications/creating_reports/creating_reports_11_chapter11.md
+++ b/specifications/creating_reports/creating_reports_11_chapter11.md
@@ -48,7 +48,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  969
 
-Navigating Sort Groups From a Table of Contents
+Navigating Sort Groups From a Table of Contents
 
 The TOC displays all values of the first (highest-level) vertical sort field, as well as the values of
 any lower level BY fields that you designate for inclusion. These values are displayed as an
@@ -97,7 +97,7 @@ order to access the components required to operate successfully.
 
 970
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 HTMLARCHVE can be used to create self-contained HTML pages with user-defined images
 when client access is not available.
@@ -154,7 +154,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  971
 
-Adding the HTML Table of Contents Tree Control to Reports
+Adding the HTML Table of Contents Tree Control to Reports
 
 Syntax:
 
@@ -217,7 +217,7 @@ the first (highest level) vertical sort field, PLANT:
 
 972
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 SET COMPOUND='BYTOC 2'
 
@@ -270,7 +270,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  973
 
-Adding the HTML Table of Contents Tree Control to Reports
+Adding the HTML Table of Contents Tree Control to Reports
 
 In the following request, the TOC Tree control is enabled in the Report StyleSheet:
 
@@ -295,7 +295,7 @@ Run the report. The TOC object displays in the upper-left corner.
 
 974
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 Double-click the TOC icon to open the Table of Contents Tree control. This displays the values
 of the sort fields in the report in the order in which they have been specified.
@@ -310,7 +310,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  975
 
-Adding the HTML Table of Contents Tree Control to Reports
+Adding the HTML Table of Contents Tree Control to Reports
 
 Tip: You can also customize the look and feel of the TOC object by editing a .css file. It is
 recommended that you make a backup copy prior to editing.
@@ -365,7 +365,7 @@ END
 
 976
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 One section of the report is displayed at a time.
 
@@ -394,7 +394,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  977
 
-Adding the HTML Table of Contents Tree Control to Reports
+Adding the HTML Table of Contents Tree Control to Reports
 
 Example:
 
@@ -428,7 +428,7 @@ END
 
 978
 
-The output is displayed with the TOC object in the upper-left corner.
+The output is displayed with the TOC object in the upper-left corner.
 
 11. Navigating Within an HTML Report
 
@@ -441,7 +441,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  979
 
-Adding the HTML Table of Contents Tree Control to Reports
+Adding the HTML Table of Contents Tree Control to Reports
 
 Scroll back to the top of the report window and reopen the TOC. This time select Americas.
 Your selection flashes to highlight it on the screen. Although the report display does not
@@ -457,7 +457,7 @@ your cursor.
 
 980
 
-Select Brazil. Your selection flashes and moves to the top of the window, as shown next.
+Select Brazil. Your selection flashes and moves to the top of the window, as shown next.
 
 11. Navigating Within an HTML Report
 
@@ -493,7 +493,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  981
 
-Adding the HTML Table of Contents Tree Control to Reports
+Adding the HTML Table of Contents Tree Control to Reports
 
 TABHEADING
 
@@ -554,7 +554,7 @@ line.
 
 982
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 sort_column
 
@@ -606,7 +606,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  983
 
-Adding the HTML Table of Contents Tree Control to Reports
+Adding the HTML Table of Contents Tree Control to Reports
 
 When you run the report. The TOC appears as a drop-down menu in the heading, in place of
 the field CONTINENT:
@@ -618,7 +618,7 @@ highlight it in the window.
 
 984
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 You can display all available fields (the whole report) by clicking the View Entire Report option.
 To remove the TOC, click the Remove Table of Contents option. To restore the TOC, double-click
@@ -659,13 +659,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  985
 
-Adding the HTML Table of Contents Tree Control to Reports
+Adding the HTML Table of Contents Tree Control to Reports
 
 The output is:
 
 986
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 Click the arrow in the second TOC drop-down list and select North America. Keep in mind that
 the values in this drop-down list are related to those in the higher level drop-down list. They are
@@ -680,7 +680,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  987
 
-Adding the HTML Table of Contents Tree Control to Reports
+Adding the HTML Table of Contents Tree Control to Reports
 
 Next, scroll up and choose ASIA from the first TOC list. This selection changes your highest-
 level sort group, and affects all of the lists below it. ASIA flashes and moves to the top of the
@@ -702,7 +702,7 @@ Define frames and populate them with reports. See Specifying a Target Frame on p
 
 988
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 Reference: HTML Table of Contents Limits
 
@@ -747,7 +747,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  989
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 You can create two types of Accordion Reports:
 
@@ -795,7 +795,7 @@ Note: Accordion Reports are only supported for HTML report output.
 
 990
 
-Requirements for Accordion Reports
+Requirements for Accordion Reports
 
 11. Navigating Within an HTML Report
 
@@ -848,7 +848,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  991
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 SET FOCHTMLURL = http://hostname[:port]/ibi_apps/ibi_html
 
@@ -897,7 +897,7 @@ values will represent the aggregation of the lowest level BY.
 
 992
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 Styling an Accordion By Row report can be done using standard HTML report techniques, but it
 is important to keep the report structure in mind. All rows, except the lowest level, are actually
@@ -949,7 +949,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  993
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 n
 
@@ -1000,7 +1000,7 @@ $
 
 994
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 TYPE=TITLE,
     COLOR='WHITE',
@@ -1046,7 +1046,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  995
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 Clicking the plus sign (+) next to the Midwest region opens the rows that show the states
 associated with that region, as shown in the following image.
@@ -1056,7 +1056,7 @@ associated with that state, as shown in the following image.
 
 996
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 Clicking the plus sign (+) next to the Coffee category shows the products associated with that
 category, as shown in the following image. This is the lowest level of the Accordion By Row
@@ -1093,7 +1093,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  997
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 TYPE=TITLE,
     BACKCOLOR=RGB(102 102 102),
@@ -1147,7 +1147,7 @@ summary lines.
 
 998
 
-The output is:
+The output is:
 
 11. Navigating Within an HTML Report
 
@@ -1162,7 +1162,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  999
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 where:
 
@@ -1218,7 +1218,7 @@ END
 
 1000
 
-The initial output shows only the top level BY field (REGION), as shown in the following image.
+The initial output shows only the top level BY field (REGION), as shown in the following image.
 
 11. Navigating Within an HTML Report
 
@@ -1232,7 +1232,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1001
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 Clicking the plus sign (+) next to the Coffee category shows the products associated with that
 category, as shown in the following image. This is the lowest level of the Accordion By Row
@@ -1248,7 +1248,7 @@ Note: The color of the arrows match the color of the SUBTOTAL line, in this case
 
 1002
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 TABLE FILE GGSALES
 SUM DOLLARS/D8MC
@@ -1285,7 +1285,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1003
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 Clicking the right arrow next to the state IL opens the rows that show the categories
 associated with that state, as shown in the following image.
@@ -1300,7 +1300,7 @@ purple.
 
 1004
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 TABLE FILE GGSALES
 SUM DOLLARS/D8MC
@@ -1340,7 +1340,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1005
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 EXPANDBYROWTREE is not supported with OLAP. When both OLAP and
 EXPANDBYROWTREE are enabled, EXPANDBYROWTREE will be ignored. As a workaround,
@@ -1398,7 +1398,7 @@ AS Name
 1006
 
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 Existing Field Information
 
@@ -1432,7 +1432,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1007
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 DEFINE FILE GGSALES.
 UNITS/D12C DESCRIPTION ''=UNITS;
@@ -1486,7 +1486,7 @@ FIELD=UNITS, ALIAS=E10, FORMAT=I08, TITLE='Unit Sales',
 
 1008
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 The following image shows the pop-up description for the tree control, located at the top-left
 corner of the table, displaying the list of column titles or AS name for the given BY column
@@ -1510,7 +1510,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1009
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 SET POPUPDESC = ON
 DEFINE FILE GGSALES.
@@ -1545,7 +1545,7 @@ an AS name has been given to this field.
 
 1010
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 For additional information on pop-up field descriptions with HTML reports, see Displaying
 Report Data on page 39.
@@ -1580,7 +1580,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1011
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 DEFINE FILE EMPLOYEE
 NAME_SORT/A50=EMPLOYEE.EMPINFO.LAST_NAME || ( ', ' |
@@ -1612,7 +1612,7 @@ $
 
 1012
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 TYPE=TITLE,
     BACKCOLOR=RGB(102 102 102),
@@ -1649,7 +1649,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1013
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 If you hover the mouse over any value in the NAME_DISPLAY column, the tooltip will display the
 AS name, Employee Name, as shown in the following image.
@@ -1672,7 +1672,7 @@ reformatted with the format, YY, and by the virtual field NAME_DISPLAY (employee
 
 1014
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 DEFINE FILE EMPLOYEE
 NAME_SORT/A50=EMPLOYEE.EMPINFO.LAST_NAME || ( ', ' |
@@ -1716,7 +1716,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1015
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 DEFINE FILE EMPLOYEE
 NAME_SORT/A50=EMPLOYEE.EMPINFO.LAST_NAME || ( ', ' |
@@ -1758,7 +1758,7 @@ On Demand Paging
 
 1016
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 TABLEF
 
@@ -1813,7 +1813,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1017
 
-Controlling the Display of Sorted Data With Accordion Reports
+Controlling the Display of Sorted Data With Accordion Reports
 
 Data Visualization, HTML BYTOC, OLAP, On Demand Paging (WebFOCUS Viewer), column
 freezing, and the ReportCaster burst feature are also not supported with Accordion Reports.
@@ -1851,7 +1851,7 @@ END
 
 1018
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 The following image shows an Accordion by Column Report which displays all data associated
 with the first-level sort field, Region, by default. The expanded data values you see are the
@@ -1880,7 +1880,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1019
 
-Navigating a Multi-Page Report With the WebFOCUS Viewer
+Navigating a Multi-Page Report With the WebFOCUS Viewer
 
 The following is page 1 of a 31-page report displayed in the WebFOCUS Viewer.
 
@@ -1906,7 +1906,7 @@ when client access is not available.
 
 1020
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 To generate HTML pages containing user-defined images that can operate interactively, use
 one of the following commands:
@@ -1960,7 +1960,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1021
 
-Linking Report Pages
+Linking Report Pages
 
 When using the Search option:
 
@@ -2017,7 +2017,7 @@ of the report.
 
 1022
 
-11. Navigating Within an HTML Report
+11. Navigating Within an HTML Report
 
 TABLE FILE GGORDER
 ON TABLE SUBHEAD
@@ -2045,13 +2045,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1023
 
-Linking Report Pages
+Linking Report Pages
 
 Click the image on the left of page 1 to display page 2.
 
 1024
 
-Click the "go back" image on page 2 to redisplay page 1.
+Click the "go back" image on page 2 to redisplay page 1.
 
 11. Navigating Within an HTML Report
 
@@ -2075,7 +2075,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1025
 
-Linking Report Pages
+Linking Report Pages
 
 TABLE FILE GGORDER
 ON TABLE SUBHEAD
@@ -2101,7 +2101,7 @@ The first page looks as follows:
 
 1026
 
-Click the page number three times to move to PAGE 4.
+Click the page number three times to move to PAGE 4.
 
 11. Navigating Within an HTML Report
 
@@ -2116,6 +2116,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1027
 
-Linking Report Pages
+Linking Report Pages
 
 1028

--- a/specifications/creating_reports/creating_reports_12_chapter12.md
+++ b/specifications/creating_reports/creating_reports_12_chapter12.md
@@ -48,7 +48,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1029
 
-Bursting Reports Overview
+Bursting Reports Overview
 
 PCSEND
 
@@ -95,7 +95,7 @@ ON TABLE SUBHEAD
 
 1030
 
-12. Bursting Reports Into Multiple HTML Files
+12. Bursting Reports Into Multiple HTML Files
 
 and
 
@@ -136,7 +136,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1031
 
-Bursting Reports Overview
+Bursting Reports Overview
 
 Example:
 
@@ -177,7 +177,7 @@ Regional Report
 
 1032
 
-12. Bursting Reports Into Multiple HTML Files
+12. Bursting Reports Into Multiple HTML Files
 
 Region
 
@@ -273,6 +273,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Bursting Reports Overview
+Bursting Reports Overview
 
 1034

--- a/specifications/creating_reports/creating_reports_13_chapter13.md
+++ b/specifications/creating_reports/creating_reports_13_chapter13.md
@@ -43,7 +43,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1035
 
-Missing Field Values
+Missing Field Values
 
 Example:
 
@@ -78,7 +78,7 @@ prefix operators such as MAX. and AVE.
 
 1036
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 To prevent the use of these default values in calculations (which might then give erroneous
 results), you can add the MISSING attribute to the field declaration in the Master File, for
@@ -131,7 +131,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1037
 
-Missing Field Values
+Missing Field Values
 
 The numeric values in the first two records are missing (indicated by the periods). The last two
 records have values of 1 and 3. If you average these fields without the MISSING attribute
@@ -178,7 +178,7 @@ missing.
 
 1038
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 Example:
 
@@ -226,7 +226,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1039
 
-Missing Field Values
+Missing Field Values
 
 To ensure that missing values are handled properly for temporary fields, you can set the
 MISSING attribute ON for the virtual field in the DEFINE or COMPUTE command, and specify
@@ -281,7 +281,7 @@ Is optional. It helps to clarify the meaning of the command.
 
 1040
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 expression
 
@@ -338,7 +338,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1041
 
-Missing Field Values
+Missing Field Values
 
 Notice that the products C13, C14, and E2 in the New York section all show missing values for
 either RETURNS or DAMAGED, because the MISSING ON attribute has been set in the Master
@@ -370,7 +370,7 @@ END
 
 1042
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 The output is:
 
@@ -401,7 +401,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1043
 
-Missing Field Values
+Missing Field Values
 
 ALL
 
@@ -439,7 +439,7 @@ unless both AAA and BBB are missing.
 
 1044
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 Changing SET MISS_ON to ALL, produces the following output. CCC is assigned a missing
 value because one of the fields used to calculate it is always missing.
@@ -485,7 +485,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1045
 
-Missing Field Values
+Missing Field Values
 
 Consider the following request. CCC uses EQ 0 in the IF-THEN-ELSE test, and DDD uses IS
 MISSING.
@@ -529,7 +529,7 @@ SET MISSINGTEST = {NEW|OLD|SPECIAL}
 
 1046
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 where:
 
@@ -586,7 +586,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1047
 
 
-Missing Field Values
+Missing Field Values
 
 Running the request with MISSINGTEST=OLD produces the output shown in the following
 image:
@@ -615,7 +615,7 @@ You can specify WHERE criteria to identify segment instances with missing field 
 
 1048
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 You cannot use these tests to identify missing instances. See Handling a Missing Segment
 Instance on page 1056.
@@ -659,7 +659,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1049
 
-Missing Field Values
+Missing Field Values
 
 Example:
 
@@ -691,7 +691,7 @@ END
 
 1050
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 The output is:
 
@@ -726,7 +726,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1051
 
-Missing Field Values
+Missing Field Values
 
 Syntax:
 
@@ -782,7 +782,7 @@ HOLD Master File and the missing data symbols are replaced with default values.
 
 1052
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 Syntax:
 
@@ -832,7 +832,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1053
 
-Missing Field Values
+Missing Field Values
 
 The output is:
 
@@ -890,7 +890,7 @@ adds missing values to the SALES data source, has been run.
 
 1054
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 SET COMPMISS = OFF
 TABLE FILE SALES
@@ -945,7 +945,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1055
 
-Handling a Missing Segment Instance
+Handling a Missing Segment Instance
 
 Reference: Usage Notes for SET COMPMISS
 
@@ -982,7 +982,7 @@ are missing.
 
 1056
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 Nonexistent descendant instances affect whether parent segment instances are included in
 report results. The SET ALL parameter and the ALL. prefix enable you to include parent
@@ -1037,7 +1037,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1057
 
-Handling a Missing Segment Instance
+Handling a Missing Segment Instance
 
 Example:
 
@@ -1187,7 +1187,7 @@ Note: The report output has been truncated for demonstration purposes.
 
 1058
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 Including Missing Instances in Reports With the ALL. Prefix
 
@@ -1248,7 +1248,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1059
 
-Handling a Missing Segment Instance
+Handling a Missing Segment Instance
 
 Note: A request with WHERE or IF criteria, which screen fields in a segment that has missing
 instances, omits instances in the parent segment even if you use the SET ALL=ON command.
@@ -1299,7 +1299,7 @@ value.
 
 1060
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 ON
 
@@ -1335,7 +1335,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1061
 
-Handling a Missing Segment Instance
+Handling a Missing Segment Instance
 
 The output is:
 
@@ -1364,7 +1364,7 @@ command or a JOIN LEFT_OUTER command (either inside or outside of the Master Fil
 
 1062
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 Reference: Usage Notes for SET SHORTPATH = SQL
 
@@ -1407,7 +1407,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1063
 
-Handling a Missing Segment Instance
+Handling a Missing Segment Instance
 
 EMP_ID     COURSE_CODE     COURSE_NAME
 ------     -----------     -----------
@@ -1457,7 +1457,7 @@ EMP_ID     COURSE_CODE     COURSE_NAME
 
 1064
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 The following request adds the SET SHORTPATH = SQL command.
 
@@ -1517,7 +1517,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1065
 
-Setting the NODATA Character String
+Setting the NODATA Character String
 
 Testing for Missing Instances in FOCUS Data Sources
 
@@ -1671,7 +1671,7 @@ NODATA character is a period. However, you can change this character designation
 
 1066
 
-13. Handling Records With Missing Field Values
+13. Handling Records With Missing Field Values
 
 Syntax:
 
@@ -1716,6 +1716,6 @@ Creating Reports With TIBCO® WebFOCUS Language
  1067
 
 
-Setting the NODATA Character String
+Setting the NODATA Character String
 
 1068

--- a/specifications/creating_reports/creating_reports_14_chapter14.md
+++ b/specifications/creating_reports/creating_reports_14_chapter14.md
@@ -59,7 +59,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1069
 
-The SET ALL command globally determines how all joins are implemented. If the SET ALL=ON
+The SET ALL command globally determines how all joins are implemented. If the SET ALL=ON
 command is issued, all joins are treated as outer joins. With SET ALL=OFF, the default, all
 joins are treated as inner joins.
 
@@ -105,7 +105,7 @@ Types of Joins
 
 1070
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 For more information on unique and non-unique joins, see Unique and Non-Unique Joined
 Structures on page 1072.
@@ -139,7 +139,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1071
 
-Types of Joins
+Types of Joins
 
 Reference: Notes on DBA Security for Joined Data Structures
 
@@ -177,7 +177,7 @@ file, regardless of whether the structure is unique.
 
 1072
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 Example:
 
@@ -212,7 +212,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1073
 
-Types of Joins
+Types of Joins
 
 To join these two data sources, issue the following JOIN command, using the ALL phrase:
 
@@ -245,7 +245,7 @@ values. OLD is the default value.
 
 1074
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 GNTINT
 
@@ -295,7 +295,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1075
 
-Types of Joins
+Types of Joins
 
 Issuing SET JOINOPT=NEW enables segments to be retrieved in the expected order (from left
 to right and from top to bottom), without missing data.
@@ -334,7 +334,7 @@ For example, the GENERIC data source shown below consists of Segments A and B.
 
 1076
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 The following request creates a recursive structure:
 
@@ -359,7 +359,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1077
 
-Types of Joins
+Types of Joins
 
 If you use tag names in a recursive joined structure, note the following guidelines:
 
@@ -410,7 +410,7 @@ Parts of divisions, such as instrument panels and seats.
 
 1078
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 Subparts, such as nuts and bolts.
 
@@ -439,7 +439,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1079
 
-Types of Joins
+Types of Joins
 
 For example, CABIN is a first-level division appearing in the top segment. It lists SEATS as a
 component in the bottom segment. SEATS also appears in the top segment. It lists BOLTS as
@@ -454,7 +454,7 @@ This creates the following recursive structure.
 
 1080
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 You can then produce a report on all three levels of data with this TABLE command (the field
 SUBDESCRIPT describes the contents of the field SUBPART):
@@ -504,7 +504,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1081
 
-Creating an Equijoin
+Creating an Equijoin
 
 The first record retrieved is a JOB file record for employee #071382660. Next, all records in
 the SALARY data source containing employee #071382660 are retrieved. This process
@@ -558,7 +558,7 @@ referenced file. This field is called the host field.
 
 1082
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 AND hfld2...
 
@@ -617,7 +617,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1083
 
-Creating an Equijoin
+Creating an Equijoin
 
 The tag name for the host file must be the same in all the JOIN commands of a joined
 structure.
@@ -674,7 +674,7 @@ assumed to be blank. A join without a name overwrites an existing join without a
 
 1084
 
-END
+END
 
 Required when the JOIN command is longer than one line. It terminates the command.
 It must be on a line by itself.
@@ -707,7 +707,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1085
 
-Creating an Equijoin
+Creating an Equijoin
 
 The procedure then adds an employee to EMPINFO named Fred Newman who has no matching
 record in the JOBINFO or EDINFO data sources.
@@ -754,7 +754,7 @@ END
 
 
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 The output is:
 
@@ -813,7 +813,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1087
 
-Creating an Equijoin
+Creating an Equijoin
 
 Example:
 
@@ -871,7 +871,7 @@ END
 
 1088
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 The following request generates the WF_PRODUCT table. The field ID_PRODUCT will be used in
 the right outer join command.
@@ -928,7 +928,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1089
 
-Creating an Equijoin
+Creating an Equijoin
 
 The output, shown in the following image, has a row for each ID_PRODUCT value that is in the
 WF_PRODUCT table. The columns from WF_SALES rows that do not have a matching
@@ -947,7 +947,7 @@ JOIN INNER EMP_ID IN EMPINFO TO MULTIPLE EMP_ID IN EDINFO AS J1
 
 1090
 
-The structure created by the two joins has two independent paths:
+The structure created by the two joins has two independent paths:
 
 14. Joining Data Sources
 
@@ -1006,7 +1006,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1091
 
-Creating an Equijoin
+Creating an Equijoin
 
 With MULTIPATH=COMPOUND, only employees with matching records in both of the cross-
 referenced files display on the report output:
@@ -1054,7 +1054,7 @@ segment, the host file must have a segment declaration.
 
 1092
 
-Reference: Restrictions on Group Fields
+Reference: Restrictions on Group Fields
 
 When group fields are used in a joined structure, the group in the host file and the group in the
 cross-referenced file must have the same number of elements:
@@ -1106,7 +1106,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1093
 
-Creating an Equijoin
+Creating an Equijoin
 
 (FOC32452) Use of ALL. with LEFT_OUTER/INNER not allowed
 
@@ -1147,7 +1147,7 @@ information, see Preserving Virtual Fields Using KEEPDEFINES on page 1144.
 
 1094
 
-Syntax:
+Syntax:
 
 How to Join From a Virtual Field to a Real Field
 
@@ -1210,7 +1210,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1095
 
-Creating an Equijoin
+Creating an Equijoin
 
 TAG tag1
 
@@ -1266,7 +1266,7 @@ assumed to be blank. A join without a name overwrites an existing join without a
 
 1096
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 END
 
@@ -1321,7 +1321,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1097
 
-Creating an Equijoin
+Creating an Equijoin
 
 The procedure is:
 
@@ -1374,7 +1374,7 @@ referenced values that are prefixed with the host value.
 
 1098
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 When joining a longer to a shorter field, the host value is unconditionally truncated to
 the cross referenced field length. If the truncation removes non-blank characters, the
@@ -1422,7 +1422,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1099
 
-Creating an Equijoin
+Creating an Equijoin
 
 The edit options may differ. The length may also differ, but with the following effect:
 
@@ -1472,7 +1472,7 @@ values are converted to hex C and all signs for negative values are converted to
 
 1100
 
-The JOINOPT parameter also corrects for lagging values in a unique join. For information,
+The JOINOPT parameter also corrects for lagging values in a unique join. For information,
 see How to Correct for Lagging Values With a Unique Join on page 1074.
 
 14. Joining Data Sources
@@ -1533,7 +1533,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1101
 
-Using a Conditional Join
+Using a Conditional Join
 
 The standard ? JOIN command lists every join currently in effect, and indicates any that are
 based on WHERE criteria.
@@ -1592,7 +1592,7 @@ and aliases in the host data source.
 
 1102
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 hfld2
 
@@ -1651,7 +1651,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1103
 
-Using a Conditional Join
+Using a Conditional Join
 
 Note: Single line JOIN syntax is not supported.
 
@@ -1689,7 +1689,7 @@ END
 
 1104
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 The output is:
 
@@ -1750,7 +1750,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1105
 
-Full Outer Joins
+Full Outer Joins
 
 JOIN FULL_OUTER hfld1 [AND hfld2 ...] IN table1 [TAG tag1] TO {UNIQUE|
 MULTIPLE} cfld [AND cfld2 ...] IN table2 [TAG tag2] [AS joinname]
@@ -1805,7 +1805,7 @@ field joins.
 
 1106
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 IN crfile
 
@@ -1864,7 +1864,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1107
 
-Full Outer Joins
+Full Outer Joins
 
 The WITH phrase is required unless the KEEPDEFINES parameter is set to ON and deffld
 was defined prior to issuing the JOIN command.
@@ -1919,7 +1919,7 @@ You want to ensure that a subsequent JOIN command does not overwrite it.
 
 1108
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 You want to clear it selectively later.
 
@@ -1976,7 +1976,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1109
 
-Full Outer Joins
+Full Outer Joins
 
 MULTIPLE
 
@@ -2033,7 +2033,7 @@ to 4000:
 
 1110
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 TABLE FILE WF_RETAIL_LITE
 SUM GROSS_PROFIT_US PRODUCT_CATEGORY PRODUCT_SUBCATEG
@@ -2080,7 +2080,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1111
 
-Full Outer Joins
+Full Outer Joins
 
 The trace shows that the full outer join was optimized (translated to SQL) so that SQL Server
 could process the join:
@@ -2100,7 +2100,7 @@ T1."ID_PRODUCT";
 
 1112
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 The output has a row for each ID_PRODUCT value that is in either table. Rows with
 ID_PRODUCT values from 2150 to 2167 are only in the WF_SALES table, so the columns from
@@ -2122,7 +2122,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1113
 
-Reporting Against a Multi-Fact Cluster Synonym
+Reporting Against a Multi-Fact Cluster Synonym
 
 A dimension table can be a child of multiple fact tables (called a shared dimension) or be a
 child of a single fact table (called a non-shared dimension). In most cases, the fact tables are
@@ -2151,7 +2151,7 @@ The MATCH FILE command is not supported for reporting against a multi-fact synon
 
 1114
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 Example:
 
@@ -2189,7 +2189,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1115
 
-Reporting Against a Multi-Fact Cluster Synonym
+Reporting Against a Multi-Fact Cluster Synonym
 
 Syntax:
 
@@ -2236,7 +2236,7 @@ WebFOCUS Retail data source to an Excel file named PROJECTED.
 
 1116
 
-To generate the WebFOCUS Retail data source in the Web Console, click Tutorials from the
+To generate the WebFOCUS Retail data source in the Web Console, click Tutorials from the
 Applications page.
 
 14. Joining Data Sources
@@ -2279,7 +2279,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1117
 
-Reporting Against a Multi-Fact Cluster Synonym
+Reporting Against a Multi-Fact Cluster Synonym
 
 The following image shows the data in the Excel file.
 
@@ -2298,7 +2298,7 @@ END
 
 1118
 
-The output is:
+The output is:
 
 14. Joining Data Sources
 
@@ -2306,7 +2306,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1119
 
-Reporting Against a Multi-Fact Cluster Synonym
+Reporting Against a Multi-Fact Cluster Synonym
 
 Generating Outer Joins of Cluster Synonym Contexts
 
@@ -2323,7 +2323,7 @@ and retrieve all values from both contexts.
 
 1120
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 Syntax:
 
@@ -2355,7 +2355,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1121
 
-Reporting Against a Multi-Fact Cluster Synonym
+Reporting Against a Multi-Fact Cluster Synonym
 
 Example:
 
@@ -2393,7 +2393,7 @@ ACTUAL=A11V,
 
 1122
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 The following request joins the Excel file as a root and generates a report that contains fields
 from both roots and the shared dimension. Using the default value for BLEND-MODE produces
@@ -2439,7 +2439,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1123
 
-Reporting Against a Multi-Fact Cluster Synonym
+Reporting Against a Multi-Fact Cluster Synonym
 
 For the Cost of Goods field in the row that corresponds to product category Displays, which
 is not represented in the WF_RETAIL data source.
@@ -2465,7 +2465,7 @@ synonym can be used in the join.
 
 1124
 
-Example:
+Example:
 
 Joining From a Multi-Fact Synonym
 
@@ -2499,7 +2499,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1125
 
-Reporting Against a Multi-Fact Cluster Synonym
+Reporting Against a Multi-Fact Cluster Synonym
 
 The following request joins the product segment to the dimension table wf_retail_vendor based
 on the vendor ID and issues a request against the joined structure:
@@ -2516,7 +2516,7 @@ END
 
 1126
 
-The output is:
+The output is:
 
 14. Joining Data Sources
 
@@ -2524,7 +2524,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1127
 
-Navigating Joins Between Cluster Synonyms
+Navigating Joins Between Cluster Synonyms
 
 Navigating Joins Between Cluster Synonyms
 
@@ -2572,7 +2572,7 @@ NESTED_CLUSTERS
 
 1128
 
-Example:
+Example:
 
 Navigating Joins Between Cluster Synonyms
 
@@ -2631,7 +2631,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1129
 
-Navigating Joins Between Cluster Synonyms
+Navigating Joins Between Cluster Synonyms
 
 The output is shown in the following image. The inner join was done last, reducing the number
 of stations in the host file to the same number as in the cluster.
@@ -2671,7 +2671,7 @@ SQL_SCRIPT
 
 1130
 
-14. Joining Data Sources
+14. Joining Data Sources
 
     SELECT
     SUM(T1."VB001_CNT_START_STATION_ID"),
@@ -2718,7 +2718,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1131
 
-Cross Database Join Optimization
+Cross Database Join Optimization
 
 One type of performance optimization results from extracting data from the cross-referenced
 table prior to performing the join, or issuing a sub-select. You can disable this optimization
@@ -2746,7 +2746,7 @@ You can view the generated query in either the Session Log or the trace file.
 
 1132
 
-The following SQL request joins a Microsoft SQL Server named citibike_mssql table to a
+The following SQL request joins a Microsoft SQL Server named citibike_mssql table to a
 MySQL table named station_zip_mysql.
 
 14. Joining Data Sources
@@ -2799,7 +2799,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1133
 
-Cross Database Join Optimization
+Cross Database Join Optimization
 
 Next, the citibike_mssql table is joined to the HOLD file.
 
@@ -2851,7 +2851,7 @@ temporary table created for the merge sub-select statement.
 
 1134
 
-For example, following flow creates three left outer joins between Microsoft SQL Server tables
+For example, following flow creates three left outer joins between Microsoft SQL Server tables
 and Oracle tables. The Oracle synonyms start with the characters o_.
 
 14. Joining Data Sources
@@ -2860,7 +2860,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1135
 
-Cross Database Join Optimization
+Cross Database Join Optimization
 
 The following SQL statement corresponds to the joins generated by the flow.
 
@@ -2907,7 +2907,7 @@ SELECT
 
 1136
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 FROM
    ((("ibisamp/facts".wf_retail_sales T1
@@ -2935,7 +2935,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1137
 
-Cross Database Join Optimization
+Cross Database Join Optimization
 
 The Session Log shows the joins that were generated. The left outer joins were converted to
 inner joins, as shown in the following partial listing.
@@ -2989,7 +2989,7 @@ END
 
 1138
 
-In addition, joins that use the same DBMS are passed to that DBMS, as shown in the following
+In addition, joins that use the same DBMS are passed to that DBMS, as shown in the following
 partial listing.
 
 14. Joining Data Sources
@@ -3045,7 +3045,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1139
 
-Adding DBA Restrictions to the Join Condition: SET DBAJOIN
+Adding DBA Restrictions to the Join Condition: SET DBAJOIN
 
 To activate the context analysis feature, click Change Common Adapter Settings on the
 Adapters page of the Web Console. Then select Yes for the FCA parameter in the
@@ -3068,7 +3068,7 @@ structure and the join is an outer or unique join.
 
 1140
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 When restrictions are treated as report filters, lower-level segment instances that do not
 satisfy them are omitted from the report output, along with their host segments. Since host
@@ -3130,7 +3130,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1141
 
-Adding DBA Restrictions to the Join Condition: SET DBAJOIN
+Adding DBA Restrictions to the Join Condition: SET DBAJOIN
 
 Issue the following request:
 
@@ -3165,7 +3165,7 @@ SELECT
 
 1142
 
-Rerun the request with SET DBAJOIN=ON. The output now displays all host rows, with missing
+Rerun the request with SET DBAJOIN=ON. The output now displays all host rows, with missing
 values substituted for lower-level segment instances that did not satisfy the DBA restriction, as
 shown on the following image:
 
@@ -3196,7 +3196,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1143
 
-Preserving Virtual Fields During Join Parsing
+Preserving Virtual Fields During Join Parsing
 
 Preserving Virtual Fields Using KEEPDEFINES
 
@@ -3249,7 +3249,7 @@ Clears the virtual field after a JOIN command is run. This value is the default.
 
 1144
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 Reference: Usage Notes for KEEPDEFINES
 
@@ -3305,7 +3305,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1145
 
-Preserving Virtual Fields During Join Parsing
+Preserving Virtual Fields During Join Parsing
 
 Next a new virtual field, YEARS, is defined for the join between VIDEOTRK and MOVIES:
 
@@ -3358,7 +3358,7 @@ VIDEOTRK DAYSKEPT                     I5            4
 
 1146
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 The report output shows that the original definition for DAYSKEPT is now in effect:
 
@@ -3418,7 +3418,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1147
 
-Preserving Virtual Fields During Join Parsing
+Preserving Virtual Fields During Join Parsing
 
 The following JOIN command creates a new context. Because KEEPDEFINES is set to ON,
 virtual field C is not cleared by the JOIN command:
@@ -3473,7 +3473,7 @@ Note: DEFINE FILE RETURN is only activated when a DEFINE FILE SAVE is in effect.
 
 1148
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 Screening Segments With Conditional JOIN Expressions
 
@@ -3522,7 +3522,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1149
 
-Displaying Joined Structures
+Displaying Joined Structures
 
 Example:
 
@@ -3573,7 +3573,7 @@ in an alternate file view.
 
 1150
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 The cross-referenced file segment types in the joined structure are the following:
 
@@ -3625,7 +3625,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1151
 
 
-Clearing Joined Structures
+Clearing Joined Structures
 
 Syntax:
 
@@ -3681,7 +3681,7 @@ JOIN MOVIECODE IN VIDEOTRK TO MOVIECODE IN MOVIES AS J1
 
 1152
 
-14. Joining Data Sources
+14. Joining Data Sources
 
 The next request creates a conditional join (JW3) using MOVIES as the host data source:
 
@@ -3732,6 +3732,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Clearing Joined Structures
+Clearing Joined Structures
 
 1154

--- a/specifications/creating_reports/creating_reports_15_chapter15.md
+++ b/specifications/creating_reports/creating_reports_15_chapter15.md
@@ -46,7 +46,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1155
 
-Merging Data
+Merging Data
 
 You can merge up to 16 sets of data in one Match request. For example, you can merge
 different data sources, or data from the same data source.
@@ -101,7 +101,7 @@ command with the wildcard character (*).
 
 1156
 
-Types of MATCH Processing
+Types of MATCH Processing
 
 15. Merging Data Sources
 
@@ -149,7 +149,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1157
 
-Types of MATCH Processing
+Types of MATCH Processing
 
 The way MATCH merges data depends on the order in which you name data sources in the
 request, the BY fields, display commands, the type of processing, and the merge phrases you
@@ -206,7 +206,7 @@ data sources.
 
 1158
 
-15. Merging Data Sources
+15. Merging Data Sources
 
 Alias names are assigned sequentially (E01, E02, ...) in the HOLD Master File that results
 from the MATCH request. When the same field name is used mutliple times in the MATCH,
@@ -244,7 +244,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1159
 
-Types of MATCH Processing
+Types of MATCH Processing
 
 Example: Merging Data Sources
 
@@ -292,7 +292,7 @@ EMP_ID     COURSE_CODE         CURR_SAL  LAST_NAME        FIRST_NAME
 
 1160
 
-Example:
+Example:
 
 Comparing Grouped and Ungrouped Processing
 
@@ -345,7 +345,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1161
 
-Types of MATCH Processing
+Types of MATCH Processing
 
 The partial output is shown in the following image.
 
@@ -374,7 +374,7 @@ AFTER MATCH HOLD FORMAT FOCUS OLD-OR-NEW
 
 1162
 
-15. Merging Data Sources
+15. Merging Data Sources
 
 The following hierarchical multi-segment Master File is generated.
 
@@ -416,13 +416,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1163
 
-Types of MATCH Processing
+Types of MATCH Processing
 
 The following diagram illustrates the general merge process:
 
 1164
 
-15. Merging Data Sources
+15. Merging Data Sources
 
 Syntax:
 
@@ -458,7 +458,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1165
 
-MATCH Processing With Common High-Order Sort Fields
+MATCH Processing With Common High-Order Sort Fields
 
 NEW-NOT-OLD specifies that records that appear only in the new data source appear in the
 HOLD file.
@@ -482,7 +482,7 @@ are compared.
 
 1166
 
-15. Merging Data Sources
+15. Merging Data Sources
 
 At least one pair of sort fields is required. Field formats must be the same. In some cases, you
 can redefine a field format using the DEFINE command. If the field names differ, use the AS
@@ -556,7 +556,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1167
 
-MATCH Processing With Common High-Order Sort Fields
+MATCH Processing With Common High-Order Sort Fields
 
 Record n: 112847612 SMITH 103
 
@@ -664,7 +664,7 @@ COURSE_CODE
 
 
 
-Example: Merging With a Common High-Order Sort Field
+Example: Merging With a Common High-Order Sort Field
 
 This request combines data from the EMPLOYEE and EMPDATA data sources. The sort fields
 are EID and PIN.
@@ -775,7 +775,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Fine-Tuning MATCH Processing
+Fine-Tuning MATCH Processing
 
 119329144
 
@@ -971,7 +971,7 @@ PRINT would produce.
 
 
 
-Example:
+Example:
 
 Using Display Commands in MATCH Processing
 
@@ -1036,7 +1036,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Fine-Tuning MATCH Processing
+Fine-Tuning MATCH Processing
 
 Note that the records from file A are duplicated for each record from file B.
 
@@ -1086,7 +1086,7 @@ Note the blank value for F2 and the 0 for F3.
 
 
 
-Request 5: This request sums the fields F2 and F3 from file A, sums the field F5 from file B
+Request 5: This request sums the fields F2 and F3 from file A, sums the field F5 from file B
 and sorts it by field F1, the common high-order sort field, and by F4.
 
 15. Merging Data Sources
@@ -1136,7 +1136,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1173
 
 
-Universal Concatenation
+Universal Concatenation
 
 Syntax:
 
@@ -1192,7 +1192,7 @@ Is a subrequest. Subrequests can only include WHERE and IF phrases.
 
 1174
 
-15. Merging Data Sources
+15. Merging Data Sources
 
 END|RUN
 
@@ -1239,7 +1239,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1175
 
-Universal Concatenation
+Universal Concatenation
 
 Field Name and Format Matching
 
@@ -1284,7 +1284,7 @@ Text (TX) fields and CLOB fields (if supported) cannot be concatenated.
 
 1176
 
-Example: Matching Field Names and Formats
+Example: Matching Field Names and Formats
 
 The following annotated example concatenates data from the EMPDATA and SALHIST data
 sources.
@@ -1354,7 +1354,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Merging Concatenated Data Sources
+Merging Concatenated Data Sources
 
 000-00-0070
 
@@ -1419,7 +1419,7 @@ Records from the first file with no match in the second file (OLD-NOT-NEW).
 
 1178
 
-15. Merging Data Sources
+15. Merging Data Sources
 
 Records from the second file with no match in the first file (NEW-NOT-OLD).
 
@@ -1482,7 +1482,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1179
 
-Merging Concatenated Data Sources
+Merging Concatenated Data Sources
 
 9. All merged data from the first and second answer sets, now a HOLD file, is merged with the
 data concatenated in the third answer set using the AFTER MATCH merge_phrase in the
@@ -1505,7 +1505,7 @@ record in the HOLD file, and so on for all remaining records.
 
 1180
 
-Example: Merging Concatenated Data Sources With Common High-Order Sort Fields
+Example: Merging Concatenated Data Sources With Common High-Order Sort Fields
 
 The following annotated sample stored procedure illustrates MATCH with MORE, using a
 common sort field:
@@ -1573,7 +1573,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Merging Concatenated Data Sources
+Merging Concatenated Data Sources
 
 The first page of output is:
 
@@ -1599,7 +1599,7 @@ SSN                CURRENT  FIRST        EXPENSES
 
 1182
 
-Example: Merging Concatenated Data Sources Without a Common Sort Field
+Example: Merging Concatenated Data Sources Without a Common Sort Field
 
 In this example, the merged data sources do not share a sort field:
 
@@ -1653,7 +1653,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Cartesian Product
+Cartesian Product
 
 The first page of output is:
 
@@ -1713,7 +1713,7 @@ a field in that segment is referenced.
 
 1184
 
-15. Merging Data Sources
+15. Merging Data Sources
 
 Short paths do not display in requests with Cartesian product.
 
@@ -1792,7 +1792,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1185
 
-Cartesian Product
+Cartesian Product
 
 XJ12L AUTO
 

--- a/specifications/creating_reports/creating_reports_16_chapter16.md
+++ b/specifications/creating_reports/creating_reports_16_chapter16.md
@@ -49,7 +49,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1187
 
-What Kinds of Formatting Can I Do?
+What Kinds of Formatting Can I Do?
 
 You can also select which character to use to mark decimal position, using either a period
 (.) or a comma (,), to match the convention of the country in which the report will be read.
@@ -92,7 +92,7 @@ Choosing a Display Format on page 575.
 
 1188
 
-16. Formatting Reports: An Overview
+16. Formatting Reports: An Overview
 
 Making a report accessible to all users regardless of their physical abilities, their browser
 type, or their screen settings. For example, you can design a report fonts, colors, layout,
@@ -114,7 +114,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1189
 
-How to Specify Formatting in a Report
+How to Specify Formatting in a Report
 
 Consider how the formatting applied to the version on the left:
 
@@ -163,7 +163,7 @@ about them and how to choose between them in How to Choose a Type of Style Sheet
 
 1190
 
-Example:
+Example:
 
 Specifying Formatting for the Order Revenue Report
 
@@ -182,7 +182,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1191
 
-How to Specify Formatting in a Report
+How to Specify Formatting in a Report
 
    TABLE FILE CENTORD
 1.HEADING
@@ -243,7 +243,7 @@ explanations in the topics that describe each formatting feature.
 
 1192
 
-16. Formatting Reports: An Overview
+16. Formatting Reports: An Overview
 
 The formatting logic that you apply to your own reports may be briefer or more extensive than
 this example, depending on the report and on what formatting you choose to apply.
@@ -291,7 +291,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1193
 
-Standard and Legacy Formatting
+Standard and Legacy Formatting
 
 Standard and Legacy Formatting
 
@@ -339,7 +339,7 @@ can quickly update formatting for multiple report components.
 
 1194
 
-16. Formatting Reports: An Overview
+16. Formatting Reports: An Overview
 
 For example, if you declare all the report data to be blue, all data in all columns will be
 displayed as blue. If you also declare all vertical sort (BY) columns to be orange, this will
@@ -386,7 +386,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1195
 
-Navigating From a Report to Other Resources
+Navigating From a Report to Other Resources
 
 Use a table of contents to jump directly to the data that interests that reader. The report
 generates the table of contents dynamically based on sort values, and enables the reader

--- a/specifications/creating_reports/creating_reports_17_chapter17.md
+++ b/specifications/creating_reports/creating_reports_17_chapter17.md
@@ -49,7 +49,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1197
 
-Creating a WebFOCUS StyleSheet
+Creating a WebFOCUS StyleSheet
 
 Outside of a report request, as a separate file. This enables you to apply one StyleSheet to
 multiple reports. For details, see Creating and Applying a WebFOCUS StyleSheet File on page
@@ -103,7 +103,7 @@ The following illustrates an inline StyleSheet. The StyleSheet is highlighted in
 
 1198
 
-17. Creating and Managing a WebFOCUS StyleSheet
+17. Creating and Managing a WebFOCUS StyleSheet
 
 TABLE FILE GGSALES
 SUM UNITS DOLLARS BY CATEGORY BY PRODUCT
@@ -133,7 +133,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1199
 
-Creating a WebFOCUS StyleSheet
+Creating a WebFOCUS StyleSheet
 
 where:
 
@@ -178,7 +178,7 @@ StyleSheet declarations, see General WebFOCUS StyleSheet Syntax on page 1202.
 
 1200
 
-17. Creating and Managing a WebFOCUS StyleSheet
+17. Creating and Managing a WebFOCUS StyleSheet
 
 As an alternative to creating a new StyleSheet file, you can use one of the sample StyleSheet
 files provided with WebFOCUS as a template.
@@ -230,7 +230,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1201
 
-General WebFOCUS StyleSheet Syntax
+General WebFOCUS StyleSheet Syntax
 
 General WebFOCUS StyleSheet Syntax
 
@@ -271,7 +271,7 @@ SET STYLE * and ends with ENDSTYLE.
 
 1202
 
-17. Creating and Managing a WebFOCUS StyleSheet
+17. Creating and Managing a WebFOCUS StyleSheet
 
 TABLE FILE CENTORD
 HEADING
@@ -326,7 +326,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Reusing WebFOCUS StyleSheet Declarations With Macros
+Reusing WebFOCUS StyleSheet Declarations With Macros
 
 Split a single declaration across a line. The declaration will continue to be processed until
 the terminating dollar sign. For example, you can split a declaration like this:
@@ -375,7 +375,7 @@ To define a macro, use the DEFMACRO attribute followed by the desired styling at
 
 1204
 
-17. Creating and Managing a WebFOCUS StyleSheet
+17. Creating and Managing a WebFOCUS StyleSheet
 
 Syntax:
 
@@ -436,7 +436,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1205
 
-Reusing WebFOCUS StyleSheet Declarations With Macros
+Reusing WebFOCUS StyleSheet Declarations With Macros
 
 condition
 
@@ -484,7 +484,7 @@ by TYPE=DATA, COLUMN=N1).
 
 1206
 
-17. Creating and Managing a WebFOCUS StyleSheet
+17. Creating and Managing a WebFOCUS StyleSheet
 
 The output is:
 
@@ -513,7 +513,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1207
 
-WebFOCUS StyleSheet Attribute Inheritance
+WebFOCUS StyleSheet Attribute Inheritance
 
 TYPE=TITLE, COLUMN=N2, STYLE=-BOLD, BACKCOLOR=YELLOW, $
 
@@ -566,7 +566,7 @@ declarations discussed in this example are highlighted in the report request.
 
 1208
 
-17. Creating and Managing a WebFOCUS StyleSheet
+17. Creating and Managing a WebFOCUS StyleSheet
 
 The page heading in this report has two lines. The first StyleSheet declaration identifies the
 report component HEADING to be formatted in bold and have 12-point font size. This will
@@ -598,7 +598,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1209
 
-WebFOCUS StyleSheet Attribute Inheritance
+WebFOCUS StyleSheet Attribute Inheritance
 
 Example:
 
@@ -647,7 +647,7 @@ embedded fields in the footing.
 
 1210
 
-17. Creating and Managing a WebFOCUS StyleSheet
+17. Creating and Managing a WebFOCUS StyleSheet
 
 The output is:
 
@@ -669,7 +669,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1211
 
-Creating Reports With the ENWarm StyleSheet
+Creating Reports With the ENWarm StyleSheet
 
 Report Styling
 
@@ -710,7 +710,7 @@ Bottom gap: .05
 
 1212
 
-17. Creating and Managing a WebFOCUS StyleSheet
+17. Creating and Managing a WebFOCUS StyleSheet
 
 Headings and Footings Styling
 
@@ -753,7 +753,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1213
 
-Creating Reports With the ENWarm StyleSheet
+Creating Reports With the ENWarm StyleSheet
 
 Font color: RGB (102, 102, 102)
 
@@ -773,7 +773,7 @@ Bold
 
 1214
 
-17. Creating and Managing a WebFOCUS StyleSheet
+17. Creating and Managing a WebFOCUS StyleSheet
 
 Styling for the subfooting element is shown in the following image.
 
@@ -789,7 +789,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1215
 
-Creating Reports With the ENWarm StyleSheet
+Creating Reports With the ENWarm StyleSheet
 
 Across Title
 
@@ -822,7 +822,7 @@ active reports.
 
 1216
 
-17. Creating and Managing a WebFOCUS StyleSheet
+17. Creating and Managing a WebFOCUS StyleSheet
 
 Pagination, Menu, and Hover Text Styling in WebFOCUS Active Reports
 
@@ -845,7 +845,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1217
 
-Creating Reports With the ENWarm StyleSheet
+Creating Reports With the ENWarm StyleSheet
 
 Background color: RGB (#F8F8F8)
 

--- a/specifications/creating_reports/creating_reports_18_chapter18.md
+++ b/specifications/creating_reports/creating_reports_18_chapter18.md
@@ -40,7 +40,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1219
 
-Generating an Internal Cascading Style Sheet for HTML Reports
+Generating an Internal Cascading Style Sheet for HTML Reports
 
 Generating an Internal Cascading Style Sheet for HTML Reports
 
@@ -94,7 +94,7 @@ the report appearance. ON is the default value.
 
 1220
 
-18. Controlling Report Formatting
+18. Controlling Report Formatting
 
 OFF
 
@@ -148,7 +148,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1221
 
-Conditionally Formatting, Displaying, and Linking in a StyleSheet
+Conditionally Formatting, Displaying, and Linking in a StyleSheet
 
 Within a report request, use
 
@@ -191,7 +191,7 @@ conditional styling (WHEN).
 
 1222
 
-Applying Sequential Conditional Formatting
+Applying Sequential Conditional Formatting
 
 18. Controlling Report Formatting
 
@@ -252,7 +252,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1223
 
-Conditionally Formatting, Displaying, and Linking in a StyleSheet
+Conditionally Formatting, Displaying, and Linking in a StyleSheet
 
 field1, field2
 
@@ -307,7 +307,7 @@ value on the right.
 
 1224
 
-18. Controlling Report Formatting
+18. Controlling Report Formatting
 
 value
 
@@ -368,7 +368,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Conditionally Formatting, Displaying, and Linking in a StyleSheet
+Conditionally Formatting, Displaying, and Linking in a StyleSheet
 
 3. The third conditional declaration formats any rows whose order total is greater than
 
@@ -400,7 +400,7 @@ applied to the entire row.
 
 1226
 
-18. Controlling Report Formatting
+18. Controlling Report Formatting
 
 TABLE FILE CENTORD
 HEADING
@@ -426,7 +426,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Conditionally Formatting, Displaying, and Linking in a StyleSheet
+Conditionally Formatting, Displaying, and Linking in a StyleSheet
 
 Example:
 
@@ -460,7 +460,7 @@ END
 
 
 
-The output is:
+The output is:
 
 18. Controlling Report Formatting
 
@@ -475,7 +475,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1229
 
-Conditionally Formatting, Displaying, and Linking in a StyleSheet
+Conditionally Formatting, Displaying, and Linking in a StyleSheet
 
 In this example, the ACROSS values are used in conditional styling to set a unique backcolor
 for all ACROSS columns in the Category Coffee, and additional font styling for the Espresso
@@ -510,7 +510,7 @@ The output is:
 
 1230
 
-18. Controlling Report Formatting
+18. Controlling Report Formatting
 
 Example:
 
@@ -548,7 +548,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Conditionally Formatting, Displaying, and Linking in a StyleSheet
+Conditionally Formatting, Displaying, and Linking in a StyleSheet
 
 The output is:
 
@@ -567,7 +567,7 @@ shown in the following request.
 
 1232
 
-18. Controlling Report Formatting
+18. Controlling Report Formatting
 
 TABLE FILE CENTHR
 HEADING
@@ -601,7 +601,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Conditionally Formatting, Displaying, and Linking in a StyleSheet
+Conditionally Formatting, Displaying, and Linking in a StyleSheet
 
 The output is:
 
@@ -617,7 +617,7 @@ accomplish this by evaluating the sort field (STATUS) in the WHEN attribute cond
 
 1234
 
-18. Controlling Report Formatting
+18. Controlling Report Formatting
 
 TABLE FILE CENTHR
 HEADING
@@ -647,7 +647,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Conditionally Formatting, Displaying, and Linking in a StyleSheet
+Conditionally Formatting, Displaying, and Linking in a StyleSheet
 
 In order to apply the same conditional formatting to only two columns, instead of all the
 columns, this version of the report request uses two declarations, each specifying a different
@@ -679,7 +679,7 @@ END
 
 
 
-The output is:
+The output is:
 
 18. Controlling Report Formatting
 
@@ -694,7 +694,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1237
 
-Conditionally Formatting, Displaying, and Linking in a StyleSheet
+Conditionally Formatting, Displaying, and Linking in a StyleSheet
 
 DEFINE FILE GGSALES
 SDATE/YYM = DATE;
@@ -720,7 +720,7 @@ The output is:
 1238
 
 
-Including Summary Lines, Underlines, Skipped Lines, and Page Breaks
+Including Summary Lines, Underlines, Skipped Lines, and Page Breaks
 
 18. Controlling Report Formatting
 
@@ -770,7 +770,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1239
 
-Including Summary Lines, Underlines, Skipped Lines, and Page Breaks
+Including Summary Lines, Underlines, Skipped Lines, and Page Breaks
 
 option
 
@@ -831,7 +831,7 @@ generated:
 
 1240
 
-Now change the value of the ONFIELD parameter to IGNORE and run the request again,
+Now change the value of the ONFIELD parameter to IGNORE and run the request again,
 supplying the value DEPT for the variable &F1. The partial output is:
 
 18. Controlling Report Formatting
@@ -882,7 +882,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Conditionally Including Summary Lines, Underlines, Skipped Lines, and Page Breaks
+Conditionally Including Summary Lines, Underlines, Skipped Lines, and Page Breaks
 
 Syntax:
 
@@ -941,7 +941,7 @@ performed for each value of the sort field.
 
 1242
 
-18. Controlling Report Formatting
+18. Controlling Report Formatting
 
 If the BY or ON phrase includes several options, the WHEN condition applies only to the
 option that immediately precedes it.
@@ -987,7 +987,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Conditionally Including Summary Lines, Underlines, Skipped Lines, and Page Breaks
+Conditionally Including Summary Lines, Underlines, Skipped Lines, and Page Breaks
 
 The output is:
 
@@ -1027,7 +1027,7 @@ END
 1244
 
 
-The output is:
+The output is:
 
 18. Controlling Report Formatting
 
@@ -1035,7 +1035,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1245
 
-Controlling the Display of Empty Reports
+Controlling the Display of Empty Reports
 
 Controlling the Display of Empty Reports
 
@@ -1087,7 +1087,7 @@ EMPTYREPORT.
 
 1246
 
-18. Controlling Report Formatting
+18. Controlling Report Formatting
 
 ON
 
@@ -1130,7 +1130,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1247
 
-Formatting a Report Using Only StyleSheet Defaults
+Formatting a Report Using Only StyleSheet Defaults
 
 Changing the EMPTYREPORT setting to ANSI produces the output shown in the following
 image.

--- a/specifications/creating_reports/creating_reports_19_chapter19.md
+++ b/specifications/creating_reports/creating_reports_19_chapter19.md
@@ -48,7 +48,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1249
 
-Identifying an Entire Report, Column, or Row
+Identifying an Entire Report, Column, or Row
 
 The following illustrates where the REPORT component and the COLUMN and ACROSSCOLUMN
 attributes appear in a report, and which TYPE values you use to identify them. Although in this
@@ -80,7 +80,7 @@ TYPE=REPORT
 
 1250
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 Example:
 
@@ -110,7 +110,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1251
 
-Identifying an Entire Report, Column, or Row
+Identifying an Entire Report, Column, or Row
 
 Syntax:
 
@@ -168,7 +168,7 @@ To select all display fields use C*.
 
 1252
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 Identifier
 
@@ -232,7 +232,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1253
 
-Identifying an Entire Report, Column, or Row
+Identifying an Entire Report, Column, or Row
 
 The output is:
 
@@ -267,7 +267,7 @@ END
 
 1254
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 The output is:
 
@@ -310,7 +310,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1255
 
-Identifying an Entire Report, Column, or Row
+Identifying an Entire Report, Column, or Row
 
 The output is:
 
@@ -348,7 +348,7 @@ report commands. Use the field name to identify the sort column.
 
 1256
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 Example:
 
@@ -373,7 +373,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1257
 
-Identifying Tags for SUBTOTAL and GRANDTOTAL Lines
+Identifying Tags for SUBTOTAL and GRANDTOTAL Lines
 
 Example:
 
@@ -405,7 +405,7 @@ SUBTOTAL syntax.
 
 1258
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 You can define styling for the subtotal and grand total tag separately from the rest of the row.
 Text attributes available for the tag, including font, color, size, and style, can be used to
@@ -462,7 +462,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1259
 
-Identifying Tags for SUBTOTAL and GRANDTOTAL Lines
+Identifying Tags for SUBTOTAL and GRANDTOTAL Lines
 
 drilltype
 
@@ -503,7 +503,7 @@ END
 
 1260
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 The output is:
 
@@ -526,7 +526,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1261
 
-Identifying Data
+Identifying Data
 
 The following illustrates where the DATA and ACROSSVALUE components appear in a report,
 and which TYPE values you use to identify them.
@@ -558,7 +558,7 @@ TYPE = DATA
 
 1262
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 Example:
 
@@ -588,7 +588,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1263
 
-Identifying Data
+Identifying Data
 
 Syntax:
 
@@ -630,7 +630,7 @@ The output is:
 
 1264
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 Syntax:
 
@@ -681,7 +681,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1265
 
-Identifying Data
+Identifying Data
 
 The output is:
 
@@ -712,7 +712,7 @@ END
 
 1266
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 The following image shows the output with the ACROSS-TOTAL value, Plant Totals, styled in red
 italics.
@@ -739,7 +739,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1267
 
-Identifying Data
+Identifying Data
 
 The following figure shows each component:
 
@@ -771,7 +771,7 @@ example.
 
 1268
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 BY
 
@@ -813,7 +813,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1269
 
-Identifying Data
+Identifying Data
 
 Example:
 
@@ -847,7 +847,7 @@ The output is:
 
 1270
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 Example:
 
@@ -895,7 +895,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1271
 
-Identifying Data
+Identifying Data
 
 The output is:
 
@@ -925,7 +925,7 @@ END
 
 1272
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 The output is:
 
@@ -955,7 +955,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1273
 
-Identifying a Heading, Footing, Title, or FML Free Text
+Identifying a Heading, Footing, Title, or FML Free Text
 
 TABLE FILE EMPLOYEE
 SUM GROSS AND DED_AMT
@@ -997,7 +997,7 @@ Specifies a horizontal sort (ACROSS) title.
 
 1274
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 ACROSSVALUE
 
@@ -1054,7 +1054,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1275
 
-Identifying a Heading, Footing, Title, or FML Free Text
+Identifying a Heading, Footing, Title, or FML Free Text
 
 The following image shows the report output.
 
@@ -1077,7 +1077,7 @@ Is an explicit row label.
 
 1276
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 Example:
 
@@ -1116,7 +1116,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1277
 
-Identifying a Heading, Footing, Title, or FML Free Text
+Identifying a Heading, Footing, Title, or FML Free Text
 
 A TABLE request can have more than one page heading or footing. For each heading or footing,
 a WHEN clause against the data being retrieved can determine whether the heading or footing
@@ -1151,7 +1151,7 @@ The following output goes with the previous code example:
 
 1278
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 Note: Since this request simply illustrates how to identify different types of headings and
 footings, it omits a StyleSheet.
@@ -1205,7 +1205,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1279
 
-Identifying a Heading, Footing, Title, or FML Free Text
+Identifying a Heading, Footing, Title, or FML Free Text
 
 Example:
 
@@ -1235,7 +1235,7 @@ The output is:
 
 1280
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 Syntax:
 
@@ -1285,7 +1285,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1281
 
-Identifying a Heading, Footing, Title, or FML Free Text
+Identifying a Heading, Footing, Title, or FML Free Text
 
 The output is:
 
@@ -1316,7 +1316,7 @@ strings and embedded fields in the same heading or footing.
 
 1282
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 item_#
 
@@ -1343,7 +1343,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1283
 
-Identifying a Heading, Footing, Title, or FML Free Text
+Identifying a Heading, Footing, Title, or FML Free Text
 
 Example:
 
@@ -1385,7 +1385,7 @@ page 1277.
 
 1284
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 line_#
 
@@ -1429,7 +1429,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1285
 
-Identifying a Heading, Footing, Title, or FML Free Text
+Identifying a Heading, Footing, Title, or FML Free Text
 
 The output is:
 
@@ -1458,7 +1458,7 @@ StyleSheet declarations include styling elements for the second and third condit
 
 1286
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 DEFINE FILE EMPLOYEE
 GENDER/A1 = DECODE FIRST_NAME(ALFRED 'M' RICHARD 'M' JOHN 'M'
@@ -1508,7 +1508,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1287
 
-Identifying a Page Number, Underline, or Skipped Line
+Identifying a Page Number, Underline, or Skipped Line
 
 The second page of output is for an employee in the MIS department, so the signature line is
 in boldface:
@@ -1537,7 +1537,7 @@ END
 
 1288
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 The following output goes with the previous code example.
 
@@ -1569,7 +1569,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1289
 
-Identifying a Page Number, Underline, or Skipped Line
+Identifying a Page Number, Underline, or Skipped Line
 
 Example:
 
@@ -1601,7 +1601,7 @@ The output is:
 
 1290
 
-19. Identifying a Report Component in a WebFOCUS StyleSheet
+19. Identifying a Report Component in a WebFOCUS StyleSheet
 
 Example:
 
@@ -1631,6 +1631,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1291
 
-Identifying a Page Number, Underline, or Skipped Line
+Identifying a Page Number, Underline, or Skipped Line
 
 1292

--- a/specifications/creating_reports/creating_reports_20_chapter20.md
+++ b/specifications/creating_reports/creating_reports_20_chapter20.md
@@ -46,7 +46,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1293
 
-What Is a Cascading Style Sheet?
+What Is a Cascading Style Sheet?
 
 An external cascading style sheet, which is stored in a separate file that can be shared by
 multiple documents. The external CSS file can reside on any web server accessible to the
@@ -96,7 +96,7 @@ declaration has a property (background) and a value assigned to the property (ye
 
 1294
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 A declaration defines formatting, and a selector determines to what the formatting will be
 applied. A selector can be any HTML element. A selector can also be a class. You can define a
@@ -147,7 +147,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1295
 
-Formatting a Report With an External Cascading Style Sheet
+Formatting a Report With an External Cascading Style Sheet
 
 Easier standards conformance. You can ensure that reports conform to your enterprise's
 formatting guidelines, because now formatting instructions for all your Web documents can
@@ -179,7 +179,7 @@ an External Cascading Style Sheet on page 1298.
 
 1296
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 For an example that demonstrates how these items work together, see Linking to the
 ReportStyles External Cascading Style Sheet on page 1299 and the following diagram:
@@ -188,7 +188,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1297
 
-Formatting a Report With an External Cascading Style Sheet
+Formatting a Report With an External Cascading Style Sheet
 
 Procedure: How to Format a Report Using an External Cascading Style Sheet
 
@@ -241,7 +241,7 @@ CSSURL.
 
 1298
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 For an example, see Linking to the ReportStyles External Cascading Style Sheet on page
 1299. For more information, see Linking to an External Cascading Style Sheet on page
@@ -291,7 +291,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1299
 
-Formatting a Report With an External Cascading Style Sheet
+Formatting a Report With an External Cascading Style Sheet
 
 You could accomplish the same thing using a SET command:
 
@@ -351,7 +351,7 @@ curprods.fex
 1300
 
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 Note: To specify a path that points to a WebFOCUS repository that contains the report01.css
 file, use the following syntax for the CSSURL parameter on the TYPE=REPORT line in the
@@ -413,7 +413,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1301
 
-Working With an External Cascading Style Sheet
+Working With an External Cascading Style Sheet
 
 11.The CSS rule for the generic class headText specifies the font family Times New Roman
 and, if Times New Roman is unavailable, the generic font family serif. It also specifies a
@@ -443,7 +443,7 @@ Sheet on page 1304.
 
 1302
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 Using CSS rules and classes to specify report formatting. For more information, see
 Choosing a Cascading Style Sheet Rule on page 1304.
@@ -493,7 +493,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1303
 
-Working With an External Cascading Style Sheet
+Working With an External Cascading Style Sheet
 
 Editing an External Cascading Style Sheet
 
@@ -538,7 +538,7 @@ graph appears, and its heading and footing, but not the graph itself.
 
 1304
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 TD will specify default formatting only for the report, and for any other table cells that you
 may have on the page. TD is the table data (that is, table cell) element. WebFOCUS
@@ -584,7 +584,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1305
 
-Applying External Cascading Style Sheet Formatting
+Applying External Cascading Style Sheet Formatting
 
 Applying External Cascading Style Sheet Formatting
 
@@ -625,7 +625,7 @@ CSS With Other Formatting Methods on page 1308.
 
 1306
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 Syntax:
 
@@ -682,7 +682,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1307
 
-Combining an External CSS With Other Formatting Methods
+Combining an External CSS With Other Formatting Methods
 
 link
 
@@ -728,7 +728,7 @@ Both of these will attempt to align the report page heading.
 
 1308
 
-Combining an External CSS With a WebFOCUS StyleSheet
+Combining an External CSS With a WebFOCUS StyleSheet
 
 20. Using an External Cascading Style Sheet
 
@@ -771,7 +771,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1309
 
-Linking to an External Cascading Style Sheet
+Linking to an External Cascading Style Sheet
 
 You can specify classes and WebFOCUS StyleSheet attributes that format different properties
 of the same report component, and that format different report components. For example, the
@@ -824,7 +824,7 @@ compared with 69 characters in the parameter.
 
 1310
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 All formatting information in one place, since you can specify the link to the external
 CSS and the references to CSS classes within the WebFOCUS StyleSheet. This makes it
@@ -880,7 +880,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1311
 
-Linking to an External Cascading Style Sheet
+Linking to an External Cascading Style Sheet
 
 Example:
 
@@ -911,7 +911,7 @@ The request produces this report:
 1312
 
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 Note: To specify a path that points to a WebFOCUS repository that contains the report01.css
 file, use the following syntax for the CSSURL parameter on the TYPE=REPORT line in the
@@ -967,7 +967,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1313
 
-Inheritance and External Cascading Style Sheets
+Inheritance and External Cascading Style Sheets
 
 Inheritance and External Cascading Style Sheets
 
@@ -1021,7 +1021,7 @@ prodvend.fex
 
 1314
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
     END
 
@@ -1064,7 +1064,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1315
 
-Using External Cascading Style Sheets With Non-HTML Reports
+Using External Cascading Style Sheets With Non-HTML Reports
 
 The procedure displays this report:
 
@@ -1095,7 +1095,7 @@ to Excel 2000, so you would place it with the macro definitions for HTML.)
 
 1316
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 Branch between the HTML and non-HTML declarations using Dialogue Manager.
 
@@ -1106,7 +1106,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1317
 
-Using External Cascading Style Sheets With Non-HTML Reports
+Using External Cascading Style Sheets With Non-HTML Reports
 
 Syntax:
 
@@ -1167,7 +1167,7 @@ sets the display type for the report. Alternatively, you could use ON TABLE HOLD
 
 1318
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 the report as a file and set its file type.
 
@@ -1218,7 +1218,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1319
 
-Using External Cascading Style Sheets With Non-HTML Reports
+Using External Cascading Style Sheets With Non-HTML Reports
 
 Example:
 
@@ -1282,7 +1282,7 @@ using external cascading style sheet classes.
 
 1320
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 6. Branch to the WebFOCUS StyleSheet declarations that apply the macros to the components
 
@@ -1329,7 +1329,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1321
 
-Requirements for Using an External Cascading Style Sheet
+Requirements for Using an External Cascading Style Sheet
 
 Exceptions. Even when specifying external CSS classes, you should use native WebFOCUS
 StyleSheet attributes to:
@@ -1376,7 +1376,7 @@ the cascading style sheet of each document.
 
 1322
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 For instructions about checking or changing a browser setting, see the browser Help. For
 information about how conflicts between CSS rules are resolved (for example, between a
@@ -1422,7 +1422,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1323
 
-FAQ About Using External Cascading Style Sheets
+FAQ About Using External Cascading Style Sheets
 
 Do I always need to use the CLASS attribute?
 
@@ -1455,7 +1455,7 @@ where mycss.css contains:
 
 1324
 
-The output is:
+The output is:
 
 20. Using an External Cascading Style Sheet
 
@@ -1476,7 +1476,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1325
 
-FAQ About Using External Cascading Style Sheets
+FAQ About Using External Cascading Style Sheets
 
 Which version of CSS does WebFOCUS support?
 
@@ -1508,7 +1508,7 @@ other than HTML, making CSS a rarely-used option for formatting free form.
 
 1326
 
-Troubleshooting External Cascading Style Sheets
+Troubleshooting External Cascading Style Sheets
 
 20. Using an External Cascading Style Sheet
 
@@ -1560,7 +1560,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1327
 
-Troubleshooting External Cascading Style Sheets
+Troubleshooting External Cascading Style Sheets
 
 Solution 4: Remove the unsupported property, or upgrade your browser to a version that
 supports the property.
@@ -1609,7 +1609,7 @@ supports the property.
 
 1328
 
-20. Using an External Cascading Style Sheet
+20. Using an External Cascading Style Sheet
 
 Reason 4: Each report component can be assigned only one cascading style sheet class. If
 you have specified more than one class, only the first one specified is assigned to the
@@ -1660,6 +1660,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1329
 
-Troubleshooting External Cascading Style Sheets
+Troubleshooting External Cascading Style Sheets
 
 1330

--- a/specifications/creating_reports/creating_reports_21_chapter21.md
+++ b/specifications/creating_reports/creating_reports_21_chapter21.md
@@ -62,7 +62,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1331
 
-Selecting Page Size, Orientation, and Color
+Selecting Page Size, Orientation, and Color
 
 Reference: Page Size, Orientation, and Color Attributes
 
@@ -125,7 +125,7 @@ This syntax applies to a PDF, PS, PPT, or PPTX report.
 
 1332
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 [TYPE=REPORT,] PAGESIZE={size|LETTER}, $
 
@@ -191,7 +191,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1333
 
-Selecting Page Size, Orientation, and Color
+Selecting Page Size, Orientation, and Color
 
 Value
 
@@ -275,7 +275,7 @@ ENVELOPE-MONARCH
 
 1334
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Value
 
@@ -355,7 +355,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1335
 
-Selecting Page Size, Orientation, and Color
+Selecting Page Size, Orientation, and Color
 
 PORTRAIT
 
@@ -409,7 +409,7 @@ Is a supported color. For a list of values, see Formatting Report Data on page 1
 
 1336
 
-Example:
+Example:
 
 Setting Page Color
 
@@ -447,7 +447,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1337
 
-Setting Page Margins
+Setting Page Margins
 
 Attribute
 
@@ -521,7 +521,7 @@ scale for typefaces.
 
 1338
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Syntax:
 
@@ -566,7 +566,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1339
 
-Positioning a Report Component
+Positioning a Report Component
 
 Example:
 
@@ -600,7 +600,7 @@ on the column positioning command IN, see Positioning a Column on page 1367.
 
 1340
 
-For details on positioning a heading or footing, or an element in a heading or footing, see Using
+For details on positioning a heading or footing, or an element in a heading or footing, see Using
 Headings, Footings, Titles, and Labels on page 1517.
 
 Reference: Positioning Attributes
@@ -674,7 +674,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1341
 
-Positioning a Report Component
+Positioning a Report Component
 
 -
 
@@ -710,7 +710,7 @@ The output is:
 
 1342
 
-Example:
+Example:
 
 Specifying a Relative Starting Position for a Column
 
@@ -747,7 +747,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1343
 
-Positioning a Report Component
+Positioning a Report Component
 
 TYPE=type, [COLUMN=identifier,|ACROSSCOLUMN=acrosscolumn,]
  {LEFTGAP|RIGHTGAP}=gap, $
@@ -803,7 +803,7 @@ Indicates how much space to add to the right of a report column.
 
 1344
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Note: For TOPGAP, BOTTOMGAP, LEFTGAP, and RIGHT GAP, you must specify a value of at
 least 0.013889 (the decimal size of a point in inches). If you specify a value less than this,
@@ -834,7 +834,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1345
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 Example:
 
@@ -879,7 +879,7 @@ Specify the absolute or relative starting position for a column.
 
 1346
 
-Reference: Column Arrangement Features
+Reference: Column Arrangement Features
 
 21. Laying Out the Report Page
 
@@ -962,7 +962,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1347
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 When SQUEEZE is set to ON (the default), StyleSheet column width is ignored. Column width is
 determined using your browser's default settings.
@@ -1018,7 +1018,7 @@ TYPE=DATA, COLUMN=n, not TYPE=REPORT, COLUMN=n.
 
 1348
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 SQUEEZE is not supported for columns created with the OVER phrase.
 
@@ -1061,7 +1061,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1349
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 Blank spaces pad the column width up to the length of the field format for Category (A11) and
 Product (A16). The HTML report is:
@@ -1095,7 +1095,7 @@ greater.
 
 1350
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 OFF
 
@@ -1128,7 +1128,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1351
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 Example:
 
@@ -1165,7 +1165,7 @@ FIXED.
 
 1352
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Syntax:
 
@@ -1218,7 +1218,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1353
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 Syntax:
 
@@ -1269,7 +1269,7 @@ END
 
 1354
 
-LINEPRICE (Sales) is now the first column, PRODCAT (Product) is the second column (as it was
+LINEPRICE (Sales) is now the first column, PRODCAT (Product) is the second column (as it was
 by default), and SNAME (Store Name) is the third column. The PDF report is:
 
 21. Laying Out the Report Page
@@ -1304,7 +1304,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1355
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 The difference between FOLD-LINE and OVER is that FOLD-LINE begins the second line (not the
 second column) just underneath the first line, but slightly indented. OVER literally stacks the
@@ -1354,7 +1354,7 @@ END
 
 1356
 
-The report is:
+The report is:
 
 21. Laying Out the Report Page
 
@@ -1397,7 +1397,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1357
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 With the use of OVER, the columns GROSS, DED_AMT, and NET are stacked for readability:
 
@@ -1410,7 +1410,7 @@ size of the gaps between columns with the LEFTGAP and RIGHTGAP StyleSheet attrib
 
 1358
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 By default, the gaps between columns are placed outside of the boundaries reserved for the
 fields on the report output. Therefore, the width or squeeze value defined for a field defines
@@ -1433,7 +1433,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1359
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 With OVER and blank AS names, each data value becomes a data cell that can be used to
 construct rows and columns within the data lines of the report. In order to align data values on
@@ -1470,7 +1470,7 @@ Places the left and right gaps internal to the defined field width.
 
 1360
 
-Example:
+Example:
 
 Comparing External Gaps With Internal Gaps
 
@@ -1483,14 +1483,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1361
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 With GAPINTERNAL=ON, the defined WIDTH represents the entire space used by the given data
 cell or column. This takes the cumulative effect out as the OVER values proceed across a row.
 
 1362
 
-Example:
+Example:
 
 Using GAPINTERNAL in a Report
 
@@ -1527,7 +1527,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1363
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 The widths specified for UNITS and DOLLARS are one inch each, while the PRODUCT field is
 specified to be two inches. With GAPINTERNAL=OFF, the LAYOUTGRID shows that the widths
@@ -1536,7 +1536,7 @@ space presented by the external leftgap and rightgap accounts for this effect:
 
 1364
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 The heading borders are aligned on the right of the report because of the SQUEEZE=ON
 attribute in the StyleSheet. Extra space was added to the report to align the headings. If you
@@ -1547,14 +1547,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1365
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 Changing the StyleSheet declaration to GAPINTERNAL=ON causes the specified widths to be
 used because the gaps are internal and are included in the specified values:
 
 1366
 
-The following report output demonstrates that the values align properly even if the PRODUCT
+The following report output demonstrates that the values align properly even if the PRODUCT
 values are defined with JUSTIFY=RIGHT:
 
 21. Laying Out the Report Page
@@ -1570,7 +1570,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1367
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 Syntax:
 
@@ -1616,7 +1616,7 @@ END
 
 1368
 
-The columns are spaced for readability:
+The columns are spaced for readability:
 
 21. Laying Out the Report Page
 
@@ -1641,7 +1641,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1369
 
-Arranging Columns on a Page
+Arranging Columns on a Page
 
 The ACROSS set starts in column 35, and there are eight extra spaces between the data
 columns in the ACROSS:
@@ -1662,7 +1662,7 @@ END
 
 1370
 
-In the report, GROSS and DED_AMT are stacked, starting in column 40. LAST_NAME starts in
+In the report, GROSS and DED_AMT are stacked, starting in column 40. LAST_NAME starts in
 column 20.
 
 21. Laying Out the Report Page
@@ -1678,7 +1678,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1371
 
-Suppressing Column Display
+Suppressing Column Display
 
 Reference: Column Suppression Commands
 
@@ -1738,7 +1738,7 @@ field occurrence is suppressed.
 
 1372
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 TABLE FILE SALES
 HEADING
@@ -1758,13 +1758,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1373
 
-Suppressing Column Display
+Suppressing Column Display
 
 Without NOPRINT, the report would unnecessarily repeat the city:
 
 1374
 
-Example:
+Example:
 
 Suppressing Display of a Sort Field With Subtotal
 
@@ -1789,13 +1789,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1375
 
-Suppressing Column Display
+Suppressing Column Display
 
 Without SUP-PRINT, the report would unnecessarily repeat the category:
 
 1376
 
-Example:
+Example:
 
 Sorting Alphabetically
 
@@ -1829,7 +1829,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1377
 
-Inserting a Page Break
+Inserting a Page Break
 
 In an HTML report, PAGE-BREAK creates a new section of the report, with column titles and an
 incremented page number, on the same webpage. It does not, by itself, create a new
@@ -1893,7 +1893,7 @@ HTML tables are aligned consistently across pages.
 
 1378
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Syntax:
 
@@ -1942,7 +1942,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1379
 
-Inserting a Page Break
+Inserting a Page Break
 
 The first two pages of the report are displayed to illustrate where the page breaks occur:
 
@@ -1950,7 +1950,7 @@ The second page is:
 
 1380
 
-Example:
+Example:
 
 Displaying a Multiple-Table HTML Report
 
@@ -1976,13 +1976,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1381
 
-Inserting a Page Break
+Inserting a Page Break
 
 Two pages of the report follow, showing consistent alignment:
 
 1382
 
-The same two pages illustrate inconsistent alignment with SQUEEZE set to ON:
+The same two pages illustrate inconsistent alignment with SQUEEZE set to ON:
 
 21. Laying Out the Report Page
 
@@ -2000,7 +2000,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1383
 
-Inserting a Page Break
+Inserting a Page Break
 
 If you use NOSPLIT with PAGE-BREAK, the PAGE-BREAK must apply to a higher-level sort field.
 Otherwise, NOSPLIT is ignored. NOSPLIT is also ignored when report output is stored in a
@@ -2040,7 +2040,7 @@ END
 
 1384
 
-When the value of LAST_NAME changes from STEVENS to CROSS, the lines related to CROSS
+When the value of LAST_NAME changes from STEVENS to CROSS, the lines related to CROSS
 do not fit on the current page. With NOSPLIT, they appear on the next page:
 
 21. Laying Out the Report Page
@@ -2049,11 +2049,11 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1385
 
-Inserting a Page Break
+Inserting a Page Break
 
 1386
 
-Without NOSPLIT, the information for CROSS falls on the first and second pages:
+Without NOSPLIT, the information for CROSS falls on the first and second pages:
 
 21. Laying Out the Report Page
 
@@ -2061,7 +2061,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1387
 
-Inserting Page Numbers
+Inserting Page Numbers
 
 Inserting Page Numbers
 
@@ -2086,7 +2086,7 @@ conditional styling (WHEN).
 
 1388
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 If you enable Section 508 accessibility, a default page number is not included in the HTML
 table.
@@ -2168,7 +2168,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1389
 
-Inserting Page Numbers
+Inserting Page Numbers
 
 Command
 
@@ -2221,7 +2221,7 @@ to do so.
 
 1390
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Syntax:
 
@@ -2278,7 +2278,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1391
 
-Inserting Page Numbers
+Inserting Page Numbers
 
 The first two pages of output are:
 
@@ -2303,7 +2303,7 @@ The heading or footing can use the following syntax to display “Page x of y”
 
 1392
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 {HEADING|FOOTING}
 "Page <TABPAGENO of <BYLASTPAGE"
@@ -2357,14 +2357,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1393
 
-Inserting Page Numbers
+Inserting Page Numbers
 
 The following partial output shows that the page number resets to 1 when the product changes
 and that the BYLASTPAGE variable displays the total number of pages for each product:
 
 1394
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Assigning Any Page Number to the First Page
 
@@ -2426,7 +2426,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1395
 
-Inserting Page Numbers
+Inserting Page Numbers
 
 The report is:
 
@@ -2464,7 +2464,7 @@ END
 
 1396
 
-The first page of the second report is numbered 4, which is one more than the last page of the
+The first page of the second report is numbered 4, which is one more than the last page of the
 previous report:
 
 21. Laying Out the Report Page
@@ -2506,7 +2506,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1397
 
-Inserting Page Numbers
+Inserting Page Numbers
 
 You can use the system variable TABPAGENO.
 
@@ -2544,7 +2544,7 @@ END
 
 1398
 
-TABPAGENO inserts the page number in the sort footing. The first page of the report is:
+TABPAGENO inserts the page number in the sort footing. The first page of the report is:
 
 21. Laying Out the Report Page
 
@@ -2583,7 +2583,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1399
 
-Inserting Page Numbers
+Inserting Page Numbers
 
 In an HTML report request, using either the LINES-PER-PAGE StyleSheet option or the SET
 LINES command, you will see the number of lines, as opposed to the number of data rows.
@@ -2610,7 +2610,7 @@ END
 
 1400
 
-The following image shows the output for the first page.
+The following image shows the output for the first page.
 
 21. Laying Out the Report Page
 
@@ -2618,7 +2618,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1401
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 The following image shows the output for the second page.
 
@@ -2633,7 +2633,7 @@ grid lines around them.
 
 1402
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Borders: In a PDF, HTML, DHTML, XLSX, EXL2K, PPTX, PPT, or PS report, you can use BORDER
 attributes in a StyleSheet to specify the weight, style, and color of border lines. If you wish, you
@@ -2690,7 +2690,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1403
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 Attribute
 
@@ -2757,7 +2757,7 @@ FILL applies grid lines to all cells of a report. Column titles are not underlin
 
 1404
 
-Syntax:
+Syntax:
 
 How to Add and Format Borders
 
@@ -2817,7 +2817,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1405
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 line_style
 
@@ -2886,7 +2886,7 @@ components in equal intensities results in shades of gray.
 
 1406
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Note: Format EXL2K does not support the GRID=ON parameter.
 
@@ -2922,7 +2922,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1407
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 Example:
 
@@ -2957,7 +2957,7 @@ END
 
 1408
 
-All cells have grid lines:
+All cells have grid lines:
 
 21. Laying Out the Report Page
 
@@ -2980,7 +2980,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1409
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 Column titles are underlined:
 
@@ -3013,7 +3013,7 @@ END
 
 1410
 
-The output is shown in the following image. A blank row has been added after the heading.
+The output is shown in the following image. A blank row has been added after the heading.
 
 21. Laying Out the Report Page
 
@@ -3021,7 +3021,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1411
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 The following version of the request has no border attributes.
 
@@ -3037,7 +3037,7 @@ END
 
 1412
 
-The output is shown in the following image. There is no blank row between the report heading
+The output is shown in the following image. There is no blank row between the report heading
 and report body.
 
 21. Laying Out the Report Page
@@ -3046,7 +3046,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1413
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 Syntax:
 
@@ -3104,7 +3104,7 @@ attributes.
 
 1414
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 OFF turns borders off. OFF is the default value.
 
@@ -3162,7 +3162,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1415
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 MEDIUM identifies a medium line. ON sets the line to MEDIUM.
 
@@ -3228,7 +3228,7 @@ internal borders with HEADALIGN=BODY.
 
 1416
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 color
 
@@ -3291,7 +3291,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1417
 
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 The REPORT component has BORDER=ON, so the page heading has an external border.
 
@@ -3319,7 +3319,7 @@ page footing, not to the size of the data columns in the body of the report.
 
 1418
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 You can use the ALIGN-BORDERS=BODY attribute in a StyleSheet to align the subheadings and
 subfootings with the report body on PDF report output instead of the other heading elements.
@@ -3356,13 +3356,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1419
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 The following image illustrates report output without the ALIGN-BORDERS=BODY attribute.
 
 1420
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 When the body lines are wider than the subheading and subfooting lines, the border and
 backcolor of the subheading and subfooting lines are expanded to match the width of the data
@@ -3372,7 +3372,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1421
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 If the subheading and subfooting lines are longer than the body lines, an additional filler cell is
 added to each data line to allow the defined borders and backcolor to fill the width defined by
@@ -3380,7 +3380,7 @@ the subheading and subfooting lines, as shown on the following report output.
 
 1422
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 ALIGN-BORDERS=BODY has been designed to work on:
 
@@ -3404,7 +3404,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1423
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 Example:
 
@@ -3449,7 +3449,7 @@ ON TABLE SUBFOOT
 1424
 
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 WHERE CATEGORY EQ 'Coffee';
 ON TABLE SET PAGE-NUM OFF
@@ -3507,7 +3507,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1425
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 $
 TYPE=SUBHEAD,
@@ -3543,7 +3543,7 @@ END
 
 1426
 
-The output shows that the subheading margins align with the heading, not with the report
+The output shows that the subheading margins align with the heading, not with the report
 body.
 
 21. Laying Out the Report Page
@@ -3552,14 +3552,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1427
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 Now change the ALIGN-BORDERS attribute to ALIGN-BORDERS=BODY and rerun the request.
 The subheadings now align with the report body, as shown in the following image.
 
 1428
 
-Example:
+Example:
 
 Aligning Subheading and Subfooting Margins in a Multi-Panel Report
 
@@ -3606,7 +3606,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1429
 
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 WHERE CATEGORY NE 'Coffee';
 ON TABLE SET PAGE-NUM OFF
@@ -3654,7 +3654,7 @@ TYPE=HEADING,
 
 1430
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 $
 TYPE=FOOTING,
@@ -3704,7 +3704,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1431
 
-Adding Grids and Borders
+Adding Grids and Borders
 
 The output shows that the subheadings are aligned with the data on each panel.
 
@@ -3741,7 +3741,7 @@ Suppresses grid lines. OFF is the default value.
 
 1432
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 HEAVY
 
@@ -3784,7 +3784,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1433
 
-Defining Borders Around Boxes With PPTX and PDF Formats
+Defining Borders Around Boxes With PPTX and PDF Formats
 
 TABLE FILE GGSALES
 BY REGION NOPRINT
@@ -3822,7 +3822,7 @@ in PPTX and PDF formats.
 
 1434
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 TABLE FILE GGSALES
 BY REGION NOPRINT
@@ -3869,7 +3869,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1435
 
-Displaying Superscripts On Data, Heading, and Footing Lines
+Displaying Superscripts On Data, Heading, and Footing Lines
 
 DEFINE FILE ...
 field/An = <sup>text</sup>;
@@ -3923,7 +3923,7 @@ MARKUP=ON.
 
 1436
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 DEFINE FILE GGSALES
 SUP1/A12= '<SUP>1</SUP>';
@@ -3969,13 +3969,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1437
 
-Displaying Superscripts On Data, Heading, and Footing Lines
+Displaying Superscripts On Data, Heading, and Footing Lines
 
 The output is:
 
 1438
 
-Example:
+Example:
 
 Displaying Superscripts in Heading and Footing Lines in XLSX Output
 
@@ -4018,7 +4018,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1439
 
-Adding Underlines and Skipped Lines
+Adding Underlines and Skipped Lines
 
 The output is shown in the following image.
 
@@ -4040,7 +4040,7 @@ the default underline from light to heavy (or single to double in a PDF report).
 
 1440
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Reference: Section Separation Features
 
@@ -4122,7 +4122,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1441
 
-Adding Underlines and Skipped Lines
+Adding Underlines and Skipped Lines
 
 Feature
 
@@ -4199,7 +4199,7 @@ easy for the reader to write comments next to individual lines.
 
 1442
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 SKIP-LINE used with a sort field adds a blank line before every change in the value of that
 field. This is one of the only ON conditions that does not have to refer solely to a sort (BY)
@@ -4239,7 +4239,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1443
 
 
-Adding Underlines and Skipped Lines
+Adding Underlines and Skipped Lines
 
 The data for each employee stands out and is easy to read:
 
@@ -4264,7 +4264,7 @@ internal cascading style sheets).
 
 1444
 
-Example:
+Example:
 
 Adding Color to Blank Lines
 
@@ -4294,7 +4294,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1445
 
-Adding Underlines and Skipped Lines
+Adding Underlines and Skipped Lines
 
 Syntax:
 
@@ -4338,7 +4338,7 @@ END
 
 1446
 
-The data for each bank stands out and is easy to read:
+The data for each bank stands out and is easy to read:
 
 21. Laying Out the Report Page
 
@@ -4368,7 +4368,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1447
 
-Adding Underlines and Skipped Lines
+Adding Underlines and Skipped Lines
 
 RGB
 
@@ -4408,7 +4408,7 @@ The result is an eye-catching separation between sort group values. The online P
 
 1448
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Syntax:
 
@@ -4457,7 +4457,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1449
 
-Adding Underlines and Skipped Lines
+Adding Underlines and Skipped Lines
 
 Example:
 
@@ -4482,7 +4482,7 @@ The partial report is:
 
 1450
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Syntax:
 
@@ -4544,7 +4544,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1451
 
-Adding Underlines and Skipped Lines
+Adding Underlines and Skipped Lines
 
 The output shows that only the column titles are underlined:
 
@@ -4573,7 +4573,7 @@ END
 
 1452
 
-The output is:
+The output is:
 
 21. Laying Out the Report Page
 
@@ -4604,7 +4604,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1453
 
-Adding Underlines and Skipped Lines
+Adding Underlines and Skipped Lines
 
 The output is:
 
@@ -4630,7 +4630,7 @@ Generates a heavy underline. Enclose the equal sign in single quotation marks.
 
 1454
 
-Example:
+Example:
 
 Changing the Default Underline in a Financial Modeling Language (FML) Report
 (HTML)
@@ -4678,7 +4678,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1455
 
-Removing Blank Lines From a Report
+Removing Blank Lines From a Report
 
 The output is:
 
@@ -4722,7 +4722,7 @@ a border or backcolor StyleSheet attribute anywhere in the report.
 
 1456
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 ALL
 
@@ -4768,7 +4768,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1457
 
-Removing Blank Lines From a Report
+Removing Blank Lines From a Report
 
 Applying borders for the entire report (TYPE=REPORT) is recommended to avoid certain
 known issues that arise when bordering report elements individually. In some reports
@@ -4809,7 +4809,7 @@ END
 
 1458
 
-The output has a blank line below the heading, above the footing, and above and below the
+The output has a blank line below the heading, above the footing, and above and below the
 subtotal lines and the grand total line.
 
 21. Laying Out the Report Page
@@ -4818,7 +4818,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1459
 
-Removing Blank Lines From a Report
+Removing Blank Lines From a Report
 
 Changing the DROPBLNKLINE setting to HEADING produces the following output. The blank line
 below the heading and the blank line above the footing have been removed. The blank lines
@@ -4826,7 +4826,7 @@ above and below the subtotal and grand total lines are still inserted.
 
 1460
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Changing the DROPBLNKLINE setting to ON (or BODY) produces the following output in which
 the blank lines above and below the subtotal and grand total lines have been removed, but the
@@ -4836,7 +4836,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1461
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 Changing the DROPBLNKLINE setting to ALL produces the following output in which the blank
 lines around the subtotal and grandtotal lines as well as the blank lines below the heading and
@@ -4857,7 +4857,7 @@ Format) or JPEG (Joint Photographic Experts Group, .jpg extension).
 
 1462
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Image support with WebFOCUS standard reporting formats
 
@@ -4909,7 +4909,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1463
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 Note: For JPEG files, currently only the .jpg extension is supported. The .jpeg extension is not
 supported.
@@ -4962,7 +4962,7 @@ the image is not embedded.
 
 1464
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 The encoding algorithm that uses 64-bit encoding supported for images less than 32K in
 size is supported by Internet Explorer 8. For Internet Explorer 8, Information Builders
@@ -5022,7 +5022,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1465
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 Syntax:
 
@@ -5077,7 +5077,7 @@ an Internal Cascading Style Sheet on page 1476.
 
 1466
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Valid values are:
 
@@ -5131,7 +5131,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1467
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 SET BASEURL=http://host:port/
 .
@@ -5171,7 +5171,7 @@ END
 
 1468
 
-IMAGEBREAK, set to ON, generates a line break between the logo and the heading text:
+IMAGEBREAK, set to ON, generates a line break between the logo and the heading text:
 
 21. Laying Out the Report Page
 
@@ -5206,13 +5206,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1469
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 The output is:
 
 1470
 
-Example:
+Example:
 
 Using a File Name in a Data Source Field in an HTML Report
 
@@ -5248,13 +5248,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1471
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 The output is:
 
 1472
 
-Example:
+Example:
 
 Supplying an Image Description Using the ALT Attribute
 
@@ -5300,7 +5300,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1473
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 When you run the request, the image displays below the report data, as shown in the following
 image.
@@ -5329,7 +5329,7 @@ Applies the image to the entire report. Not required, as it is the default.
 
 1474
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 url
 
@@ -5363,7 +5363,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1475
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 Syntax:
 
@@ -5416,7 +5416,7 @@ When specifying a GIF file, you can omit the file extension.
 
 1476
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 column
 
@@ -5468,7 +5468,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1477
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 w
 
@@ -5511,7 +5511,7 @@ END
 
 1478
 
-The company logo is positioned and sized in the report heading:
+The company logo is positioned and sized in the report heading:
 
 21. Laying Out the Report Page
 
@@ -5543,7 +5543,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1479
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 The report is:
 
@@ -5575,7 +5575,7 @@ END
 
 1480
 
-The report is:
+The report is:
 
 21. Laying Out the Report Page
 
@@ -5612,7 +5612,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1481
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 SET HTMLCSS=ON (required for image positioning in subheads in HTML reports). Setting
 HTMLCSS=ON creates an HTML report with an Internal cascading style sheet. A report with
@@ -5658,7 +5658,7 @@ When specifying a GIF file, you can omit the file extension.
 
 1482
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 column
 
@@ -5715,7 +5715,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1483
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 w
 
@@ -5756,7 +5756,7 @@ field named prodimage whose data type is BLOB.
 
 1484
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 The following Master File describes the Microsoft SQL Server data source named retaildetail.
 
@@ -5800,7 +5800,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1485
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 The following request joins the two data sources and prints product names and prices with the
 corresponding image. The output is generated in DHTML format.
@@ -5843,7 +5843,7 @@ TYPE=DATA,COLUMN=PRODIMAGE,IMAGE=(PRODIMAGE),SIZE=(1 1),$
 
 1486
 
-The partial output shows that DHTML format preserves the specified spacing.
+The partial output shows that DHTML format preserves the specified spacing.
 
 21. Laying Out the Report Page
 
@@ -5851,7 +5851,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1487
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 The following request generates the output in HTML format.
 
@@ -5888,7 +5888,7 @@ END
 
 1488
 
-The partial output shows that the spacing is different because the browser removes blank
+The partial output shows that the spacing is different because the browser removes blank
 spaces for HTML report output.
 
 21. Laying Out the Report Page
@@ -5897,7 +5897,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1489
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 The following request generates the report output in PDF format.
 
@@ -5934,7 +5934,7 @@ END
 
 1490
 
-The PDF partial output preserves specified spacing providing results similar to DHTML output.
+The PDF partial output preserves specified spacing providing results similar to DHTML output.
 
 21. Laying Out the Report Page
 
@@ -5942,7 +5942,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1491
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 Example:
 
@@ -6002,7 +6002,7 @@ END
 
 1492
 
-The partial output is.
+The partial output is.
 
 21. Laying Out the Report Page
 
@@ -6010,7 +6010,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1493
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 Example:
 
@@ -6065,7 +6065,7 @@ rendered as specified by the styling SIZE height and width values specified in t
 
 1494
 
-The partial output follows.
+The partial output follows.
 
 21. Laying Out the Report Page
 
@@ -6081,7 +6081,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1495
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 The Microsoft SQL Server data source named retaildetail contains product information for a
 sports clothing and shoe retailer. The Microsoft SQL Server data source named retailimage
@@ -6115,7 +6115,7 @@ ON CATEGORY SUBHEAD
 
 1496
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 PRINT PRICE NOPRINT PRODIMAGE NOPRINT
 BY CATEGORY NOPRINT
@@ -6154,13 +6154,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1497
 
-Adding an Image to a Report
+Adding an Image to a Report
 
 The output for the first category is:
 
 1498
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Reference: File Size and Compression Considerations For Images in BLOB Fields
 
@@ -6193,7 +6193,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1499
 
-Associating Bar Graphs With Report Data
+Associating Bar Graphs With Report Data
 
 Horizontal Bar Graph. You can apply a horizontal bar graph to report columns. The report
 output displays a horizontal bar graph in a new column to the right of the associated data
@@ -6217,7 +6217,7 @@ formats, see the Describing Data With WebFOCUS Language manual.
 
 1500
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 You apply data visualization bar graphs to columns by adding a declaration to your WebFOCUS
 StyleSheet that begins with the GRAPHTYPE attribute. This attribute adds either a vertical or
@@ -6277,7 +6277,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1501
 
-Associating Bar Graphs With Report Data
+Associating Bar Graphs With Report Data
 
 Syntax:
 
@@ -6331,7 +6331,7 @@ components in equal intensities results in shades of gray.
 
 1502
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 RGB(#hexcolor)
 
@@ -6389,7 +6389,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1503
 
-Associating Bar Graphs With Report Data
+Associating Bar Graphs With Report Data
 
 Syntax:
 
@@ -6426,7 +6426,7 @@ using StyleSheet syntax. For details, see Formatting Report Data on page 1697.
 
 1504
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Example:
 
@@ -6460,7 +6460,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1505
 
 
-Associating Bar Graphs With Report Data
+Associating Bar Graphs With Report Data
 
 Controlling Bar Graph Scaling in Horizontal (ACROSS) Sort Fields
 
@@ -6506,7 +6506,7 @@ V
 
 1506
 
-Example:
+Example:
 
 Setting Orientation for Visualization Bars
 
@@ -6541,7 +6541,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1507
 
-Associating Bar Graphs With Report Data
+Associating Bar Graphs With Report Data
 
 SET VISBARORIENT=H
 TABLE FILE GGSALES
@@ -6587,7 +6587,7 @@ report-lever setting (TYPE=REPORT).
 
 1508
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 UNIFORM
 
@@ -6632,7 +6632,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1509
 
 
-Working With Mailing Labels and Multi-Pane Pages
+Working With Mailing Labels and Multi-Pane Pages
 
 The following request is the same as the above request, except it has the
 GRAPHSCALE=DISTINCT attribute included in the StyleSheet.
@@ -6670,7 +6670,7 @@ These features apply to a PDF or PS report.
 1510
 
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Reference: Attributes for Mailing Labels and Multi-Pane Printing
 
@@ -6750,7 +6750,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1511
 
-Working With Mailing Labels and Multi-Pane Pages
+Working With Mailing Labels and Multi-Pane Pages
 
 Syntax:
 
@@ -6813,7 +6813,7 @@ Prints the labels across the page.
 
 1512
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 LABELPROMPT
 
@@ -6857,13 +6857,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1513
 
-Working With Mailing Labels and Multi-Pane Pages
+Working With Mailing Labels and Multi-Pane Pages
 
 The first page of labels prints as follows:
 
 1514
 
-21. Laying Out the Report Page
+21. Laying Out the Report Page
 
 Example:
 
@@ -6894,6 +6894,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1515
 
-Working With Mailing Labels and Multi-Pane Pages
+Working With Mailing Labels and Multi-Pane Pages
 
 1516

--- a/specifications/creating_reports/creating_reports_22_chapter22.md
+++ b/specifications/creating_reports/creating_reports_22_chapter22.md
@@ -69,7 +69,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1517
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 Controlling the Vertical Positioning of a
 Heading or Footing
@@ -104,7 +104,7 @@ every page of the report.
 
 1518
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The following sample report contains sort headings and sort footings, as well as, a page
 heading and page footing for reference.
@@ -139,7 +139,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1519
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 Extending Heading and Footing Code to Multiple Lines in a Report Request
 
@@ -190,7 +190,7 @@ JOIN STORE_CODE IN CENTCOMP TO STORE_CODE IN CENTORD
 
 1520
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 TABLE FILE CENTCOMP
 HEADING
@@ -213,7 +213,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1521
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 The partial output is:
 
@@ -232,7 +232,7 @@ Replaces the default worksheet tab name with the name you specify in an EXL2K re
 
 1522
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The worksheet tab names for an Excel Table of Contents report are the BY field values that
 correspond to the data on the current worksheet. If the user specifies the TITLETEXT keyword
@@ -278,7 +278,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1523
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 Example:
 
@@ -301,7 +301,7 @@ The output is:
 
 1524
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -339,7 +339,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1525
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 Syntax:
 
@@ -400,7 +400,7 @@ Dialogue Manager variables.
 
 1526
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Images. You can include images in a heading or footing.
 
@@ -458,14 +458,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1527
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 The output illustrates the placement of a report heading on a multi-page HTML report. The
 report heading is at the top of the first page.
 
 1528
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Subsequent pages do not contain a heading.
 
@@ -475,7 +475,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1529
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 Syntax:
 
@@ -536,7 +536,7 @@ Dialogue Manager variables.
 
 1530
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Images. You can include images in a heading or footing.
 
@@ -595,7 +595,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1531
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 The output illustrates the placement of a report footing on a multi-page HTML report. The
 report footing follows the data on the last page.
@@ -616,7 +616,7 @@ DEPARTMENT).
 
 1532
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Add a page footing to supply information that warrants repetition on each page, such as the
 date of the report, or a reminder that it is confidential. You can also use a page footing to
@@ -674,7 +674,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1533
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 content
 
@@ -731,7 +731,7 @@ must be considered when applying formatting.
 
 1534
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Blank lines
 
@@ -767,7 +767,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1535
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 The second page of data applies to the PRODUCTION department.
 
@@ -816,7 +816,7 @@ Is text for the page footing. You can include multiple lines of text.
 
 1536
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The text must start on a line by itself, following the FOOTING command.
 
@@ -871,7 +871,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1537
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 Example:
 
@@ -897,7 +897,7 @@ END
 
 1538
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The partial output illustrates the placement of page footings on a multi-page HTML report. The
 page footing appears on both pages of the report.
@@ -906,7 +906,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1539
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 Tip: If you do not see the navigation arrows, click the maximize button.
 
@@ -959,7 +959,7 @@ Matrix in the HTML Reporting Features section JavaScript components row.
 
 1540
 
-Reference: Usage Notes for HTMLARCHIVE With HFREEZE
+Reference: Usage Notes for HTMLARCHIVE With HFREEZE
 
 22. Using Headings, Footings, Titles, and Labels
 
@@ -1020,7 +1020,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1541
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 nn[.n]
 
@@ -1072,7 +1072,7 @@ Compound Reports
 
 1542
 
-Reference: Usage Notes for Freezing Areas of AHTML Report Output
+Reference: Usage Notes for Freezing Areas of AHTML Report Output
 
 22. Using Headings, Footings, Titles, and Labels
 
@@ -1124,7 +1124,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1543
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 By default, WebFOCUS generates a blank line before a subheading or subfooting. You can
 eliminate these automatic blank lines by issuing the SET DROPBLNKLINE=ON command.
@@ -1141,7 +1141,7 @@ other heading elements.
 
 1544
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Syntax:
 
@@ -1206,7 +1206,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1545
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 variable
 
@@ -1265,7 +1265,7 @@ Inserts a new page after the sort heading. Column titles appear on every page.
 
 1546
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 You can use NEWPAGE with PDF reports.In HTML reports, blank space is added instead of
 a new page.
@@ -1299,7 +1299,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1547
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 Example:
 
@@ -1327,7 +1327,7 @@ embedded field values.
 
 1548
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Syntax:
 
@@ -1388,7 +1388,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1549
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 content
 
@@ -1446,7 +1446,7 @@ must be considered when applying formatting.
 
 1550
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 WHEN expression
 
@@ -1470,7 +1470,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1551
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 Example:
 
@@ -1496,7 +1496,7 @@ embedded field values.
 
 1552
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -1535,7 +1535,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1553
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 The following report appears.
 
@@ -1563,7 +1563,7 @@ END
 
 1554
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 In the output, the sort footing for Biscotti is suppressed.
 
@@ -1590,14 +1590,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1555
 
-Creating Headings and Footings
+Creating Headings and Footings
 
 The sort footing text (for example, "Balance of investments for FRANCE in Euros is
 87,336,971.") replaces the default label for the RECAP value (** EURO 87,336,971).
 
 1556
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -1646,7 +1646,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1557
 
-Including an Element in a Heading or Footing
+Including an Element in a Heading or Footing
 
 A page number. See Including a Page Number in a Heading or Footing on page 1567.
 
@@ -1700,7 +1700,7 @@ alphanumeric field for all values of SET STYLEMODE.
 
 1558
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 <fieldname>
 
@@ -1745,14 +1745,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1559
 
-Including an Element in a Heading or Footing
+Including an Element in a Heading or Footing
 
 The output displays the output for a multi-page HTML report. On the first page of output, the
 value of DEPARTMENT in the page heading and footing is MIS.
 
 1560
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 On the second page of output, the value of DEPARTMENT is PRODUCTION.
 
@@ -1783,7 +1783,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1561
 
-Including an Element in a Heading or Footing
+Including an Element in a Heading or Footing
 
 The heading displays the text Difference < 100,000, as shown in the following image.
 
@@ -1815,7 +1815,7 @@ The resulting report displays in a fixed font without colors and other web capab
 
 1562
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -1847,7 +1847,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1563
 
-Including an Element in a Heading or Footing
+Including an Element in a Heading or Footing
 
 The totals appear in the page heading.
 
@@ -1872,7 +1872,7 @@ END
 
 1564
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The prefix operators generate summary data in the page heading.
 
@@ -1922,7 +1922,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1565
 
-Including an Element in a Heading or Footing
+Including an Element in a Heading or Footing
 
 Syntax:
 
@@ -1977,7 +1977,7 @@ END
 
 1566
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output is:
 
@@ -2031,7 +2031,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1567
 
-Including an Element in a Heading or Footing
+Including an Element in a Heading or Footing
 
 Because a new session is created on the WebFOCUS Reporting Server each time a
 request is submitted, values for global variables are not retained between report
@@ -2090,7 +2090,7 @@ END
 
 1568
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output is:
 
@@ -2127,7 +2127,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1569
 
-Displaying Syntax Components in Heading and Footing Objects
+Displaying Syntax Components in Heading and Footing Objects
 
 Displaying Syntax Components in Heading and Footing Objects
 
@@ -2154,7 +2154,7 @@ beyond the width of the report or chart container.
 
 1570
 
-Example:
+Example:
 
 Displaying Report Syntax Components
 
@@ -2196,7 +2196,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1571
 
-Repeating Headings and Footings on Panels in PDF Report Output
+Repeating Headings and Footings on Panels in PDF Report Output
 
 The output is shown in the following image.
 
@@ -2222,7 +2222,7 @@ subheadings, or subfootings.
 
 1572
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 HEADPANEL causes borders from the initial page to be replicated on the paneled pages.
 Additional control of subheading and subfooting borders can be gained through the use of
@@ -2280,7 +2280,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1573
 
-Repeating Headings and Footings on Panels in PDF Report Output
+Repeating Headings and Footings on Panels in PDF Report Output
 
 sortcolumn
 
@@ -2335,7 +2335,7 @@ subfooting, but the second panel does not.
 
 1574
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output for page 1 panel 1 has the heading and subfooting, as shown in the following
 image. Note that with HEADPANEL=OFF, TABPAGENO does not include the panel number.
@@ -2344,14 +2344,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1575
 
-Repeating Headings and Footings on Panels in PDF Report Output
+Repeating Headings and Footings on Panels in PDF Report Output
 
 The output for page 1 panel 2 does not have the heading or subfooting, as shown in the
 following image.
 
 1576
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The following output shows panels 1 and 2 if the StyleSheet declaration is changed to set
 HEADPANEL=ON for the entire report (TYPE=REPORT, HEADPANEL=ON ,$). The heading and
@@ -2362,11 +2362,11 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1577
 
-Repeating Headings and Footings on Panels in PDF Report Output
+Repeating Headings and Footings on Panels in PDF Report Output
 
 1578
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -2403,13 +2403,13 @@ Creating Reports With TIBCO® WebFOCUS Language
  1579
 
 
-Repeating Headings and Footings on Panels in PDF Report Output
+Repeating Headings and Footings on Panels in PDF Report Output
 
 Panel 1 displays both the heading and the subfooting, as shown in the following image.
 
 1580
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Panel 2 displays only the subfooting, not the heading, as shown in the following image.
 
@@ -2417,7 +2417,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1581
 
-Repeating Headings and Footings on Panels in PDF Report Output
+Repeating Headings and Footings on Panels in PDF Report Output
 
 Since the page heading is not repeated, if you use the <TABPAGENO system variable to place
 the page number in the heading, it will not display the panel number and will not display on the
@@ -2447,7 +2447,7 @@ END
 1582
 
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The first panel displays the page number in the heading, without the panel number, as shown
 in the following image.
@@ -2456,14 +2456,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1583
 
-Repeating Headings and Footings on Panels in PDF Report Output
+Repeating Headings and Footings on Panels in PDF Report Output
 
 The second panel does not display the heading and therefore, does not display the embedded
 page number, as shown in the following image.
 
 1584
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -2521,7 +2521,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1585
 
 
-Repeating Headings and Footings on Panels in PDF Report Output
+Repeating Headings and Footings on Panels in PDF Report Output
 
 TYPE=REPORT,
      FONT='ARIAL',
@@ -2580,7 +2580,7 @@ $
 
 1586
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 TYPE=SUBFOOT,
      SIZE=10,
@@ -2607,7 +2607,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1587
 
-Repeating Headings and Footings on Panels in PDF Report Output
+Repeating Headings and Footings on Panels in PDF Report Output
 
 Since HEADPANEL=ON for the entire report, both panels display all of the heading and footing
 elements.
@@ -2616,7 +2616,7 @@ The following image shows page 1 panel 1.
 
 1588
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The following image shows page 1 panel 2.
 
@@ -2637,7 +2637,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1589
 
-Customizing a Column Title
+Customizing a Column Title
 
 Example:
 
@@ -2666,7 +2666,7 @@ The output is:
 
 1590
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Reference: Limits for Column Titles
 
@@ -2720,7 +2720,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1591
 
-Customizing a Column Title
+Customizing a Column Title
 
 Example:
 
@@ -2745,7 +2745,7 @@ The output is:
 
 1592
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -2771,7 +2771,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1593
 
-Customizing a Column Title
+Customizing a Column Title
 
 Example:
 
@@ -2811,7 +2811,7 @@ a MATCH command, or when duplicate field names exist in a HOLD file.
 
 1594
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Syntax:
 
@@ -2880,7 +2880,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1595
 
-Controlling Column Title Underlining Using a SET Command
+Controlling Column Title Underlining Using a SET Command
 
 With the default value (ON) for SET TITLELINE, the column titles are underlined.
 
@@ -2889,7 +2889,7 @@ underlines would have been is still there.
 
 1596
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 With SET TITLELINE=SKIP, both the underlines and the blank line are removed.
 
@@ -2922,7 +2922,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1597
 
-Controlling Column Title Underlining Using a StyleSheet Attribute
+Controlling Column Title Underlining Using a StyleSheet Attribute
 
 Example:
 
@@ -2944,7 +2944,7 @@ With the default value (ON) for TITLELINE, the column titles are underlined.
 
 1598
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 With TITLELINE=OFF, the column titles are not underlined, but the blank line where the
 underlines would have been is still there.
@@ -2955,7 +2955,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1599
 
-Creating Labels to Identify Data
+Creating Labels to Identify Data
 
 Creating Labels to Identify Data
 
@@ -3014,7 +3014,7 @@ summed, the format of the total is the same as the format of the fields. When fi
 
 1600
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 with different formats are summed, the default D12.2 is used for either the row or
 column total.
@@ -3060,7 +3060,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1601
 
-Creating Labels to Identify Data
+Creating Labels to Identify Data
 
 Example:
 
@@ -3112,7 +3112,7 @@ detail line. MULTI-LINES is a synonym for MULTILINES.
 
 1602
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 field1 field2
 
@@ -3155,7 +3155,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1603
 
-Creating Labels to Identify Data
+Creating Labels to Identify Data
 
 In the output, the department values MIS and PRODUCTION are included by default in the
 customized subtotal label.
@@ -3180,7 +3180,7 @@ END
 
 1604
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output is:
 
@@ -3213,7 +3213,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1605
 
-Creating Labels to Identify Data
+Creating Labels to Identify Data
 
 AS 'label'
 
@@ -3251,7 +3251,7 @@ END
 
 1606
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 In the output, the department values MIS and PRODUCTION are included by default in the
 customized subtotal label. The default grand total label is TOTAL.
@@ -3281,7 +3281,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1607
 
-Formatting a Heading, Footing, Title, or Label
+Formatting a Heading, Footing, Title, or Label
 
 You can:
 
@@ -3331,7 +3331,7 @@ Controlling the Vertical Positioning of a Heading or Footing on page 1685.
 
 1608
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Position a report or sort heading or footing on a separate page. See Placing a Report
 Heading or Footing on Its Own Page on page 1692.
@@ -3371,7 +3371,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1609
 
-Applying Font Attributes to a Heading, Footing, Title, or Label
+Applying Font Attributes to a Heading, Footing, Title, or Label
 
 For an HTML report, the font name must be enclosed in single quotation marks. The
 StyleSheet attribute TYPE = TABHEADING identifies the report heading, and the attribute TYPE
@@ -3395,7 +3395,7 @@ The output is:
 
 1610
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -3430,7 +3430,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1611
 
-Applying Font Attributes to a Heading, Footing, Title, or Label
+Applying Font Attributes to a Heading, Footing, Title, or Label
 
 Example:
 
@@ -3459,7 +3459,7 @@ The partial output is:
 
 1612
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Adding Borders and Grid Lines
 
@@ -3494,7 +3494,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1613
 
-Adding Borders and Grid Lines
+Adding Borders and Grid Lines
 
 Example:
 
@@ -3522,7 +3522,7 @@ The output is:
 
 1614
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -3556,7 +3556,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1615
 
-Justifying a Heading, Footing, Title, or Label
+Justifying a Heading, Footing, Title, or Label
 
 Example:
 
@@ -3597,7 +3597,7 @@ A column title. See Justifying a Column Title on page 1624.
 
 1616
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 A label for a row or column total. See Justifying a Label for a Row or Column Total on page
 1629.
@@ -3652,7 +3652,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1617
 
-Justifying a Heading, Footing, Title, or Label
+Justifying a Heading, Footing, Title, or Label
 
 line_#
 
@@ -3697,7 +3697,7 @@ END
 
 1618
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output is:
 
@@ -3734,7 +3734,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1619
 
-Justifying a Heading, Footing, Title, or Label
+Justifying a Heading, Footing, Title, or Label
 
 The output is:
 
@@ -3765,7 +3765,7 @@ END
 
 1620
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output is:
 
@@ -3797,7 +3797,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1621
 
-Justifying a Heading, Footing, Title, or Label
+Justifying a Heading, Footing, Title, or Label
 
 Syntax:
 
@@ -3858,7 +3858,7 @@ For details, see Including an Element in a Heading or Footing on page 1557.
 
 1622
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 spot marker
 
@@ -3915,7 +3915,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1623
 
-Justifying a Heading, Footing, Title, or Label
+Justifying a Heading, Footing, Title, or Label
 
 The page heading is centered over the report data, as shown in the first page of output.
 
@@ -3941,7 +3941,7 @@ report content.
 
 1624
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 You can also justify a column title for a display or BY field using legacy formatting methods.
 However, when legacy formatting is applied to an ACROSS field, data values, not column titles,
@@ -3996,7 +3996,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1625
 
-Justifying a Heading, Footing, Title, or Label
+Justifying a Heading, Footing, Title, or Label
 
 LEFT which left justifies the column title. This value is the default for an alphanumeric
 field.
@@ -4037,7 +4037,7 @@ The output is:
 
 1626
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -4087,7 +4087,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1627
 
-Justifying a Heading, Footing, Title, or Label
+Justifying a Heading, Footing, Title, or Label
 
 The output is:
 
@@ -4131,7 +4131,7 @@ will justify the title, see How to Justify a Column Title Using a StyleSheet on 
 
 1628
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -4184,7 +4184,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1629
 
-Justifying a Heading, Footing, Title, or Label
+Justifying a Heading, Footing, Title, or Label
 
 R which right justifies the label.
 
@@ -4224,7 +4224,7 @@ The output is:
 
 1630
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Justifying a Label for a Subtotal or Grand Total
 
@@ -4264,13 +4264,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1631
 
-Justifying a Heading, Footing, Title, or Label
+Justifying a Heading, Footing, Title, or Label
 
 The output is:
 
 1632
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Choosing an Alignment Method for Heading and Footing Elements
 
@@ -4351,7 +4351,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1633
 
 
-Choosing an Alignment Method for Heading and Footing Elements
+Choosing an Alignment Method for Heading and Footing Elements
 
 Applies
 to ...
@@ -4430,7 +4430,7 @@ displayed to its right.
 
 1634
 
-Applies
+Applies
 to ...
 
 PDF
@@ -4521,7 +4521,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1635
 
-Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
+Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
 
 For HTML or Excel 2000 output, when HEADALIGN is set either to BODY or INTERNAL, output is
 laid out as an HTML table, which means that the browser determines the widths of the
@@ -4569,7 +4569,7 @@ element within each of them using this syntax.
 
 1636
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Tip: For a summary of other alignment methods, see Choosing an Alignment Method for
 Heading and Footing Elements on page 1633.
@@ -4623,7 +4623,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1637
 
-Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
+Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
 
 Example:
 
@@ -4655,7 +4655,7 @@ END
 
 1638
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output shows that the text Total is aligned with the product names and the subtotal field
 object is right aligned with the Ordered Units column.
@@ -4674,7 +4674,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1639
 
-Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
+Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
 
 In the following example, the first row (the anchor data row) contains a single value. Items
 placed in headings to correspond with column two that appears on subsequent rows are not
@@ -4705,7 +4705,7 @@ END
 
 1640
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output shows that the heading lines have one column each, while the data lines alternate
 between one column and two columns.
@@ -4722,7 +4722,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1641
 
-Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
+Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
 
 All HEADALIGN settings are compatible with COLSPAN syntax, which allows heading items to
 span multiple columns.
@@ -4750,7 +4750,7 @@ TYPE=SUBHEAD, HEADALIGN=NONE, $
 
 1642
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 HEADALIGN=NONE with COLSPAN
 
@@ -4770,7 +4770,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1643
 
-Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
+Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
 
 Country is aligned with Model in the first column of the internal table. The value of <COUNTRY
 is aligned with the value of <MODEL in the second column.
@@ -4785,7 +4785,7 @@ setting.
 
 1644
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 HEADALIGN=BODY places the heading lines within the cells of the main HTML table. As a
 result, the columns of the heading correspond to the columns of the main table.
@@ -4799,7 +4799,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1645
 
-Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
+Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
 
 HEADALIGN=BODY with COLSPAN
 
@@ -4835,7 +4835,7 @@ END
 
 1646
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The partial output is:
 
@@ -4843,7 +4843,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1647
 
-Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
+Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
 
 Example:
 
@@ -4886,7 +4886,7 @@ the main HTML table for the body of the report.
 
 1648
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output is:
 
@@ -4894,13 +4894,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1649
 
-Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
+Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
 
 Notice that the positioning is maintained when the grid is hidden (off).
 
 1650
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -4933,7 +4933,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1651
 
-Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
+Aligning a Heading or Footing Element in an HTML, XLSX, EXL2K, PDF, PPTX, or DHTML Report
 
 Example:
 
@@ -4967,7 +4967,7 @@ TYPE = SUBFOOT, LINE = 2, OBJECT = FIELD, STYLE = BOLD, $
 
 1652
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 then only the text in TEXTFLD is bold.
 
@@ -5002,7 +5002,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1653
 
-Aligning a Heading or Footing Element Across Columns in an HTML or PDF Report
+Aligning a Heading or Footing Element Across Columns in an HTML or PDF Report
 
 subtype
 
@@ -5049,7 +5049,7 @@ Is the column with which the specified item is aligned.
 
 1654
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -5082,13 +5082,13 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1655
 
-Aligning a Heading or Footing Element Across Columns in an HTML or PDF Report
+Aligning a Heading or Footing Element Across Columns in an HTML or PDF Report
 
 The output is:
 
 1656
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -5125,7 +5125,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1657
 
-Aligning a Heading or Footing Element Across Columns in an HTML or PDF Report
+Aligning a Heading or Footing Element Across Columns in an HTML or PDF Report
 
 Example:
 
@@ -5159,7 +5159,7 @@ END
 
 1658
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output shows that the first item in the sort footing (the text Total) is in the fifth column of
 the report output. The second item in the sort footing (the field <ST.QUANTITY) is positioned in
@@ -5186,7 +5186,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1659
 
-Aligning Content in a Multi-Line Heading or Footing
+Aligning Content in a Multi-Line Heading or Footing
 
 These techniques rely on internal cascading style sheets, which support WebFOCUS
 StyleSheet attributes that were not previously available for HTML reports. The syntax
@@ -5243,7 +5243,7 @@ You can use LINE in combination with ITEM.
 
 1660
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 ITEM
 
@@ -5300,7 +5300,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1661
 
-Aligning Content in a Multi-Line Heading or Footing
+Aligning Content in a Multi-Line Heading or Footing
 
 LEFT which left justifies the heading or footing. LEFT is the default value.
 
@@ -5366,7 +5366,7 @@ item: the first column of text is item 1, the next column of data is item 2, and
 
 1662
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Note especially the last column, in which decimal data with different numbers of decimal
 places is lined up on the decimal point to facilitate reading and comparison.
@@ -5418,7 +5418,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1663
 
-Aligning Content in a Multi-Line Heading or Footing
+Aligning Content in a Multi-Line Heading or Footing
 
 For each item, you specify the width of the column and the justification of its content, as
 illustrated in the following code.
@@ -5466,7 +5466,7 @@ but the number of digits of decimal precision varies.
 
 1664
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 By aligning the decimal points in a vertical stack, you can more easily read and compare these
 numbers, as illustrated in the following output:
@@ -5572,7 +5572,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1665
 
-Aligning Content in a Multi-Line Heading or Footing
+Aligning Content in a Multi-Line Heading or Footing
 
 Procedure: How to Measure for Decimal Alignment
 
@@ -5628,7 +5628,7 @@ StyleSheet on page 1249.
 
 1666
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Request and annotations:
 
@@ -5671,7 +5671,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1667
 
-Aligning Content in a Multi-Line Heading or Footing
+Aligning Content in a Multi-Line Heading or Footing
 
 The output highlights the key information and its relationship by aligning text and data,
 including decimal data in which decimal points are aligned for easy comparison.
@@ -5689,7 +5689,7 @@ contains data values related to the text.
 
 1668
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Line #
 
@@ -5713,7 +5713,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1669
 
-Aligning Content in a Multi-Line Heading or Footing
+Aligning Content in a Multi-Line Heading or Footing
 
 Line #
 
@@ -5759,7 +5759,7 @@ each item.
 
 1670
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Line #
 
@@ -5810,7 +5810,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1671
 
-Positioning Headings, Footings, or Items Within Them
+Positioning Headings, Footings, or Items Within Them
 
 In addition, for a PDF or PS report, you can use the POSITION attribute to specify an absolute
 or relative starting position for an element within a heading or footing or to align an item in a
@@ -5870,7 +5870,7 @@ END
 
 1672
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output is:
 
@@ -5903,7 +5903,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1673
 
-Positioning Headings, Footings, or Items Within Them
+Positioning Headings, Footings, or Items Within Them
 
 The output is:
 
@@ -5934,7 +5934,7 @@ lines enables you to format each line differently.
 
 1674
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 If a heading or footing has multiple lines and you apply a StyleSheet declaration that
 does not specify LINE, the declaration is applied to all lines. Blank lines are counted
@@ -5984,7 +5984,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1675
 
-Positioning Headings, Footings, or Items Within Them
+Positioning Headings, Footings, or Items Within Them
 
 Example:
 
@@ -6013,7 +6013,7 @@ The output is:
 
 1676
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -6045,7 +6045,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1677
 
-Positioning Headings, Footings, or Items Within Them
+Positioning Headings, Footings, or Items Within Them
 
 Example:
 
@@ -6082,7 +6082,7 @@ produce the exact report you desire.
 
 1678
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The PRINTPLUS parameter must be set to ON to use the following TABLE capabilities:
 
@@ -6127,7 +6127,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1679
 
-Positioning Headings, Footings, or Items Within Them
+Positioning Headings, Footings, or Items Within Them
 
 Example:
 
@@ -6239,7 +6239,7 @@ Choosing an Alignment Method for Heading and Footing Elements on page 1633.
 
 
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The following spot markers enable you to position items and to identify items to be formatted:
 
@@ -6287,7 +6287,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1681
 
-Positioning Headings, Footings, or Items Within Them
+Positioning Headings, Footings, or Items Within Them
 
 TABLE FILE CENTCOMP
 HEADING
@@ -6316,7 +6316,7 @@ immediately after a field in a PDF report.
 
 1682
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The first technique uses the POSITION attribute in a StyleSheet to position the closing
 parenthesis immediately after the STORE_CODE value. The second technique uses the <-1
@@ -6351,7 +6351,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1683
 
 
-Positioning Headings, Footings, or Items Within Them
+Positioning Headings, Footings, or Items Within Them
 
 Without the spot marker and position measurement, the output would have looked like this:
 
@@ -6390,7 +6390,7 @@ and the character that will follow it.
 1684
 
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output is:
 
@@ -6417,7 +6417,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1685
 
-Controlling the Vertical Positioning of a Heading or Footing
+Controlling the Vertical Positioning of a Heading or Footing
 
 Syntax:
 
@@ -6467,7 +6467,7 @@ END
 
 1686
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 The output is:
 
@@ -6509,7 +6509,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1687
 
-Controlling the Vertical Positioning of a Heading or Footing
+Controlling the Vertical Positioning of a Heading or Footing
 
 In the absence of grids, the default value is 0.
 
@@ -6543,7 +6543,7 @@ The output is:
 
 1688
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Example:
 
@@ -6572,7 +6572,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1689
 
-Controlling the Vertical Positioning of a Heading or Footing
+Controlling the Vertical Positioning of a Heading or Footing
 
 Syntax:
 
@@ -6634,7 +6634,7 @@ For details, see Including an Element in a Heading or Footing on page 1557.
 
 1690
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 spot marker
 
@@ -6687,7 +6687,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1691
 
-Placing a Report Heading or Footing on Its Own Page
+Placing a Report Heading or Footing on Its Own Page
 
 The following output shows the end of the report, with the footing.
 
@@ -6725,7 +6725,7 @@ Generates a report heading.
 
 1692
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 SUBFOOT
 
@@ -6784,7 +6784,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1693
 
-Placing a Report Heading or Footing on Its Own Page
+Placing a Report Heading or Footing on Its Own Page
 
 Note: When a closing spot marker is immediately followed by an opening spot marker
 (><), a single space text item will be placed between the two spot markers (> <). This
@@ -6822,7 +6822,7 @@ The second page of output contains the column titles and data.
 
 1694
 
-22. Using Headings, Footings, Titles, and Labels
+22. Using Headings, Footings, Titles, and Labels
 
 Tip: To produce comparable results in HTML, include the following code in the request to turn
 on the WebFOCUS Viewer.
@@ -6864,7 +6864,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1695
 
-Placing a Report Heading or Footing on Its Own Page
+Placing a Report Heading or Footing on Its Own Page
 
 Note: To produce comparable results in HTML, include the following code in the request to turn
 on the WebFOCUS Viewer.

--- a/specifications/creating_reports/creating_reports_23_chapter23.md
+++ b/specifications/creating_reports/creating_reports_23_chapter23.md
@@ -49,7 +49,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1697
 
-Specifying Font Format in a Report
+Specifying Font Format in a Report
 
 pts
 
@@ -109,7 +109,7 @@ Corresponding HTML Font Size
 
 1698
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 Size in Points
 
@@ -174,7 +174,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1699
 
-Specifying Font Format in a Report
+Specifying Font Format in a Report
 
 The output is:
 
@@ -202,7 +202,7 @@ The output is:
 
 1700
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 Syntax:
 
@@ -263,7 +263,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1701
 
-Specifying Font Format in a Report
+Specifying Font Format in a Report
 
 AQUAMARINE
 
@@ -351,7 +351,7 @@ SILVER
 
 1702
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 GREEN YELLOW
 
@@ -430,7 +430,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1703
 
-Specifying Font Format in a Report
+Specifying Font Format in a Report
 
 subtype
 
@@ -489,7 +489,7 @@ Specifies the default monospaced font of the web browser.
 
 1704
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 Example:
 
@@ -527,7 +527,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1705
 
-Specifying Background Color in a Report
+Specifying Background Color in a Report
 
 Syntax:
 
@@ -578,7 +578,7 @@ pound sign (#).
 
 1706
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 Example:
 
@@ -608,7 +608,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1707
 
-Specifying Background Color in a Report
+Specifying Background Color in a Report
 
 Syntax:
 
@@ -671,7 +671,7 @@ END
 
 1708
 
-The output is:
+The output is:
 
 23. Formatting Report Data
 
@@ -701,7 +701,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1709
 
-Alternating Background Color By Wrapped Line
+Alternating Background Color By Wrapped Line
 
 Example:
 
@@ -731,7 +731,7 @@ END
 
 1710
 
-The output is:
+The output is:
 
 23. Formatting Report Data
 
@@ -739,7 +739,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1711
 
-Specifying Data Format in a Report
+Specifying Data Format in a Report
 
 With the SET ALTBACKPERLINE=ON command added to the request, the alternating
 background color is applied by line, as shown in the following output.
@@ -757,7 +757,7 @@ data.
 
 1712
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 Changing the Format of Values in a Report Column
 
@@ -809,7 +809,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1713
 
-Specifying Data Format in a Report
+Specifying Data Format in a Report
 
 The output is:
 
@@ -867,7 +867,7 @@ line.
 
 1714
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 You may specify justification for display fields, BY fields, and ACROSS fields. For ACROSS
 fields, data values, not column titles, are justified as specified.
@@ -921,7 +921,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1715
 
-Specifying Data Format in a Report
+Specifying Data Format in a Report
 
 SET COMPMISS = OFF
 TABLE FILE SALES
@@ -974,7 +974,7 @@ STORE_CODE  RETURNS     RETURNS
 
 1716
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 Reference: Usage Notes for SET COMPMISS
 
@@ -1033,7 +1033,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1717
 
-Specifying Data Format in a Report
+Specifying Data Format in a Report
 
 Example:
 
@@ -1165,7 +1165,7 @@ report.
 
 1718
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 Example:
 
@@ -1201,7 +1201,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1719
 
-Positioning Data in a Report
+Positioning Data in a Report
 
 By default, WRAP is set to ON for HTML output, allowing each individual browser to define the
 width of each column in the report. For PDF, PS, DHTML, PPT, and PPTX output, WRAP is set
@@ -1247,7 +1247,7 @@ them. Each designated value will wrap within the defined ACROSS group.
 
 1720
 
-Syntax:
+Syntax:
 
 How to Control Wrapping of Report Data
 
@@ -1298,7 +1298,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1721
 
-Positioning Data in a Report
+Positioning Data in a Report
 
 Example:
 
@@ -1340,7 +1340,7 @@ END
 
 1722
 
-The output is:
+The output is:
 
 23. Formatting Report Data
 
@@ -1364,7 +1364,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1723
 
-Positioning Data in a Report
+Positioning Data in a Report
 
 The partial output is shown in the following image.
 
@@ -1383,7 +1383,7 @@ END
 
 1724
 
-The partial output shows that the VENDOR_NAME column now wraps. Notice that turning WRAP
+The partial output shows that the VENDOR_NAME column now wraps. Notice that turning WRAP
 ON causes the OVER value, not the OVER TITLE, to wrap:
 
 23. Formatting Report Data
@@ -1418,7 +1418,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1725
 
-Positioning Data in a Report
+Positioning Data in a Report
 
 An
 
@@ -1463,7 +1463,7 @@ price columns under them.
 
 1726
 
-The following version of the request wraps the ACROSS values (TYPE=ACROSSVALUE,
+The following version of the request wraps the ACROSS values (TYPE=ACROSSVALUE,
 WRAP=ON ,$):
 
 23. Formatting Report Data
@@ -1503,7 +1503,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1727
 
-Positioning Data in a Report
+Positioning Data in a Report
 
 Example:
 
@@ -1541,7 +1541,7 @@ END
 
 1728
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 On the report output, the Package Type and Size have been placed over the vendor name. The
 page heading has the corresponding titles. In the heading, the titles Package and Size have
@@ -1563,7 +1563,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1729
 
-Positioning Data in a Report
+Positioning Data in a Report
 
 Example:
 
@@ -1598,7 +1598,7 @@ END
 
 1730
 
-The output shows that the titles and data align properly.
+The output shows that the titles and data align properly.
 
 23. Formatting Report Data
 
@@ -1625,7 +1625,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1731
 
-Positioning Data in a Report
+Positioning Data in a Report
 
 n
 
@@ -1656,7 +1656,7 @@ END
 
 1732
 
-With WRAPGAP=OFF, each wrapped line is placed on the next report line:
+With WRAPGAP=OFF, each wrapped line is placed on the next report line:
 
 23. Formatting Report Data
 
@@ -1664,7 +1664,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1733
 
-Positioning Data in a Report
+Positioning Data in a Report
 
 With WRAPGAP=ON, the wrapped lines are placed directly under each other:
 
@@ -1685,7 +1685,7 @@ using /R /L and /C, see Using Headings, Footings, Titles, and Labels on page 151
 
 1734
 
-Syntax:
+Syntax:
 
 How to Justify a Report Column
 
@@ -1748,7 +1748,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1735
 
-Positioning Data in a Report
+Positioning Data in a Report
 
 The output is:
 
@@ -1779,7 +1779,7 @@ column width may not be large enough to hold the value (indicated by asterisks i
 
 1736
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 You can apply a field-based format to any type of field. However, the new format must be
 compatible with the original format:
@@ -1829,7 +1829,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1737
 
-Positioning Data in a Report
+Positioning Data in a Report
 
 After the format field is defined, you can apply it in a report request:
 
@@ -1886,7 +1886,7 @@ W GERMANY   88,190.00    54,563.00
 1738
 
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 Displaying Multi-Line An and AnV Fields
 
@@ -1928,7 +1928,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1739
 
-Positioning Data in a Report
+Positioning Data in a Report
 
 Example:
 
@@ -1967,7 +1967,7 @@ The following report request is for an EBCDIC environment:
 
 1740
 
-23. Formatting Report Data
+23. Formatting Report Data
 
 DEFINE FILE EMPLOYEE
 ANLB/A40 ='THIS IS AN An FIELD;WITH A LINE BREAK.';
@@ -2011,6 +2011,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1741
 
-Positioning Data in a Report
+Positioning Data in a Report
 
 1742

--- a/specifications/creating_reports/creating_reports_24_chapter24.md
+++ b/specifications/creating_reports/creating_reports_24_chapter24.md
@@ -59,7 +59,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1743
 
-The GRAPH Command
+The GRAPH Command
 
 Graphs allow you to display multivariate or complex data efficiently, precisely, and in a way that
 a viewer can intuitively grasp. A graph is an effective presentation tool because it presents a
@@ -110,7 +110,7 @@ PRINT), and the sort phrase(s) used (ACROSS or BY).
 
 1744
 
-Similarities Between GRAPH and TABLE
+Similarities Between GRAPH and TABLE
 
 24. Creating a Graph
 
@@ -162,7 +162,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1745
 
-The GRAPH Command
+The GRAPH Command
 
 Example:
 
@@ -200,7 +200,7 @@ END
 
 1746
 
-The output is:
+The output is:
 
 24. Creating a Graph
 
@@ -235,7 +235,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1747
 
-Creating an HTML5 Graph
+Creating an HTML5 Graph
 
 GRAPH FILE GGSALES
 SUM DOLLARS BUDDOLLARS
@@ -269,7 +269,7 @@ resizes the graph output if the container is resized.
 
 1748
 
-24. Creating a Graph
+24. Creating a Graph
 
 Selecting a Graph Type
 
@@ -318,7 +318,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1749
 
-Selecting a Graph Type
+Selecting a Graph Type
 
 It is important to note that scatter graphs and line graphs are distinguishable from one
 another only by virtue of their X-axis format. Line graphs can appear without connecting
@@ -364,7 +364,7 @@ you are plotting are relatively small in range.
 
 1750
 
-24. Creating a Graph
+24. Creating a Graph
 
 A logarithmic scale is a scale in which the values increase logarithmically. Each measure along
 the scale represents an exponential increase in the data value. Logarithmic scales are useful
@@ -422,7 +422,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1751
 
-Selecting a Graph Type
+Selecting a Graph Type
 
 Graph Type
 
@@ -489,7 +489,7 @@ AND
 
 1752
 
-24. Creating a Graph
+24. Creating a Graph
 
 sortfield
 
@@ -520,7 +520,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1753
 
-Selecting a Graph Type
+Selecting a Graph Type
 
 Syntax:
 
@@ -578,7 +578,7 @@ Is the name of an alphanumeric field to be displayed on the X-axis of the graph.
 
 1754
 
-24. Creating a Graph
+24. Creating a Graph
 
 Example:
 
@@ -614,7 +614,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1755
 
-Selecting a Graph Type
+Selecting a Graph Type
 
 The output is:
 
@@ -643,7 +643,7 @@ names and does not affect the graph.
 
 1756
 
-24. Creating a Graph
+24. Creating a Graph
 
 sortfield
 
@@ -672,7 +672,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1757
 
-Selecting a Graph Type
+Selecting a Graph Type
 
 Syntax:
 
@@ -718,7 +718,7 @@ END
 
 1758
 
-The output is:
+The output is:
 
 24. Creating a Graph
 
@@ -756,7 +756,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1759
 
-Selecting a Graph Type
+Selecting a Graph Type
 
 Style Options for Three-Dimensional Graphs on page 1763.
 
@@ -824,7 +824,7 @@ A vertical connected point plot graph.
 
 1760
 
-24. Creating a Graph
+24. Creating a Graph
 
 SET LOOKGRAPH=
 
@@ -904,7 +904,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1761
 
-Selecting a Graph Type
+Selecting a Graph Type
 
 SET LOOKGRAPH=
 
@@ -976,7 +976,7 @@ Multiple, ring-shaped pie graphs.
 
 1762
 
-Reference: Style Options for Scatter Graphs
+Reference: Style Options for Scatter Graphs
 
 Choose one of the following LOOKGRAPH values to change the style of scatter graphs:
 
@@ -1049,7 +1049,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1763
 
-Selecting a Graph Type
+Selecting a Graph Type
 
 SET LOOKGRAPH=
 
@@ -1126,7 +1126,7 @@ A horizontal area graph.
 
 1764
 
-24. Creating a Graph
+24. Creating a Graph
 
 SET LOOKGRAPH=
 
@@ -1192,7 +1192,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1765
 
-Selecting a Graph Type
+Selecting a Graph Type
 
 SET LOOKGRAPH=
 
@@ -1256,7 +1256,7 @@ A high-low-volume candle stock chart.
 
 1766
 
-24. Creating a Graph
+24. Creating a Graph
 
 Reference: Style Options for Polar Charts
 
@@ -1324,7 +1324,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1767
 
-Selecting a Graph Type
+Selecting a Graph Type
 
 Reference: Style Options for Spectral Charts
 
@@ -1381,7 +1381,7 @@ manage them.
 
 1768
 
-Reference: Options for HTML5-Only Chart Types
+Reference: Options for HTML5-Only Chart Types
 
 The following LOOKGRAPH values are valid only when generating an HTML5 chart:
 
@@ -1443,7 +1443,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1769
 
-Selecting Values for the X and Y Axes
+Selecting Values for the X and Y Axes
 
 The X-axis value is determined by the sort phrase (BY or ACROSS) used in your GRAPH
 request. At least one sort phrase is required in every GRAPH request. When there are multiple
@@ -1479,7 +1479,7 @@ END
 
 1770
 
-The output is:
+The output is:
 
 24. Creating a Graph
 
@@ -1505,7 +1505,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1771
 
-Creating Multiple Graphs
+Creating Multiple Graphs
 
 Example:
 
@@ -1542,7 +1542,7 @@ in the same request.
 
 1772
 
-24. Creating a Graph
+24. Creating a Graph
 
 With GRMERGE ON, WebFOCUS creates one merged graph.
 
@@ -1601,7 +1601,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1773
 
-Creating Multiple Graphs
+Creating Multiple Graphs
 
 The syntax for the GRMULTIGRAPH, GRLEGEND, and GRXAXIS parameters is:
 
@@ -1636,7 +1636,7 @@ END
 
 1774
 
-The output is:
+The output is:
 
 24. Creating a Graph
 
@@ -1662,7 +1662,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1775
 
-Creating Multiple Graphs
+Creating Multiple Graphs
 
 The first graph is for region Midwest. The legend distinguishes State-Category combinations by
 color, and the PRODUCT sort field is repeated on the X-axis for each State-Category
@@ -1694,7 +1694,7 @@ OFF
 
 1776
 
-Example: Merging OLAP-Enabled Graphs
+Example: Merging OLAP-Enabled Graphs
 
 The following OLAP request against the EMPLOYEE data source has two BY fields. To merge
 the graphs, the SET OLAPGRMERGE=ON command is issued:
@@ -1737,7 +1737,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1777
 
-Creating Multiple Graphs
+Creating Multiple Graphs
 
 Displaying Multiple Graphs in Columns
 
@@ -1782,7 +1782,7 @@ The output is:
 
 1778
 
-Plotting Dates in Graphs
+Plotting Dates in Graphs
 
 24. Creating a Graph
 
@@ -1832,7 +1832,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1779
 
-Plotting Dates in Graphs
+Plotting Dates in Graphs
 
 The output is:
 
@@ -1864,7 +1864,7 @@ setTextFormatPreset(getY1Label(),xx); // for Y Axis
 
 1780
 
-24. Creating a Graph
+24. Creating a Graph
 
 The default date format for Data Text is LONG. This only applies to graphs with dates on
 the Y axis. Currently this format is not supported on the X axis. You can overwrite the
@@ -1928,7 +1928,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1781
 
-Displaying Missing Data Values in a Graph
+Displaying Missing Data Values in a Graph
 
 For details on WHERE, WHERE TOTAL, and IF phrases, see Selecting Records for Your Report
 on page 217.
@@ -1965,7 +1965,7 @@ graph.
 
 1782
 
-24. Creating a Graph
+24. Creating a Graph
 
 Dotted line to zero. In line graphs, a dotted line connects the missing value with the
 succeeding value. In 3D bar graphs, solid lines outline the flat bar corresponding to the
@@ -2022,7 +2022,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1783
 
-Displaying Missing Data Values in a Graph
+Displaying Missing Data Values in a Graph
 
 setFillMissingData(2); displays missing values as an interpolated dotted line.
 
@@ -2053,7 +2053,7 @@ The output is:
 
 1784
 
-Example:
+Example:
 
 Displaying Missing Values as a Gap
 
@@ -2085,7 +2085,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1785
 
-Displaying Missing Data Values in a Graph
+Displaying Missing Data Values in a Graph
 
 Example:
 
@@ -2115,7 +2115,7 @@ The output is:
 
 1786
 
-Example:
+Example:
 
 Displaying Missing Values as an Interpolated Dotted Line
 
@@ -2152,7 +2152,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1787
 
-Applying Conditional Styling to a Graph
+Applying Conditional Styling to a Graph
 
 For example, you can apply the color red to all departments that did not reach their sales
 quotas and apply the color black to all departments that did reach their sales quotas. In this
@@ -2205,7 +2205,7 @@ list of valid colors, see Formatting Report Data on page 1697.
 
 1788
 
-24. Creating a Graph
+24. Creating a Graph
 
 expression
 
@@ -2250,7 +2250,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1789
 
-Linking Graphs to Other Resources
+Linking Graphs to Other Resources
 
 The output is:
 
@@ -2280,7 +2280,7 @@ SET JSURLS='/file1 [/file2] [/file3]...'
 
 1790
 
-24. Creating a Graph
+24. Creating a Graph
 
 where:
 
@@ -2339,7 +2339,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1791
 
-Linking Graphs to Other Resources
+Linking Graphs to Other Resources
 
 You can specify the name or the position of a graph column.
 
@@ -2384,7 +2384,7 @@ END
 
 1792
 
-The output is:
+The output is:
 
 24. Creating a Graph
 
@@ -2421,7 +2421,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1793
 
-Linking Graphs to Other Resources
+Linking Graphs to Other Resources
 
 url
 
@@ -2476,7 +2476,7 @@ details, see Creating Parameters on page 854.
 
 1794
 
-24. Creating a Graph
+24. Creating a Graph
 
 Note:
 
@@ -2530,7 +2530,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1795
 
-Linking Graphs to Other Resources
+Linking Graphs to Other Resources
 
 For more information about the -HTMLFORM command, see the Developing Reporting
 Applications manual.
@@ -2585,7 +2585,7 @@ example, FOCEXEC or URL) before the first DRILLMENUITEM.
 
 1796
 
-24. Creating a Graph
+24. Creating a Graph
 
 The menu created by the DRILLMENUITEM keyword is styled using a Cascading Stylesheet file.
 The file is /ibi/WebFOCUSxx/ibi_apps/ibi_html/javaassist/ibi/html/js/multidrill.css, where xx
@@ -2635,7 +2635,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1797
 
-Adding Labels to a Graph
+Adding Labels to a Graph
 
 Creating Parameters
 
@@ -2681,7 +2681,7 @@ END
 
 1798
 
-The output is:
+The output is:
 
 24. Creating a Graph
 
@@ -2709,7 +2709,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1799
 
-Applying Custom Styling to a Graph
+Applying Custom Styling to a Graph
 
 For details on customizing graph headings and footings, see Using Headings, Footings, Titles,
 and Labels on page 1517.
@@ -2766,7 +2766,7 @@ and offer some additional control when you run the request.
 
 1800
 
-For example, the BSTACK parameter enables you to specify that the bars on a bar graph are to
+For example, the BSTACK parameter enables you to specify that the bars on a bar graph are to
 be stacked rather than placed side by side.
 
 Syntax:
@@ -2826,7 +2826,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1801
 
-Applying Custom Styling to a Graph
+Applying Custom Styling to a Graph
 
 Graph SET Parameter
 
@@ -2894,7 +2894,7 @@ default.
 
 1802
 
-Graph SET Parameter
+Graph SET Parameter
 
 Values
 
@@ -2969,7 +2969,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1803
 
-Applying Custom Styling to a Graph
+Applying Custom Styling to a Graph
 
 Graph SET Parameter
 
@@ -3044,7 +3044,7 @@ automatic scaling is not used
 
 1804
 
-Graph SET Parameter
+Graph SET Parameter
 
 Values
 
@@ -3110,7 +3110,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1805
 
-Applying Custom Styling to a Graph
+Applying Custom Styling to a Graph
 
 HMAX=nn
 
@@ -3163,7 +3163,7 @@ displayed to indicate that some of the data extracted is not reflected on the gr
 
 1806
 
-24. Creating a Graph
+24. Creating a Graph
 
 Customizing Graphs Using the Graph API and HTML5 JSON Properties
 
@@ -3216,7 +3216,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1807
 
-Applying Custom Styling to a Graph
+Applying Custom Styling to a Graph
 
 JSON
 
@@ -3266,7 +3266,7 @@ where:
 
 1808
 
-The output is:
+The output is:
 
 24. Creating a Graph
 
@@ -3296,7 +3296,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1809
 
-Saving a Graph as an Image File
+Saving a Graph as an Image File
 
 Procedure: How to Save a Graph as an Image File Using GRAPHSERVURL
 
@@ -3356,7 +3356,7 @@ Is the URL to invoke the WebFOCUS Graph Servlet. The maximum number of character
 
 1810
 
-24. Creating a Graph
+24. Creating a Graph
 
 file
 
@@ -3414,7 +3414,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1811
 
-Saving a Graph as an Image File
+Saving a Graph as an Image File
 
 <HTML>
 <HEAD>
@@ -3439,7 +3439,7 @@ would schedule the actual procedure, in this case HOLDGIF, to distribute the rep
 
 1812
 
-4. Click the link to run the report. The report looks like this:
+4. Click the link to run the report. The report looks like this:
 
 24. Creating a Graph
 
@@ -3470,7 +3470,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1813
 
-Printing a Graph
+Printing a Graph
 
 Reference: Usage Notes for Saving a Graph
 
@@ -3518,7 +3518,7 @@ From the browser, select Print from the File menu.
 
 1814
 
-24. Creating a Graph
+24. Creating a Graph
 
 Syntax:
 
@@ -3552,6 +3552,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1815
 
-Printing a Graph
+Printing a Graph
 
 1816

--- a/specifications/creating_reports/creating_reports_25_chapter25.md
+++ b/specifications/creating_reports/creating_reports_25_chapter25.md
@@ -65,7 +65,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1817
 
-Reporting With FML
+Reporting With FML
 
 Procedures using FML are not hard-wired to the data. As in any other report request, they can
 easily be changed. FML includes the following facilities:
@@ -103,7 +103,7 @@ procedure lines correspond to explanations that follow the request.
 
 1818
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
    TABLE FILE FINANCE
    HEADING CENTER
@@ -165,7 +165,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1819
 
-Creating Rows From Data
+Creating Rows From Data
 
 The output is shown as follows.
 
@@ -181,7 +181,7 @@ Rows appear only for values that are retrieved from the file.
 
 1820
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 You can only insert free text between rows when a sort field changes value, such as:
 
@@ -239,7 +239,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1821
 
-Creating Rows From Data
+Creating Rows From Data
 
 value
 
@@ -295,7 +295,7 @@ of ACCOUNT is represented by a tag (1010, 1020, and so on), and displays as a se
 
 
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 TABLE FILE LEDGER
 SUM AMOUNT
@@ -343,7 +343,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1823
 
-Creating Rows From Data
+Creating Rows From Data
 
 Syntax:
 
@@ -404,7 +404,7 @@ INVENTORY            27,307
 
 1824
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Syntax:
 
@@ -463,7 +463,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1825
 
-Creating Rows From Data
+Creating Rows From Data
 
 Syntax:
 
@@ -525,7 +525,7 @@ line in the report output for which it matches the tag references.
 
 1826
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 OFF
 
@@ -585,7 +585,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1827
 
 
-Creating Rows From Data
+Creating Rows From Data
 
 Example:
 
@@ -619,7 +619,7 @@ a request that uses the FOR phrase.
 
 1828
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Combining BY and FOR Phrases in an FML Request
 
@@ -679,7 +679,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-Supplying Data Directly in a Request
+Supplying Data Directly in a Request
 
 Syntax:
 
@@ -733,7 +733,7 @@ originally specified.
 1830
 
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 The output is shown in the following image.
 
@@ -782,7 +782,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1831
 
-Referring to Rows in Calculations
+Referring to Rows in Calculations
 
 The expression can include references to specific rows using the default FML positional
 labels (R1, R2, and so on), or it can refer to rows, columns, and cells using a variety of
@@ -831,7 +831,7 @@ expressions.
 
 1832
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Note: Default labels are not assigned to rows that contain underlines, blank lines, or free text,
 since these row types need not be referenced in expressions.
@@ -887,7 +887,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1833
 
-Referring to Rows in Calculations
+Referring to Rows in Calculations
 
 Even if you assign an explicit label, the positional label (R1, R2, and so on) is retained
 internally.
@@ -948,7 +948,7 @@ functions as an explicit label.
 
 1834
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Using Labels to Repeat Rows
 
@@ -1001,7 +1001,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1835
 
-Referring to Columns in Calculations
+Referring to Columns in Calculations
 
 DEFINE FILE LEDGER
 CUR_YR/I5C=AMOUNT;
@@ -1036,7 +1036,7 @@ columns, place the column number in parentheses after the label name.
 1836
 
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Example:
 
@@ -1087,7 +1087,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1837
 
 
-Referring to Columns in Calculations
+Referring to Columns in Calculations
 
 Example:
 
@@ -1142,7 +1142,7 @@ Is the starting column.
 1838
 
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 e
 
@@ -1192,7 +1192,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1839
 
-Referring to Columns in Calculations
+Referring to Columns in Calculations
 
 Applying Relative Column Addressing in a RECAP Expression
 
@@ -1238,7 +1238,7 @@ to refer to these columns in your request.
 1840
 
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Syntax:
 
@@ -1297,7 +1297,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1841
 
-Referring to Rows and Columns in Calculations
+Referring to Rows and Columns in Calculations
 
 The output is shown in the following image.
 
@@ -1308,7 +1308,7 @@ after the last ACROSS value.
 
 1842
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Example:
 
@@ -1339,7 +1339,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1843
 
-Referring to Cells in Calculations
+Referring to Cells in Calculations
 
 Syntax:
 
@@ -1400,7 +1400,7 @@ WEST--VARIANCE                          -121
 1844
 
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Note: In addition to illustrating cell notation, this example demonstrates the use of column
 numbering. Notice that the display of the EAST and WEST VARIANCEs in columns 1 and 3,
@@ -1453,7 +1453,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1845
 
-Using Functions in RECAP Calculations
+Using Functions in RECAP Calculations
 
 input1, inputn
 
@@ -1484,7 +1484,7 @@ RECAP statement.
 
 1846
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 The request is:
 
@@ -1523,7 +1523,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1847
 
-Inserting Rows of Free Text
+Inserting Rows of Free Text
 
 Example:
 
@@ -1585,7 +1585,7 @@ c
 1848
 
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 >
 
@@ -1638,7 +1638,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1849
 
-Adding a Column to an FML Report
+Adding a Column to an FML Report
 
 DEFINE FILE LEDGER
 CUR_YR/I5C=AMOUNT;
@@ -1687,7 +1687,7 @@ END
 
 
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 The output is shown as follows.
 
@@ -1695,7 +1695,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1851
 
-Creating a Recursive Model
+Creating a Recursive Model
 
 Creating a Recursive Model
 
@@ -1726,7 +1726,7 @@ the next year of STARTING CASH.
 
 1852
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 DEFINE FILE REGION
 CUR_YR=E_ACTUAL;
@@ -1771,7 +1771,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1853
 
 
-Reporting Dynamically From a Hierarchy
+Reporting Dynamically From a Hierarchy
 
 By examining these fields, it is possible to construct the entire organization chart or chart of
 accounts structure. However, to print the chart in a traditional FML report, you need to list the
@@ -1811,7 +1811,7 @@ the session ends.
 
 1854
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 2. In the FOR phrase of the FML request. Use the GET/WITH CHILDREN or ADD phrase to
 
@@ -1871,7 +1871,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1855
 
-Reporting Dynamically From a Hierarchy
+Reporting Dynamically From a Hierarchy
 
 The CENTSYSF data source contains detail-level financial data. This is unconsolidated financial
 data for a fictional corporation, CenturyCorp. It is designed to be separate from the CENTGL
@@ -1926,7 +1926,7 @@ Is the parent value for which the children are to be retrieved.
 
 1856
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 GET CHILDREN
 
@@ -1979,7 +1979,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1857
 
-Reporting Dynamically From a Hierarchy
+Reporting Dynamically From a Hierarchy
 
 Example:
 
@@ -2023,7 +2023,7 @@ must be in effect.
 
 1858
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Displaying an FML Hierarchy With Captions
 
@@ -2078,7 +2078,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1859
 
-Reporting Dynamically From a Hierarchy
+Reporting Dynamically From a Hierarchy
 
 When used in conjunction with WITH CHILDREN, ADD first displays a line in the report output
 that consists of the summation of the parent value and all of its children. Then it displays
@@ -2128,7 +2128,7 @@ OR CHILD2 OR CHILD3 and more, if applicable.
 
 1860
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 To display the sum of just the children, you must display the parent row, display the
 summary row, and use a RECAP to subtract the parent row from the sum. For example:
@@ -2168,7 +2168,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1861
 
-Reporting Dynamically From a Hierarchy
+Reporting Dynamically From a Hierarchy
 
 Example:
 
@@ -2204,7 +2204,7 @@ The output is shown as follows.
 
 1862
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Syntax:
 
@@ -2260,7 +2260,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1863
 
-Reporting Dynamically From a Hierarchy
+Reporting Dynamically From a Hierarchy
 
 m|ALL
 
@@ -2316,7 +2316,7 @@ segment.
 
 1864
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 In the following output, the top portion shows the detail-level data. The bottom portion shows
 the consolidated data. In the consolidated portion of the report:
@@ -2335,14 +2335,14 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1865
 
-Reporting Dynamically From a Hierarchy
+Reporting Dynamically From a Hierarchy
 
 Using GET CHILDREN instead of WITH CHILDREN eliminates the top line from each portion of
 the output. The remaining lines are the same.
 
 1866
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 The following request displays a consolidated line for account 2000 and each of its direct
 children and grandchildren.
@@ -2381,7 +2381,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1867
 
-Reporting Dynamically From a Hierarchy
+Reporting Dynamically From a Hierarchy
 
 The resulting chart contains the following information. It may also contain the associated
 captions, depending on whether the AS CAPTION phrase was used in the request.
@@ -2437,7 +2437,7 @@ TABLE FILE A ...
 
 1868
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 requestfile
 
@@ -2488,7 +2488,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1869
 
-Customizing a Row Title
+Customizing a Row Title
 
 Customizing a Row Title
 
@@ -2547,7 +2547,7 @@ meaningful identifications for the corresponding tags.
 
 1870
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 TABLE FILE LEDGER
 SUM AMOUNT FOR ACCOUNT
@@ -2605,7 +2605,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1871
 
-Formatting an FML Report
+Formatting an FML Report
 
 Formatting rows, columns, and cells. You can apply StyleSheet attributes, such as FONT,
 SIZE, STYLE, and COLOR, to individual rows and columns, or to cells within those rows.
@@ -2663,7 +2663,7 @@ TOTCASH          21,239
 
 1872
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Notice that the BAR ... OVER phrase underlines only the column containing the display field.
 
@@ -2702,7 +2702,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1873
 
-Formatting an FML Report
+Formatting an FML Report
 
 The output is shown as follows.
 
@@ -2726,7 +2726,7 @@ FREETEXT denotes a free text or a blank row with the specified label.
 
 1874
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 UNDERLINE denotes underlines generated by BAR. Formatting of an underline is supported
 for PDF and PS, but not for HTML reports.
@@ -2782,7 +2782,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1875
 
-Formatting an FML Report
+Formatting an FML Report
 
 The output is shown in the following image.
 
@@ -2815,7 +2815,7 @@ the StyleSheet declaration. In this case, the column (N2) within the row (CA).
 
 1876
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 SET PAGE-NUM=OFF
 TABLE FILE LEDGER
@@ -2858,7 +2858,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1877
 
-Formatting an FML Report
+Formatting an FML Report
 
 The output is shown in the following image.
 
@@ -2886,7 +2886,7 @@ END
 
 1878
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 The output is shown in the following image.
 
@@ -2918,7 +2918,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1879
 
-Formatting an FML Report
+Formatting an FML Report
 
 The output is shown in the following image.
 
@@ -2946,7 +2946,7 @@ The output is shown in the following image.
 
 1880
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Applying Boldface to an FML RECAP Row
 
@@ -2995,7 +2995,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1881
 
-Formatting an FML Report
+Formatting an FML Report
 
 TYPE=REPORT, LABEL=row_label, [COLUMN=column,] BORDER-position=option,
 [BORDER-[position-]STYLE=line_style,]
@@ -3045,7 +3045,7 @@ format line width, line style, and line color individually, for any side of the 
 
 1882
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 line_style
 
@@ -3094,7 +3094,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1883
 
-Formatting an FML Report
+Formatting an FML Report
 
 SET PAGE-NUM=OFF
 TABLE FILE LEDGER
@@ -3116,7 +3116,7 @@ The output is shown in the following image.
 
 1884
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Example:
 
@@ -3166,7 +3166,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1885
 
-Formatting an FML Report
+Formatting an FML Report
 
 SET PAGE-NUM=OFF
 TABLE FILE LEDGER
@@ -3213,7 +3213,7 @@ Is a value of forfield to be displayed on a row of the FML report.
 
 1886
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 n
 
@@ -3263,7 +3263,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1887
 
-Formatting an FML Report
+Formatting an FML Report
 
 Example:
 
@@ -3323,7 +3323,7 @@ END
 
 1888
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 The output is shown as follows.
 
@@ -3380,7 +3380,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1889
 
-Formatting an FML Report
+Formatting an FML Report
 
 n
 
@@ -3414,7 +3414,7 @@ END
 
 1890
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 The output is shown in the following image.
 
@@ -3443,7 +3443,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1891
 
-Suppressing the Display of Rows
+Suppressing the Display of Rows
 
 The output is shown in the following image.
 
@@ -3469,7 +3469,7 @@ in the report.
 
 1892
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 DEFINE FILE REGION
 AMOUNT/I5C=E_ACTUAL;
@@ -3522,7 +3522,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1893
 
 
-Saving and Retrieving Intermediate Report Results
+Saving and Retrieving Intermediate Report Results
 
 Saving and Retrieving Intermediate Report Results
 
@@ -3562,7 +3562,7 @@ Posting Data
 
 1894
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 Syntax:
 
@@ -3620,7 +3620,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1895
 
-Saving and Retrieving Intermediate Report Results
+Saving and Retrieving Intermediate Report Results
 
 id
 
@@ -3672,7 +3672,7 @@ END
 
 1896
 
-25. Creating Financial Reports With Financial Modeling Language (FML)
+25. Creating Financial Reports With Financial Modeling Language (FML)
 
 The output is shown in the following image.
 
@@ -3723,7 +3723,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1897
 
-Creating HOLD Files From FML Reports
+Creating HOLD Files From FML Reports
 
 Query the HOLD file:
 

--- a/specifications/creating_reports/creating_reports_26_chapter26.md
+++ b/specifications/creating_reports/creating_reports_26_chapter26.md
@@ -49,7 +49,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1899
 
-Creating a Free-Form Report
+Creating a Free-Form Report
 
 BY phrases
 
@@ -91,7 +91,7 @@ employee in the Production department.
 
 1900
 
-The following diagram simulates the output you would see if you ran the procedure in the
+The following diagram simulates the output you would see if you ran the procedure in the
 example named Request for EMPLOYEE EDUCATION HOURS REPORT on page 1902.
 
 26. Creating a Free-Form Report
@@ -100,7 +100,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1901
 
-Creating a Free-Form Report
+Creating a Free-Form Report
 
 Example:
 
@@ -162,7 +162,7 @@ the EMPLOYEE data source.
 
 1902
 
-26. Creating a Free-Form Report
+26. Creating a Free-Form Report
 
 4. The heading section, initiated by the HEADING command, defines the body of the report.
 Most of the text and data fields that display in the report are specified in the heading
@@ -221,7 +221,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1903
 
-Designing a Free-Form Report
+Designing a Free-Form Report
 
 Use the HEADING command to define the body of a free-form report, and the FOOTING
 command to define what appears at the bottom of each page of a report. A footing is optional.
@@ -272,7 +272,7 @@ referenced as follows:
 
 1904
 
-26. Creating a Free-Form Report
+26. Creating a Free-Form Report
 
 "<10>| EDUCATION CREDITS EARNED <CR_EARNED>|"
 
@@ -320,7 +320,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1905
 
-Designing a Free-Form Report
+Designing a Free-Form Report
 
 The sample request (see the example named Request for EMPLOYEE EDUCATION HOURS
 REPORT on page 1902) illustrates this feature. The first two examples show how to position

--- a/specifications/creating_reports/creating_reports_27_chapter27.md
+++ b/specifications/creating_reports/creating_reports_27_chapter27.md
@@ -45,7 +45,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1907
 
-Supported and Unsupported SQL Statements
+Supported and Unsupported SQL Statements
 
 Reference: Supported SQL Statements
 
@@ -96,7 +96,7 @@ The following aggregate functions: COUNT, MIN, MAX, SUM, and AVG.
 
 1908
 
-27. Using SQL to Create Reports
+27. Using SQL to Create Reports
 
 The following expressions can appear in conditions: CASE, NULLIF, and COALESCE.
 
@@ -150,7 +150,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1909
 
-Using SQL Translator Commands
+Using SQL Translator Commands
 
 Correlated subqueries for DML Generation.
 
@@ -205,7 +205,7 @@ Is the SQL command identifier, which invokes the SQL Translator.
 
 1910
 
-27. Using SQL to Create Reports
+27. Using SQL to Create Reports
 
 Note: The SQL command components must appear in the order represented above.
 
@@ -265,7 +265,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1911
 
-Using SQL Translator Commands
+Using SQL Translator Commands
 
 You may specify headings and footings, describe actions with an ON phrase, or use the ON
 TABLE SET command. Additionally, you can use ON TABLE HOLD or ON TABLE PCHOLD to
@@ -311,7 +311,7 @@ using an equal (=) sign, are supported. For example: WHERE field = (SELECT ...).
 
 1912
 
-27. Using SQL to Create Reports
+27. Using SQL to Create Reports
 
 The SQL UNION operator translates to a TABLE request that creates a HOLD file for each data
 source specified, followed by a MATCH command with option HOLD OLD-OR-NEW, which
@@ -363,7 +363,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1913
 
-Using SQL Translator Commands
+Using SQL Translator Commands
 
 Variation 2
 
@@ -409,7 +409,7 @@ Is the join condition.
 
 1914
 
-27. Using SQL to Create Reports
+27. Using SQL to Create Reports
 
 Syntax:
 
@@ -470,7 +470,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1915
 
-Using SQL Translator Commands
+Using SQL Translator Commands
 
 nn
 
@@ -529,7 +529,7 @@ temporary HOLD files.
 
 1916
 
-Reference: SQL Join Considerations
+Reference: SQL Join Considerations
 
 27. Using SQL to Create Reports
 
@@ -580,7 +580,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1917
 
-Using SQL Translator Commands
+Using SQL Translator Commands
 
 When using the CREATE TABLE and INSERT INTO commands, the data type FLOAT should
 be declared with a precision and used in an INSERT INTO command without the 'E'
@@ -619,7 +619,7 @@ HOLD files, see Saving and Reusing Your Report Output on page 471.
 
 1918
 
-27. Using SQL to Create Reports
+27. Using SQL to Create Reports
 
 Syntax:
 
@@ -681,7 +681,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1919
 
-Using SQL Translator Commands
+Using SQL Translator Commands
 
 Cartesian Product Style Answer Sets
 
@@ -736,7 +736,7 @@ The following field identifier can be included in a request:
 
 1920
 
-27. Using SQL to Create Reports
+27. Using SQL to Create Reports
 
 Example:
 
@@ -789,7 +789,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1921
 
-SQL Translator Support for Date, Time, and Timestamp Fields
+SQL Translator Support for Date, Time, and Timestamp Fields
 
 All date formats for actual and virtual fields in the Master File are converted to the form
 YYYYMMDD. If you specify a format that lacks any component, the SQL Translator supplies a
@@ -883,7 +883,7 @@ Time information may be given to the hour, minute, second, or fraction of a seco
 
 1922
 
-27. Using SQL to Create Reports
+27. Using SQL to Create Reports
 
 The separator within date information may be either a hyphen or a slash.
 
@@ -946,7 +946,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1923
 
-SQL Translator Support for Date, Time, and Timestamp Fields
+SQL Translator Support for Date, Time, and Timestamp Fields
 
 Example:
 
@@ -999,7 +999,7 @@ END
 
 1924
 
-27. Using SQL to Create Reports
+27. Using SQL to Create Reports
 
 The output is:
 
@@ -1062,7 +1062,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1925
 
-Index Optimized Retrieval
+Index Optimized Retrieval
 
 Index Optimized Retrieval
 
@@ -1112,7 +1112,7 @@ relative sizes of the tables being joined.
 
 1926
 
-27. Using SQL to Create Reports
+27. Using SQL to Create Reports
 
 If the analysis results in joining to a table that cannot participate as a cross-referenced file
 according to FOCUS rules (because it lacks an index, for example), the Translator generates
@@ -1167,7 +1167,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1927
 
-SQL INSERT, UPDATE, and DELETE Commands
+SQL INSERT, UPDATE, and DELETE Commands
 
 If you are modifying every field in the row, you can omit the list of field names from the
 command.

--- a/specifications/creating_reports/creating_reports_28_chapter28.md
+++ b/specifications/creating_reports/creating_reports_28_chapter28.md
@@ -46,7 +46,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1929
 
-Rotating a Data Structure for Enhanced Retrieval
+Rotating a Data Structure for Enhanced Retrieval
 
 Change the path structure of a data source. This option is especially helpful if you wish to
 create a report using several sort fields that are on different paths in the file. By changing
@@ -72,7 +72,7 @@ TABLE FILE filename.fieldname
 
 1930
 
-Reference: Usage Notes for Restructuring Data
+Reference: Usage Notes for Restructuring Data
 
 28. Improving Report Processing
 
@@ -105,7 +105,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1931
 
-Optimizing Retrieval Speed for FOCUS Data Sources
+Optimizing Retrieval Speed for FOCUS Data Sources
 
 You could issue the following request to promote the segment containing PROD_CODE to the
 top of the hierarchy, thereby enabling quicker access to the data in that segment.
@@ -154,7 +154,7 @@ For related information on AUTOINDEX, see the Developing Reporting Applications 
 
 1932
 
-28. Improving Report Processing
+28. Improving Report Processing
 
 Syntax:
 
@@ -196,7 +196,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1933
 
-Automatic Indexed Retrieval
+Automatic Indexed Retrieval
 
 Example:
 
@@ -244,7 +244,7 @@ END
 
 1934
 
-28. Improving Report Processing
+28. Improving Report Processing
 
 Indexed retrieval is not invoked if the equality or range test is run against an indexed field that
 does not reside in the highest referenced segment. In the following example, indexed retrieval
@@ -294,7 +294,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1935
 
-Compiling Expressions
+Compiling Expressions
 
 Example:
 

--- a/specifications/creating_reports/creating_reports_29_appendix_a.md
+++ b/specifications/creating_reports/creating_reports_29_appendix_a.md
@@ -67,7 +67,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-EMPLOYEE Data Source
+EMPLOYEE Data Source
 
 PAYINFO
 
@@ -115,7 +115,7 @@ Lists the dates that employees attended in-house courses.
 
 
 
-COURSEG (from EDUCFILE)
+COURSEG (from EDUCFILE)
 
 Lists the courses that the employees attended.
 
@@ -167,7 +167,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1939
 
-JOBFILE Data Source
+JOBFILE Data Source
 
 EMPLOYEE Structure Diagram
 
@@ -185,7 +185,7 @@ Describes what each position is. The field JOBCODE in this segment is indexed.
 
 
 
-A. Master Files and Diagrams
+A. Master Files and Diagrams
 
 SKILLSEG
 
@@ -243,7 +243,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-EDUCFILE Data Source
+EDUCFILE Data Source
 
 EDUCFILE Data Source
 
@@ -273,7 +273,7 @@ FILENAME=EDUCFILE, SUFFIX=FOC
 
 
 
-EDUCFILE Structure Diagram
+EDUCFILE Structure Diagram
 
 SECTION 01
               STRUCTURE OF FOCUS    FILE EDUCFILE ON 05/15/03 AT 14.45.44
@@ -331,7 +331,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-SALES Data Source
+SALES Data Source
 
 SALES Master File
 
@@ -353,7 +353,7 @@ FILENAME=KSALES,   SUFFIX=FOC
 
 1944
 
-SALES Structure Diagram
+SALES Structure Diagram
 
 SECTION 01
              STRUCTURE OF FOCUS    FILE SALES ON 05/15/03 AT 14.50.28
@@ -413,7 +413,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
 
 
-CAR Data Source
+CAR Data Source
 
 COMP
 
@@ -449,7 +449,7 @@ The aliases in the CAR Master File are specified without the ALIAS keyword.
 
 
 
-CAR Master File
+CAR Master File
 
 A. Master Files and Diagrams
 
@@ -486,7 +486,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1947
 
-LEDGER Data Source
+LEDGER Data Source
 
 CAR Structure Diagram
 
@@ -498,7 +498,7 @@ and the commas act as placeholders.
 
 1948
 
-A. Master Files and Diagrams
+A. Master Files and Diagrams
 
 LEDGER Master File
 
@@ -543,7 +543,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1949
 
 
-REGION Data Source
+REGION Data Source
 
 FINANCE Structure Diagram
 
@@ -597,7 +597,7 @@ SECTION 01
 
 
 
-A. Master Files and Diagrams
+A. Master Files and Diagrams
 
 EMPDATA Data Source
 
@@ -649,7 +649,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1951
 
 
-COURSE Data Source
+COURSE Data Source
 
 TRAINING Master File
 
@@ -700,7 +700,7 @@ FILENAME=COURSE,   SUFFIX=FOC
 1952
 
 
-COURSE Structure Diagram
+COURSE Structure Diagram
 
 SECTION 01
              STRUCTURE OF FOCUS    FILE COURSE   ON 05/15/03 AT 12.26.05
@@ -756,7 +756,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1953
 
 
-LOCATOR Data Source
+LOCATOR Data Source
 
 JOBLIST Master File
 
@@ -803,7 +803,7 @@ SEGNAME=LOCATOR,   SEGTYPE=S1,
 
 1954
 
-A. Master Files and Diagrams
+A. Master Files and Diagrams
 
 LOCATOR Structure Diagram
 
@@ -861,7 +861,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1955
 
-SALHIST Data Source
+SALHIST Data Source
 
 SALHIST Data Source
 
@@ -899,7 +899,7 @@ are used in examples that illustrate the use of the Maintain Data facility.
 
 1956
 
-VIDEOTRK Master File
+VIDEOTRK Master File
 
 A. Master Files and Diagrams
 
@@ -931,7 +931,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1957
 
-VIDEOTRK, MOVIES, and ITEMS Data Sources
+VIDEOTRK, MOVIES, and ITEMS Data Sources
 
 VIDEOTRK Structure Diagram
 
@@ -978,7 +978,7 @@ SECTION 01
 1958
 
 
-A. Master Files and Diagrams
+A. Master Files and Diagrams
 
 MOVIES Master File
 
@@ -1025,7 +1025,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1959
 
 
-VIDEOTR2 Data Source
+VIDEOTR2 Data Source
 
 ITEMS Structure Diagram
 
@@ -1077,7 +1077,7 @@ FILENAME=VIDEOTR2, SUFFIX=FOC
 1960
 
 
-VIDEOTR2 Structure Diagram
+VIDEOTR2 Structure Diagram
 
 SECTION 01
      STRUCTURE OF FOCUS    FILE VIDEOTR2 ON 05/15/03 AT 16.45.48
@@ -1138,7 +1138,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1961
 
 
-Gotham Grinds Data Sources
+Gotham Grinds Data Sources
 
 GGPRODS contains product information for Gotham Grinds. It consists of one segment,
 PRODS01.
@@ -1180,7 +1180,7 @@ FILENAME=GGDEMOG, SUFFIX=FOC
 
 1962
 
-GGDEMOG Structure Diagram
+GGDEMOG Structure Diagram
 
 SECTION 01
      STRUCTURE OF FOCUS    FILE GGDEMOG  ON 05/15/03 AT 12.26.05
@@ -1220,7 +1220,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1963
 
 
-Gotham Grinds Data Sources
+Gotham Grinds Data Sources
 
 GGORDER Structure Diagram
 
@@ -1272,7 +1272,7 @@ FILENAME=GGPRODS, SUFFIX=FOC
 1964
 
 
-GGPRODS Structure Diagram
+GGPRODS Structure Diagram
 
 SECTION 01
      STRUCTURE OF FOCUS    FILE GGPRODS  ON 05/15/03 AT 12.26.05
@@ -1326,7 +1326,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1965
 
 
-Gotham Grinds Data Sources
+Gotham Grinds Data Sources
 
 GGSALES Structure Diagram
 
@@ -1383,7 +1383,7 @@ SECTION 01
 
 
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 A. Master Files and Diagrams
 
@@ -1432,7 +1432,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1967
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 CENTCOMP Master File
 
@@ -1483,7 +1483,7 @@ SECTION 01
 1968
 
 
-CENTFIN Master File
+CENTFIN Master File
 
 A. Master Files and Diagrams
 
@@ -1532,7 +1532,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1969
 
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 CENTHR Master File
 
@@ -1582,7 +1582,7 @@ FILE=CENTHR, SUFFIX=FOC
 
 1970
 
-A. Master Files and Diagrams
+A. Master Files and Diagrams
 
   DEFINE BQUARTER/Q=START_DATE;
    TITLE='Beginning,Quarter',
@@ -1636,7 +1636,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1971
 
-Century Corp Data Sources
+Century Corp Data Sources
 
   DEFINE SALARY/D12.2=IF BMONTH LT 4 THEN PAYLEVEL * 12321
    ELSE IF BMONTH GE 4 AND BMONTH LT 8 THEN PAYLEVEL * 13827
@@ -1666,7 +1666,7 @@ SECTION 01
 1972
 
 
-CENTINV Master File
+CENTINV Master File
 
 A. Master Files and Diagrams
 
@@ -1722,7 +1722,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1973
 
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 CENTORD Master File
 
@@ -1770,7 +1770,7 @@ FILE=CENTORD, SUFFIX=FOC
 
 1974
 
-CENTORD Structure Diagram
+CENTORD Structure Diagram
 
 SECTION 01
       STRUCTURE OF FOCUS    FILE CENTORD  ON 05/15/03 AT 10.17.52
@@ -1819,7 +1819,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1975
 
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 CENTQA Master File
 
@@ -1871,7 +1871,7 @@ FILE=CENTQA, SUFFIX=FOC, FDFC=19, FYRT=00
 
 1976
 
-CENTQA Structure Diagram
+CENTQA Structure Diagram
 
 SECTION 01
        STRUCTURE OF FOCUS    FILE CENTQA   ON 05/15/03 AT 10.46.43
@@ -1928,7 +1928,7 @@ Creating Reports With TIBCO® WebFOCUS Language
  1977
 
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 CENTGL Structure Diagram
 
@@ -1978,7 +1978,7 @@ SECTION 01
 
 
 
-CENTSTMT Master File
+CENTSTMT Master File
 
 A. Master Files and Diagrams
 
@@ -2013,7 +2013,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1979
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 CENTSTMT Structure Diagram
 
@@ -2068,7 +2068,7 @@ FIELDNAME=SYS_ACCOUNT,          ALIAS=ALINE,   FORMAT=A6,
 1980
 
 
-CENTGLL Structure Diagram
+CENTGLL Structure Diagram
 
 SECTION 01
        STRUCTURE OF FOCUS    FILE CENTGLL ON 05/15/03 AT 14.45.44
@@ -2091,6 +2091,6 @@ Creating Reports With TIBCO® WebFOCUS Language
  1981
 
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 1982

--- a/specifications/creating_reports/creating_reports_30_appendix_b.md
+++ b/specifications/creating_reports/creating_reports_30_appendix_b.md
@@ -41,6 +41,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1983
 
-Displaying Messages
+Displaying Messages
 
 1984

--- a/specifications/creating_reports/creating_reports_31_appendix_c.md
+++ b/specifications/creating_reports/creating_reports_31_appendix_c.md
@@ -20,7 +20,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1985
 
-TABLE Syntax Summary
+TABLE Syntax Summary
 
 TABLE Syntax Summary
 
@@ -74,7 +74,7 @@ ON   sfld  RECAP   fld1  [/fmt] = FORECAST (fld2, intvl, npredct,
 
 1986
 
-C. Table Syntax Summary and Limits
+C. Table Syntax Summary and Limits
 
 ON {sortfield|TABLE} RECAP y[/fmt] = REGRESS(n, x1, [x2, [x3,]] z);
 ON   sfld  RECAP   fld1  [/fmt] = FORECAST (infield, interval, npredict,
@@ -126,7 +126,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1987
 
-TABLEF Syntax Summary
+TABLEF Syntax Summary
 
 TABLEF Syntax Summary
 
@@ -182,7 +182,7 @@ Variables TABPAGENO, TABLASTPAGE, and BYLASTPAGE.
 
 
 
-C. Table Syntax Summary and Limits
+C. Table Syntax Summary and Limits
 
 SET SQUEEZE
 
@@ -240,7 +240,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1989
 
-FOR Syntax Summary
+FOR Syntax Summary
 
 OLD-AND-NEW
 
@@ -292,7 +292,7 @@ Can be any of the following:
 
 
 
-C. Table Syntax Summary and Limits
+C. Table Syntax Summary and Limits
 
 AS 'text'
 [INDENT m]
@@ -346,7 +346,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1991
 
-TABLE Limits
+TABLE Limits
 
 Maximum size of Alphanumeric fields: 4K characters ( in UTF, this means 12K bytes)
 

--- a/specifications/creating_reports/creating_reports_32_appendix_d.md
+++ b/specifications/creating_reports/creating_reports_32_appendix_d.md
@@ -47,7 +47,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1993
 
-Referring to Fields Using Qualified Field Names
+Referring to Fields Using Qualified Field Names
 
 Adding the letter S to the end of a field name defined in the Master File.
 
@@ -103,7 +103,7 @@ Specifies the activation status of long and qualified field names. Valid identif
 
 1994
 
-D. Referring to Fields in a Report Request
+D. Referring to Fields in a Report Request
 
 NEW specifies that 512-character and qualified field names are supported. NEW is the
 default value.
@@ -156,7 +156,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1995
 
-Displaying a List of Field Names
+Displaying a List of Field Names
 
 To write a report that includes data from every field in the segment, you can issue either of the
 following requests:
@@ -203,7 +203,7 @@ appended in the 32nd position to indicate that the field name is longer than the
 
 1996
 
-Legal and Third-Party Notices
+Legal and Third-Party Notices
 
 SOME TIBCO SOFTWARE EMBEDS OR BUNDLES OTHER TIBCO SOFTWARE. USE OF SUCH
 EMBEDDED OR BUNDLED TIBCO SOFTWARE IS SOLELY TO ENABLE THE FUNCTIONALITY (OR
@@ -251,7 +251,7 @@ DESCRIBED IN THIS DOCUMENT AT ANY TIME.
 
  1997
 
-THE CONTENTS OF THIS DOCUMENT MAY BE MODIFIED AND/OR QUALIFIED, DIRECTLY OR
+THE CONTENTS OF THIS DOCUMENT MAY BE MODIFIED AND/OR QUALIFIED, DIRECTLY OR
 INDIRECTLY, BY OTHER DOCUMENTATION WHICH ACCOMPANIES THIS SOFTWARE, INCLUDING
 BUT NOT LIMITED TO ANY RELEASE NOTES AND "READ ME" FILES.
 
@@ -262,7 +262,7 @@ Copyright © 2021. TIBCO Software Inc. All Rights Reserved.
 
 1998
 
-Index
+Index
 
 _ masking character 248
 
@@ -376,7 +376,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  1999
 
-Index
+Index
 
 adding attributes to WebFOCUS StyleSheets 981,
 
@@ -500,7 +500,7 @@ adding values for numeric fields 51
 
 2000
 
-adding virtual fields 287
+adding virtual fields 287
 
 addition operator 435
 
@@ -626,7 +626,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2001
 
-Index
+Index
 
 assigning classes in cascading style sheets to
 
@@ -748,7 +748,7 @@ BOTTOM 207
 
 bottom margins 1337
 
-Index
+Index
 
 BOTTOMGAP attribute 1341, 1343, 1687
 
@@ -870,7 +870,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2003
 
-Index
+Index
 
 Cartesian product answer sets and SQL Translator
 
@@ -994,7 +994,7 @@ choosing report formatting style sheets 1193
 
 2004
 
-Index
+Index
 
 CLASS attribute 1299, 1306, 1307, 1323
 
@@ -1120,7 +1120,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2005
 
-Index
+Index
 
 COMMA format 514
 
@@ -1244,7 +1244,7 @@ conditional formatting and WHEN phrase 1239,
 
 1241–1244, 1553
 
-Index
+Index
 
 conditional grid formatting 1718, 1719
 
@@ -1370,7 +1370,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2007
 
-Index
+Index
 
 creating bar graphs 1754, 1755
 
@@ -1490,7 +1490,7 @@ creating sort headings 1545
 
 2008
 
-D
+D
 
 data 1262, 1263
 
@@ -1616,7 +1616,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2009
 
-Index
+Index
 
 DEFINE function 361
 
@@ -1740,7 +1740,7 @@ display PRINT command 88
 
 display PRINT commands 39, 41
 
-Index
+Index
 
 display SUM command 50, 51, 88
 
@@ -1864,7 +1864,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2011
 
-Index
+Index
 
 drill through compound reports in PDF format
 
@@ -1986,7 +1986,7 @@ escape characters 253–255
 
 ESSBASE hierarchies 1853
 
-Index
+Index
 
 establishing segment locations 290
 
@@ -2110,7 +2110,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2013
 
-Index
+Index
 
 external cascading style sheet rules BODY
 
@@ -2232,7 +2232,7 @@ file names 820
 
 FILECOMPRESS parameter 586
 
-Index
+Index
 
 FILEDEF command 472, 498
 
@@ -2358,7 +2358,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2015
 
-Index
+Index
 
 font file 625, 627
 
@@ -2480,7 +2480,7 @@ limit 315, 340
 
 2016
 
-Index
+Index
 
 formatting reports 1187, 1189, 1293, 1296,
 
@@ -2602,7 +2602,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2017
 
-Index
+Index
 
 graph formatting with external cascading style
 
@@ -2724,7 +2724,7 @@ hiding columns 1372, 1375
 
 hiding display fields 1371
 
-hiding fields 1372, 1375
+hiding fields 1372, 1375
 
 hiding fields in y-axis 1771
 
@@ -2850,7 +2850,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2019
 
-Index
+Index
 
 HOLD formats 511
 
@@ -2972,7 +2972,7 @@ identifying free text in FML reports 1277
 
 identifying free text in report components 1277
 
-Index
+Index
 
 identifying headings in a style sheet 1277, 1279,
 
@@ -3098,7 +3098,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2021
 
-Index
+Index
 
 inner join structures 1090
 
@@ -3220,7 +3220,7 @@ join structures and virtual fields 1094, 1095,
 
 1097, 1145, 1147
 
-join structures and WHERE phrase 1149
+join structures and WHERE phrase 1149
 
 K
 
@@ -3344,7 +3344,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2023
 
-Index
+Index
 
 limitations of dynamic tables of contents 989
 
@@ -3466,7 +3466,7 @@ linking report pages 1022
 
 loading a hierarchy into memory 1867, 1868
 
-Index
+Index
 
 LOCATOR data source;sample data sources
 
@@ -3590,7 +3590,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2025
 
-Index
+Index
 
 merge phrases and MATCH FILE command 1158,
 
@@ -3714,7 +3714,7 @@ multiple parameters 863
 
 2026
 
-multiple records 1823
+multiple records 1823
 
 NOSPLIT command 1383, 1384
 
@@ -3836,7 +3836,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2027
 
-Index
+Index
 
 optimizing join structures 1926
 
@@ -3958,7 +3958,7 @@ page colors 1331, 1336, 1337
 
 page count 1390, 1392
 
-Index
+Index
 
 page footings 1532, 1536, 1538
 
@@ -4084,7 +4084,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2029
 
-Index
+Index
 
 PDF OPEN/CLOSE and PCHOLD formats 961
 
@@ -4206,7 +4206,7 @@ PostScript fonts 623, 625
 
 PostScript fonts in UNIX 625
 
-Index
+Index
 
 PostScript fonts in Windows 625
 
@@ -4326,7 +4326,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2031
 
-Index
+Index
 
 range of records
 
@@ -4450,7 +4450,7 @@ repeating fields 1076
 
 2032
 
-Index
+Index
 
 repeating fields in join structures 1076
 
@@ -4574,7 +4574,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2033
 
-Index
+Index
 
 restricting sort field values 156, 158, 172, 173
 
@@ -4696,7 +4696,7 @@ ITEMS 1959, 1960
 
 JOBFILE 1940, 1941
 
-sample data sources 1937
+sample data sources 1937
 
 LEDGER 1948, 1949
 
@@ -4822,7 +4822,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2035
 
-Index
+Index
 
 selecting paper size PostScript (PS) format 621
 
@@ -4946,7 +4946,7 @@ SET LINES parameter 1378
 
 2036
 
-Index
+Index
 
 SET LOOKGRAPH parameter 1759, 1760
 
@@ -5072,7 +5072,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2037
 
-Index
+Index
 
 sort field values 172
 
@@ -5196,7 +5196,7 @@ sorting report columns 173, 174
 
 2038
 
-Index
+Index
 
 SQL Translator and CREATE TABLE command
 
@@ -5322,7 +5322,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2039
 
-Index
+Index
 
 StyleSheet CLASS attribute 1306, 1307
 
@@ -5446,7 +5446,7 @@ summing columns 174
 
 2040
 
-summing field values 88
+summing field values 88
 
 summing report columns 174
 
@@ -5570,7 +5570,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2041
 
-Index
+Index
 
 temporary sort fields 95
 
@@ -5690,7 +5690,7 @@ timestamp fields 1921
 
 2042
 
-U
+U
 
 UNDER-LINE option 1440, 1446
 
@@ -5814,7 +5814,7 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2043
 
-Index
+Index
 
 vertical bar graphs 1499
 
@@ -5934,7 +5934,7 @@ WHEN for SAP BW 207
 
 WHEN phrase 378, 427, 429, 1241
 
-WHEN phrase and conditional formatting 1239,
+WHEN phrase and conditional formatting 1239,
 
 WPMINWIDTH parameter 533
 
@@ -6044,6 +6044,6 @@ Creating Reports With TIBCO® WebFOCUS Language
 
  2045
 
-Index
+Index
 
 2046

--- a/specifications/describing_data/describing_data_00_front_matter.md
+++ b/specifications/describing_data/describing_data_00_front_matter.md
@@ -7,7 +7,7 @@ Release 8207
 March 2021
 DN4501688.0321
 
-Copyright© 2021.TIBCOSoftwareInc.AllRightsReserved. Contents
+Copyright© 2021.TIBCOSoftwareInc.AllRightsReserved. Contents
 
 1. Understanding a Data Source Description . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 17
 
@@ -77,7 +77,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  3
 
-Contents
+Contents
 
 LNGPREP Modes. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 60
 
@@ -145,7 +145,7 @@ Implementing a One-to-Many Relationship in a Relational Data Source. . . . . . .
 
 4
 
-Contents
+Contents
 
 Implementing a One-to-Many Relationship in a VSAM or Sequential Data Source. . . . . . . . . 85
 
@@ -215,7 +215,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  5
 
-Contents
+Contents
 
 String Format. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 139
 
@@ -285,7 +285,7 @@ Using a Virtual Field. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 6
 
-Contents
+Contents
 
 Describing a Calculated Value: COMPUTE . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .204
 
@@ -355,7 +355,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  7
 
-Contents
+Contents
 
 Describing Positionally Related Records. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 260
 
@@ -423,7 +423,7 @@ Limits on the Number of Segments, LOCATION Files, Indexes, and Text Fields. . . 
 
 8
 
-Contents
+Contents
 
 Specifying a Physical File Name for a Segment: DATASET. . . . . . . . . . . . . . . . . . . . . . . . . . . .308
 
@@ -493,7 +493,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  9
 
-Contents
+Contents
 
 Using Cross-Referenced Descendant Segments: SEGTYPE = KL and KLU . . . . . . . . . . . . . . . . . . .356
 
@@ -561,7 +561,7 @@ Non-Overridable User Passwords (SET PERMPASS). . . . . . . . . . . . . . . . . .
 
 10
 
-Contents
+Contents
 
 Controlling Case Sensitivity of Passwords. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 412
 
@@ -631,7 +631,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  11
 
-Contents
+Contents
 
 Checking Data Source Integrity: The CHECK Subcommand . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 460
 
@@ -699,7 +699,7 @@ REGION Data Source . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
 12
 
-Contents
+Contents
 
 REGION Master File. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 484
 
@@ -771,7 +771,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  13
 
-Contents
+Contents
 
 VIDEOTR2 Data Source . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 494
 
@@ -841,7 +841,7 @@ CENTSTMT Structure Diagram. . . . . . . . . . . . . . . . . . . . . . . . . . . 
 
 14
 
-Contents
+Contents
 
 CENTGLL Master File. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 514
 
@@ -873,6 +873,6 @@ Describing Data With TIBCO WebFOCUS® Language
 
  15
 
-Contents
+Contents
 
 16

--- a/specifications/describing_data/describing_data_01_chapter1.md
+++ b/specifications/describing_data/describing_data_01_chapter1.md
@@ -46,7 +46,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  17
 
-A Note About Data Source Terminology
+A Note About Data Source Terminology
 
 A Note About Data Source Terminology
 
@@ -85,7 +85,7 @@ data sources, one Access File to describe a data source.
 
 18
 
-How an Application Uses a Data Source Description
+How an Application Uses a Data Source Description
 
 1. Understanding a Data Source Description
 
@@ -142,7 +142,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  19
 
-What Does a Master File Describe?
+What Does a Master File Describe?
 
 Note:
 
@@ -194,7 +194,7 @@ For more information, see Describing an Individual Field on page 103.
 
 20
 
-1. Understanding a Data Source Description
+1. Understanding a Data Source Description
 
 Note: Master Files/data source descriptions must contain uppercase field and segment
 names if you are using them with Maintain Data.
@@ -237,7 +237,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  21
 
-Naming a Master File
+Naming a Master File
 
 Using Long Master File Names on z/OS
 
@@ -282,7 +282,7 @@ will be reused for the next new long name created with the same prefix.
 
 22
 
-1. Understanding a Data Source Description
+1. Understanding a Data Source Description
 
 Example:
 
@@ -356,7 +356,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  23
 
-Naming a Master File
+Naming a Master File
 
 where:
 
@@ -411,7 +411,7 @@ was specified in the DYNAM ALLOC command.
 
 24
 
-1. Understanding a Data Source Description
+1. Understanding a Data Source Description
 
 Example:
 
@@ -469,7 +469,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  25
 
-What Is in a Master File?
+What Is in a Master File?
 
 Reference: Usage Notes for Long Master File Names
 
@@ -513,7 +513,7 @@ Access File and, if so, what the Access File attributes are.
 
 26
 
-1. Understanding a Data Source Description
+1. Understanding a Data Source Description
 
 Syntax:
 
@@ -567,7 +567,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  27
 
-What Is in a Master File?
+What Is in a Master File?
 
 Example:
 
@@ -626,7 +626,7 @@ SEGNAME = EMPINFO, SEGTYPE = S1 ,$
 
 28
 
-1. Understanding a Data Source Description
+1. Understanding a Data Source Description
 
 Editing and Validating a Master File
 
@@ -645,6 +645,6 @@ Describing Data With TIBCO WebFOCUS® Language
 
  29
 
-What Is in a Master File?
+What Is in a Master File?
 
 30

--- a/specifications/describing_data/describing_data_02_chapter2.md
+++ b/specifications/describing_data/describing_data_02_chapter2.md
@@ -50,7 +50,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  31
 
-Specifying a Data Source Name: FILENAME
+Specifying a Data Source Name: FILENAME
 
 You can identify a Master File profile (MFD_PROFILE) procedure to run during Master File
 processing. For more information, see Creating and Using a Master File Profile on page 46.
@@ -106,7 +106,7 @@ used to access the data source.
 
 32
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 The SUFFIX attribute is required for most types of data sources. It is optional for a fixed-format
 sequential data source. However, if you refer to a fixed-format sequential data source in a JOIN
@@ -170,7 +170,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  33
 
-Identifying a Data Source Type: SUFFIX
+Identifying a Data Source Type: SUFFIX
 
 Data Source Type
 
@@ -253,7 +253,7 @@ INFOMAN
 
 34
 
-Data Source Type
+Data Source Type
 
 SUFFIX Value
 
@@ -339,7 +339,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  35
 
-Specifying a Code Page in a Master File
+Specifying a Code Page in a Master File
 
 Data Source Type
 
@@ -413,7 +413,7 @@ CODEPAGE = codepage
 
 36
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 where:
 
@@ -477,7 +477,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  37
 
-Providing Descriptive Information for a Data Source: REMARKS
+Providing Descriptive Information for a Data Source: REMARKS
 
 FORMAT
 
@@ -547,7 +547,7 @@ data source declaration includes descriptive information about the table.
 
 38
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 FILENAME=ORDERS, SUFFIX=SQLORA,
 REMARKS='This Oracle table tracks daily, weekly, and monthly orders.' ,$
@@ -599,7 +599,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  39
 
-Specifying a Physical File Name: DATASET
+Specifying a Physical File Name: DATASET
 
 The USE command for FOCUS data sources overrides DATASET attributes and explicit
 allocations.
@@ -650,7 +650,7 @@ valid only for FOCUS or XFOCUS data sources.
 
 40
 
-Example:
+Example:
 
 Allocating a FOCUS Data Source Using the DATASET Attribute
 
@@ -702,7 +702,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  41
 
-Specifying a Physical File Name: DATASET
+Specifying a Physical File Name: DATASET
 
 For OpenVMS,
 
@@ -752,7 +752,7 @@ SEGNAME=CARREC,SEGTYPE=S1,PARENT=COMP
 
 42
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 For Windows,
 
@@ -802,7 +802,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  43
 
-Specifying a Physical File Name: DATASET
+Specifying a Physical File Name: DATASET
 
 Syntax:
 
@@ -863,7 +863,7 @@ For a binary data source:
 
 44
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 FILE=XX,  SUFFIX=FIX,  DATASET='/u22/class/data/filename.ftm   BINARY'
    .
@@ -916,7 +916,7 @@ Describing Data With TIBCO WebFOCUS® Language
  45
 
 
-Creating and Using a Master File Profile
+Creating and Using a Master File Profile
 
 Example:
 
@@ -975,7 +975,7 @@ Setting the values of global variables defined in the Master File.
 
 46
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 Creating a lookup file for Master File DEFINE commands or DBA attributes.
 
@@ -1032,7 +1032,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  47
 
-Creating and Using a Master File Profile
+Creating and Using a Master File Profile
 
 The MFD_PROFILE is not executed as a result of the MODIFY, MAINTAIN, or -READFILE
 commands.
@@ -1082,7 +1082,7 @@ MFD_PROFILE request against same Master as original request END
 
 48
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 The first time the MFD_PROFILE is invoked, &&COUNTER is set to 1, so the part of the
 MFD_PROFILE request that references the same Master File is executed, and &&COUNTER
@@ -1127,7 +1127,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  49
 
-Creating and Using a Master File Profile
+Creating and Using a Master File Profile
 
 The edited EMPDATA Master File is
 
@@ -1181,7 +1181,7 @@ FILEDEF JOBS DISK jobs.ftm
 
 50
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 -SET &PASS = 'HR3';
 SET PASS = &PASS
@@ -1209,7 +1209,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  51
 
-Creating and Using a Master File Profile
+Creating and Using a Master File Profile
 
 Example:
 
@@ -1261,7 +1261,7 @@ HR2 can see everything in the EMPDATA segment.
 
 52
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 The DDEMP2 profile procedure:
 
@@ -1312,7 +1312,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  53
 
-Creating and Using a Master File Profile
+Creating and Using a Master File Profile
 
 -* Establish the loop for each record of the security.data file
 -SET &DONE =  N ;
@@ -1366,7 +1366,7 @@ USER=HR2,   ACCESS=R, RESTRICT=VALUE, NAME=EMPDATA,
 
 54
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 The following request prints the PIN, SALARY, TITLE, and DEPT fields from EMPDATA:
 
@@ -1393,7 +1393,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  55
 
-Creating and Using a Master File Profile
+Creating and Using a Master File Profile
 
 Running the request by first issuing the SET PASS=HR1 command produces the following
 report in which only the salaries between 20000 and 35000 display because of the VALUE
@@ -1429,7 +1429,7 @@ Note: You can use the system variable &FOCSECUSER instead of the global variable
 
 56
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 FILENAME=EMPLOYEE, SUFFIX=FOC, MFD_PROFILE=DBAEMP3,$
 VARIABLE NAME=&&UID, USAGE=A8 , $
@@ -1490,7 +1490,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  57
 
-Storing Localized Metadata in Language Files
+Storing Localized Metadata in Language Files
 
 Running the request when SALLY is the connected user produces a report of employees whose
 salaries are less than $20,000:
@@ -1544,7 +1544,7 @@ these applications in the language they select.
 
 58
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 LNGPREP does two things. It extracts attribute values from a Master File into language files,
 and it inserts or updates the TRANS_FILE attribute in the Master File with a value identifying
@@ -1590,7 +1590,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  59
 
-Storing Localized Metadata in Language Files
+Storing Localized Metadata in Language Files
 
 Translating Applications into English
 
@@ -1638,7 +1638,7 @@ attribute values added to the language files.
 
 60
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 Reference: LNGPREP Best Practice
 
@@ -1671,7 +1671,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  61
 
-Storing Localized Metadata in Language Files
+Storing Localized Metadata in Language Files
 
 Languages File
 
@@ -1733,7 +1733,7 @@ LNGPREP FILE weather/forecast LNGAPP xlate LNGPREFIX tq_ LNGFILE  xlate/lnglist
 
 62
 
-2. Identifying a Data Source
+2. Identifying a Data Source
 
 Alternately, you can right-click the forecast synonym, point to Metadata Management, and
 select Prepare Translation Files. The Set Translation File for weather/forecast.mas page opens,
@@ -1757,6 +1757,6 @@ Describing Data With TIBCO WebFOCUS® Language
 
  63
 
-Storing Localized Metadata in Language Files
+Storing Localized Metadata in Language Files
 
 64

--- a/specifications/describing_data/describing_data_03_chapter3.md
+++ b/specifications/describing_data/describing_data_03_chapter3.md
@@ -61,7 +61,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  65
 
-Defining a Single Group of Fields
+Defining a Single Group of Fields
 
 For each ID number there is one first and last name, one date hired, one department, and
 one current salary.
@@ -88,7 +88,7 @@ source, a segment instance is the same as a record.
 
 66
 
-The relationship of a segment to its instances is illustrated in the following diagram.
+The relationship of a segment to its instances is illustrated in the following diagram.
 
 3. Describing a Group of Fields
 
@@ -108,7 +108,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  67
 
-Defining a Single Group of Fields
+Defining a Single Group of Fields
 
 Identifying a Key Field
 
@@ -155,7 +155,7 @@ segment name in both.
 
 68
 
-3. Describing a Group of Fields
+3. Describing a Group of Fields
 
 Syntax:
 
@@ -212,7 +212,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  69
 
-Identifying a Logical View: Redefining a Segment
+Identifying a Logical View: Redefining a Segment
 
 Example:
 
@@ -267,7 +267,7 @@ SEGNAME = EMPINFO, SEGTYPE = S1 ,$
 
 70
 
-3. Describing a Group of Fields
+3. Describing a Group of Fields
 
 If you develop an application that refers to only the employee ID and name fields, and you want
 this to be reflected in the application view of the segment, you can code an alternative Master
@@ -319,7 +319,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  71
 
-Relating Multiple Groups of Fields
+Relating Multiple Groups of Fields
 
 A related facility, the MATCH FILE command, enables many types of relationships by first
 describing a relationship as a series of extraction and merging conditions, then merging the
@@ -371,7 +371,7 @@ PARENT = SALINFO
 
 72
 
-3. Describing a Group of Fields
+3. Describing a Group of Fields
 
 Identifying the Type of Relationship: SEGTYPE
 
@@ -403,7 +403,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  73
 
-Logical Dependence: The Parent-Child Relationship
+Logical Dependence: The Parent-Child Relationship
 
 For joined structures, there is an implicit reference to the root segment, which is always
 retrieved in a database request. If a request involving a joined structure references fields from
@@ -448,7 +448,7 @@ who the employee is (that is, a child instance without the parent instance).
 
 74
 
-The following diagram illustrates the concept of a parent-child relationship.
+The following diagram illustrates the concept of a parent-child relationship.
 
 3. Describing a Group of Fields
 
@@ -466,7 +466,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  75
 
-Logical Dependence: The Parent-Child Relationship
+Logical Dependence: The Parent-Child Relationship
 
 EMPINFO is related to SALINFO, and in this relationship EMPINFO is the parent segment and
 SALINFO is the child segment. SALINFO is also related to DEDUCT. In this second relationship,
@@ -491,7 +491,7 @@ branching of the data structure tree ends with the leaf. DEDUCT is a leaf.
 
 76
 
-The following diagram illustrates the concept of a descendant segment.
+The following diagram illustrates the concept of a descendant segment.
 
 3. Describing a Group of Fields
 
@@ -504,7 +504,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  77
 
-Logical Independence: Multiple Paths
+Logical Independence: Multiple Paths
 
 Logical Independence: Multiple Paths
 
@@ -522,7 +522,7 @@ of EMPINFO (the employee) exists.
 
 78
 
-3. Describing a Group of Fields
+3. Describing a Group of Fields
 
 Understanding Multiple Paths
 
@@ -537,7 +537,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  79
 
-Cardinal Relationships Between Segments
+Cardinal Relationships Between Segments
 
 Understanding Logical Independence
 
@@ -587,7 +587,7 @@ Segments from the same type of data source.
 
 80
 
-3. Describing a Group of Fields
+3. Describing a Group of Fields
 
 Segments from different types of data sources. For example, you can define the
 relationship between an Oracle table and a FOCUS data source. Note that you can join
@@ -614,7 +614,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  81
 
-One-to-One Relationship
+One-to-One Relationship
 
 Example:
 
@@ -646,7 +646,7 @@ relationship.
 
 82
 
-3. Describing a Group of Fields
+3. Describing a Group of Fields
 
 When you retrieve data from a segment described as unique, the request treats the segment
 as an extension of its parent. If the unique segment has multiple instances, the request
@@ -692,7 +692,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  83
 
-One-to-Many Relationship
+One-to-Many Relationship
 
 The following diagram illustrates the concept of a one-to-many relationship.
 
@@ -707,7 +707,7 @@ relationship between EMPINFO and SALINFO is one-to-many.
 
 84
 
-The following diagram further illustrates the concept of a one-to-many relationship.
+The following diagram further illustrates the concept of a one-to-many relationship.
 
 3. Describing a Group of Fields
 
@@ -745,7 +745,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  85
 
-Many-to-Many Relationship
+Many-to-Many Relationship
 
 You can also specify a one-to-many relationship between two records in different data sources
 by issuing the JOIN command with the ALL or MULTIPLE option, or defining the join in the
@@ -780,7 +780,7 @@ The many-to-many type of relationship is illustrated in the following diagram.
 
 86
 
-3. Describing a Group of Fields
+3. Describing a Group of Fields
 
 When the M:M relationship is seen from the perspective of either of the two tables, it looks
 like a 1:M relationship. One student taking many classes (1:M from the perspective of
@@ -810,7 +810,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  87
 
-Many-to-Many Relationship
+Many-to-Many Relationship
 
 Implementing a Many-to-Many Relationship Indirectly
 
@@ -833,7 +833,7 @@ related to many instances of ENROLLED (since one class can have many employees e
 
 88
 
-These relationships are illustrated in the following diagram.
+These relationships are illustrated in the following diagram.
 
 3. Describing a Group of Fields
 
@@ -848,7 +848,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  89
 
-Many-to-Many Relationship
+Many-to-Many Relationship
 
 This type of join is illustrated in the following diagram.
 
@@ -871,7 +871,7 @@ JOIN EMP_ID IN ENROLLED TO EMP_ID IN EMPINFO
 
 90
 
-The new structure is illustrated in the following diagram.
+The new structure is illustrated in the following diagram.
 
 3. Describing a Group of Fields
 
@@ -892,7 +892,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  91
 
-Recursive Relationships
+Recursive Relationships
 
 Example:
 
@@ -916,7 +916,7 @@ cross-referenced field, for which the alias is prefixed instead of the field nam
 
 92
 
-3. Describing a Group of Fields
+3. Describing a Group of Fields
 
 After you have issued the join, you can generate an answer set that looks like this:
 
@@ -949,13 +949,13 @@ Describing Data With TIBCO WebFOCUS® Language
 
  93
 
-Recursive Relationships
+Recursive Relationships
 
 This produces the following data structure.
 
 94
 
-3. Describing a Group of Fields
+3. Describing a Group of Fields
 
 Relating Segments From Different Types of Data Sources
 
@@ -974,7 +974,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  95
 
-Rotating a Data Source: An Alternate View
+Rotating a Data Source: An Alternate View
 
 Rotating a Data Source: An Alternate View
 
@@ -1001,7 +1001,7 @@ alternate view field must include INDEX = I in the Master File.
 
 96
 
-3. Describing a Group of Fields
+3. Describing a Group of Fields
 
 You use the field in a record selection test, with the WHERE or IF phrases, and make the
 selection criteria an equality or range test.
@@ -1020,7 +1020,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  97
 
-Defining a Prefix for Field Titles
+Defining a Prefix for Field Titles
 
 Syntax:
 
@@ -1078,7 +1078,7 @@ Is a valid segment name.
 
 98
 
-3. Describing a Group of Fields
+3. Describing a Group of Fields
 
 'prefix'
 
@@ -1124,7 +1124,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  99
 
-Defining a Prefix for Field Titles
+Defining a Prefix for Field Titles
 
 All three segments have the same fields. The SEG_TITLE_PREFIX displays on the report output
 and indicates which segment the field came from. The following request sums DAYSDELAYED
@@ -1155,7 +1155,7 @@ END
 
 100
 
-The column heading on the output shows that the TIME_QTR value is coming from the
+The column heading on the output shows that the TIME_QTR value is coming from the
 WF_RETAIL_TIME_DELIVERED segment.
 
 3. Describing a Group of Fields
@@ -1190,6 +1190,6 @@ Describing Data With TIBCO WebFOCUS® Language
 
  101
 
-Defining a Prefix for Field Titles
+Defining a Prefix for Field Titles
 
 102

--- a/specifications/describing_data/describing_data_04_chapter4.md
+++ b/specifications/describing_data/describing_data_04_chapter4.md
@@ -67,7 +67,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  103
 
-The Field Name: FIELDNAME
+The Field Name: FIELDNAME
 
 Another name for the field, either its original name, as defined to its native data
 management system, or (for some types of data sources) a synonym of your own choosing,
@@ -113,7 +113,7 @@ source.
 
 104
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 When you generate a report, each column title in the report has the name of the field displayed
 in that column as its default, so assigning meaningful field names helps readers of the report.
@@ -163,7 +163,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  105
 
-The Field Name: FIELDNAME
+The Field Name: FIELDNAME
 
 Reference: Restrictions for Field Names
 
@@ -217,7 +217,7 @@ COMBINE commands.
 
 106
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 segname
 
@@ -250,7 +250,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  107
 
-The Field Name: FIELDNAME
+The Field Name: FIELDNAME
 
 Using a Duplicate Field Name
 
@@ -301,7 +301,7 @@ The maximum field name qualification is filename.segname.fieldname. For example:
 
 108
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 TABLE FILE EMPLOYEE
 PRINT EMPLOYEE.EMPINFO.EMP_ID
@@ -351,7 +351,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  109
 
-The Field Name: FIELDNAME
+The Field Name: FIELDNAME
 
 If a field name begins with characters that are the same as the name of a prefix operator, it
 may be unclear whether a request is referencing that field name or a second field name
@@ -396,7 +396,7 @@ COUNTRY.
 
 110
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 When a qualified field name can be evaluated as a choice between two levels of
 qualification, the field name with the higher level of qualification takes precedence.
@@ -448,7 +448,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  111
 
-The Field Synonym: ALIAS
+The Field Synonym: ALIAS
 
 The Field Synonym: ALIAS
 
@@ -500,7 +500,7 @@ can have the value blank.
 112
 
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Note that ALIAS is used in a different way for sequenced repeating fields, where its value is
 ORDER, as well as for RECTYPE and MAPVALUE fields when the data source includes
@@ -553,7 +553,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  113
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 l
 
@@ -604,7 +604,7 @@ precision floating-point (MATH), and packed decimal. See Numeric Display Options
 
 114
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Alphanumeric. You can use alphanumeric format for any value to be interpreted as a
 sequence of characters and composed of any combination of digits, letters, and other
@@ -654,7 +654,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  115
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 n
 
@@ -710,7 +710,7 @@ value. The number of significant digits supported varies with the operating envi
 
 116
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 s
 
@@ -764,7 +764,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  117
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 For example:
 
@@ -820,7 +820,7 @@ Display
 
 614.2
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Format
 
@@ -877,7 +877,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  119
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Packed-Decimal Format
 
@@ -932,7 +932,7 @@ field.
 
 120
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Overflow occurs if you attempt to store a number with more digits than can actually fit in the
 internal storage assigned. Overflow such as this is indicated by storing a number consisting of
@@ -990,7 +990,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  121
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Edit Option
 
@@ -1055,7 +1055,7 @@ Displays numeric values in terms of
 billions. For example, 1234567890
 displays as 1.23B.
 
-Edit Option
+Edit Option
 
 Meaning
 
@@ -1132,7 +1132,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  123
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Edit Option
 
@@ -1205,7 +1205,7 @@ negative
 
 124
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Edit Option
 
@@ -1289,7 +1289,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  125
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Option
 
@@ -1433,7 +1433,7 @@ JUL
 126
 
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Several display options can be combined, as shown:
 
@@ -1572,7 +1572,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  127
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Prefix
 
@@ -1675,7 +1675,7 @@ The output is shown in the following image.
 
 128
 
-Extended Currency Symbol Display Options
+Extended Currency Symbol Display Options
 
 4. Describing an Individual Field
 
@@ -1713,7 +1713,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  129
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 The following table lists the supported extended currency display options:
 
@@ -1808,7 +1808,7 @@ I9:Y
 
 130
 
-Reference: Extended Currency Symbol Formats
+Reference: Extended Currency Symbol Formats
 
 The following guidelines apply:
 
@@ -1864,7 +1864,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  131
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 D. Displays a floating dollar sign.
 
@@ -1902,7 +1902,7 @@ END
 
 132
 
-The output is:
+The output is:
 
 4. Describing an Individual Field
 
@@ -1933,7 +1933,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  133
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 pos
 
@@ -1978,7 +1978,7 @@ Note: If currency parameters are specified at multiple levels, the order of prec
 
 134
 
-Example:
+Example:
 
 Specifying Currency Parameters in a DEFINE
 
@@ -2026,7 +2026,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  135
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 The details of rounding are handled in the following ways for the following numeric formats:
 
@@ -2076,7 +2076,7 @@ displayed: 1.1
 
 136
 
-Alphanumeric Format
+Alphanumeric Format
 
 4. Describing an Individual Field
 
@@ -2131,7 +2131,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  137
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Reference: Usage Notes for 4K Alphanumeric Fields
 
@@ -2182,7 +2182,7 @@ END
 
 138
 
-The output is shown in the following image.
+The output is shown in the following image.
 
 4. Describing an Individual Field
 
@@ -2228,7 +2228,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  139
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 The STRING data type has all of the functionality of alphanumeric data types in WebFOCUS.
 The limit to a STRING field value length is 2 GB. It can be propagated to relational data
@@ -2300,7 +2300,7 @@ week.
 
 140
 
-Display Option
+Display Option
 
 Meaning
 
@@ -2390,7 +2390,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  141
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Display Option
 
@@ -2468,7 +2468,7 @@ CC00/mm/dd
 
 142
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Date Format
 
@@ -2674,7 +2674,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  143
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Date Format
 
@@ -2878,7 +2878,7 @@ yy/ddd
 
 144
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Date Format
 
@@ -2982,7 +2982,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  145
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Format
 
@@ -3048,7 +3048,7 @@ MONDAY
 
 Monday
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Example:
 
@@ -3137,7 +3137,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  147
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 The following chart describes the format of natural date literals.
 
@@ -3196,7 +3196,7 @@ updating.
 
 148
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Date Fields in Arithmetic Expressions
 
@@ -3250,7 +3250,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  149
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 format
 
@@ -3297,7 +3297,7 @@ as blanks, but are interpreted as the base date in date computations and express
 
 150
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 There are several types of formats you can use to represent date components, and the
 different types do not represent the same values or offsets.
@@ -3354,7 +3354,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  151
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 The output is shown in the following image. Note that when the partial and component dates
 are assigned to FULLDATE2 and FULLDATE3, the day assigned is 01 in both cases.
@@ -3412,7 +3412,7 @@ Displays Blanks
 152
 
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 DATEDISPLAY affects only how the base date appears. See the Developing Reporting
 Applications manual for a description of DATEDISPLAY.
@@ -3467,7 +3467,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  153
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Format
 
@@ -3533,7 +3533,7 @@ subroutines for manipulating date-time fields.
 
 154
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Date-time formats can also produce output values and accept input values that are compatible
 with the ISO 8601:2000 date-time notation standard. A SET parameter and specific formatting
@@ -3577,7 +3577,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  155
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 SET DTSTANDARD = &STAND
 DEFINE FILE EMPLOYEE
@@ -3633,7 +3633,7 @@ display options.
 
 
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 The MISSING attribute for date-time fields can be ON or OFF. If it is OFF, and the date-time field
 has no value, it defaults to blank.
@@ -3683,7 +3683,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  157
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Syntax:
 
@@ -3756,7 +3756,7 @@ I
 
 158
 
-Option
+Option
 
 Meaning
 
@@ -3852,7 +3852,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  159
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Option
 
@@ -3932,7 +3932,7 @@ see Display Options for the Date Component of a Date-Time Field on page 161.
 
 160
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 separator
 
@@ -4012,7 +4012,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  161
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Option
 
@@ -4071,7 +4071,7 @@ Month removal without day removal (which forces day removal), format HodYY.
 
 162
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Day removal without month removal, format HMeYY. Note that month removal is not forced
 by day removal.
@@ -4114,7 +4114,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  163
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 With zero removal for the day component, format HeMYY.
 
@@ -4180,7 +4180,7 @@ USAGE = HYYMDS prints
 
 164
 
-Option
+Option
 
 Meaning
 
@@ -4274,7 +4274,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  165
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 The date components can be in any of the following combinations and order:
 
@@ -4326,7 +4326,7 @@ zero.
 
 166
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Note: HOLD FORMAT ALPHA creates an ACTUAL format of AnW in the Master File. See
 Propagating an AnV Field to a HOLD File on page 168.
@@ -4384,7 +4384,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  167
 
-The Displayed Data Type: USAGE
+The Displayed Data Type: USAGE
 
 Full FOCUS and SQL operations are supported with this data type, including CREATE FILE
 for relational data sources.
@@ -4436,7 +4436,7 @@ FIELDNAME = 'TITLEV', 'TITLEV', A39V, A39V ,$
 
 168
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Text Field Format
 
@@ -4495,7 +4495,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  169
 
-The Stored Data Type: ACTUAL
+The Stored Data Type: ACTUAL
 
 The Stored Data Type: ACTUAL
 
@@ -4541,7 +4541,7 @@ between the date to be entered and the date format base date.
 
 170
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 ACTUAL Type
 
@@ -4608,7 +4608,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  171
 
-The Stored Data Type: ACTUAL
+The Stored Data Type: ACTUAL
 
 ACTUAL Type
 
@@ -4654,7 +4654,7 @@ source with a date-time field, the ACTUAL format for that field is of the form A
 
 172
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Reference: ACTUAL to USAGE Conversion
 
@@ -4754,7 +4754,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  173
 
-The Stored Data Type: ACTUAL
+The Stored Data Type: ACTUAL
 
 COBOL USAGE
 FORMAT
@@ -4874,7 +4874,7 @@ stored and formatted.
 
 174
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Adding a Geographic Role for a Field
 
@@ -4932,7 +4932,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  175
 
-Null or MISSING Values: MISSING
+Null or MISSING Values: MISSING
 
 NUTS0. Country name (NUTS level 0).
 
@@ -4986,7 +4986,7 @@ applications, especially those that perform aggregating functions, such as avera
 
 176
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 If your type of data source supports missing data, as do FOCUS data sources and most
 relational data sources, then you can use the optional MISSING attribute to enable null values
@@ -5040,7 +5040,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  177
 
-Describing an FML Hierarchy
+Describing an FML Hierarchy
 
 Changes. You can change the MISSING attribute at any time. Note that changing MISSING
 does not affect the actual stored data values that were entered using the old setting.
@@ -5089,7 +5089,7 @@ in place of the specified hierarchy field values.
 
 
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 In the Master File, use the PROPERTY=PARENT_OF and REFERENCE=hierarchyfld attributes to
 define the hierarchical relationship between two fields.
@@ -5136,7 +5136,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  179
 
-Describing an FML Hierarchy
+Describing an FML Hierarchy
 
 Syntax:
 
@@ -5178,7 +5178,7 @@ DEFINE name/format=expression;,PROPERTY=CAPTION,REFERENCE=hierarchyfld,$
 
 180
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Example:
 
@@ -5229,7 +5229,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  181
 
-Defining a Dimension: WITHIN
+Defining a Dimension: WITHIN
 
 The combination, or matrix, of two or more dimensional hierarchies in an OLAP-enabled data
 source is called multi-dimensional. For example, although products are sold within states they
@@ -5271,7 +5271,7 @@ the same higher level field.
 
 182
 
-Example:
+Example:
 
 Defining a Dimension
 
@@ -5315,7 +5315,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  183
 
-Defining a Dimension: WITHIN
+Defining a Dimension: WITHIN
 
 OSALES Master File
 
@@ -5362,7 +5362,7 @@ OSALES Master File
 
 184
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 6. DEFINE ADATE/A8 = EDIT(DATE);$
    DEFINE YR/I4 = EDIT (EDIT(ADATE,'9999$$$$')); WITHIN='*TIME',$
@@ -5405,7 +5405,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  185
 
-Validating Data: ACCEPT
+Validating Data: ACCEPT
 
 6. Shows the following:
 
@@ -5458,7 +5458,7 @@ parameter prompt screen.
 
 186
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Note: Suffix VSAM and FIX data sources may use the ACCEPT attribute to specify multiple
 RECTYPE values, which are discussed in Describing a Sequential, VSAM, or ISAM Data Source
@@ -5505,7 +5505,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  187
 
-Validating Data: ACCEPT
+Validating Data: ACCEPT
 
 Syntax:
 
@@ -5559,7 +5559,7 @@ field name.
 
 188
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 lookup_field
 
@@ -5614,7 +5614,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  189
 
-Specifying Acceptable Values for a Dimension
+Specifying Acceptable Values for a Dimension
 
 ACCEPT=FIND is used only in MODIFY procedures. It is useful for providing one central
 validation list to be used by several procedures. The FIND function is useful when the list of
@@ -5668,7 +5668,7 @@ ACCEPT='Espresso' OR 'Latte' OR 'Cappuccino' OR 'Scone' OR 'Biscotti' OR
 
 190
 
-Syntax:
+Syntax:
 
 How to Specify a Range of Acceptable Values for a Dimension
 
@@ -5730,7 +5730,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  191
 
-Alternative Report Column Titles: TITLE
+Alternative Report Column Titles: TITLE
 
 You can also specify a different column title within an individual report by using the AS phrase
 in that report request, as described in the Creating Reports With WebFOCUS Language manual.
@@ -5785,7 +5785,7 @@ TITLE with an AS name in a request, or turn it off with the SET TITLES=OFF comma
 
 192
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Virtual fields. If you use the TITLE attribute for a virtual field created with the DEFINE
 attribute, the semicolon (;) terminating the DEFINE expression must be on the same line as
@@ -5842,7 +5842,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  193
 
-Multilingual Metadata
+Multilingual Metadata
 
 Reference: Usage Notes for DESCRIPTION
 
@@ -5900,7 +5900,7 @@ Is the two-letter ISO language code.
 
 194
 
-Note: If SET LANG is used in a procedure, its value will override the values set in nlscfg.err or
+Note: If SET LANG is used in a procedure, its value will override the values set in nlscfg.err or
 in any profile.
 
 4. Describing an Individual Field
@@ -6021,7 +6021,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  195
 
-Multilingual Metadata
+Multilingual Metadata
 
 Language Name
 
@@ -6122,7 +6122,7 @@ Localized Metadata in Language Files on page 58.
 
 196
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Syntax:
 
@@ -6174,7 +6174,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  197
 
-Multilingual Metadata
+Multilingual Metadata
 
 DESC_ln = desc_for_ln
 
@@ -6226,7 +6226,7 @@ FILE=CENTINV, SUFFIX=FOC, FDFC=19, FYRT=00
 
 198
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Example:
 
@@ -6285,7 +6285,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  199
 
-Describing a Virtual Field: DEFINE
+Describing a Virtual Field: DEFINE
 
 The output now displays column headings from the TITLE_ES attributes where they exist
 (Product Number and Product Name). Where no Spanish title is specified (the Price field), the
@@ -6338,7 +6338,7 @@ FIELDNAME on page 104.
 
 200
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 format
 
@@ -6395,7 +6395,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  201
 
-Describing a Virtual Field: DEFINE
+Describing a Virtual Field: DEFINE
 
 NUTS2_CC. Province code (NUTS level 2).
 
@@ -6452,7 +6452,7 @@ Is a column title for the virtual field in the language specified by the languag
 
 202
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 DESC[CRIPTION]='desc'
 
@@ -6510,7 +6510,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  203
 
-Describing a Calculated Value: COMPUTE
+Describing a Calculated Value: COMPUTE
 
 Virtual fields defined in the Master File are available whenever the data source is used, and
 are treated like other stored fields. Thus, a field defined in the Master File cannot be cleared in
@@ -6565,7 +6565,7 @@ CITY. City name.
 
 204
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 CONTINENT. Continent name.
 
@@ -6621,7 +6621,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  205
 
-Describing a Calculated Value: COMPUTE
+Describing a Calculated Value: COMPUTE
 
 USCOUNTY. US county name.
 
@@ -6675,7 +6675,7 @@ Note: Maintain Data does not currently support using COMPUTEs in Master Files.
 
 206
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 Example:
 
@@ -6728,7 +6728,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-Describing a Filter: FILTER
+Describing a Filter: FILTER
 
 The output is:
 
@@ -6780,7 +6780,7 @@ cannot be changed.
 208
 
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 expression
 
@@ -6836,7 +6836,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  209
 
-Describing a Filter: FILTER
+Describing a Filter: FILTER
 
 A mandatory filter can be used to force access to a segment (for example, a table in a
 cluster synonym) that is not referenced in a request.
@@ -6867,7 +6867,7 @@ END
 
 210
 
-The output is shown in the following image:
+The output is shown in the following image:
 
 4. Describing an Individual Field
 
@@ -6883,7 +6883,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  211
 
-Describing a Filter: FILTER
+Describing a Filter: FILTER
 
 The following request does not reference the G_RATING filter:
 
@@ -6902,7 +6902,7 @@ END
 
 212
 
-The output is shown in the following image. Note that the G_RATING filter is applied even
+The output is shown in the following image. Note that the G_RATING filter is applied even
 though it is not referenced in the request:
 
 4. Describing an Individual Field
@@ -6919,7 +6919,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  213
 
-Describing a Sort Object: SORTOBJ
+Describing a Sort Object: SORTOBJ
 
 Reference: Usage Notes for Sort Objects in a Master File
 
@@ -6975,7 +6975,7 @@ Is a description for the sort object in the default language.
 
 214
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 DESC_ln='descln'
 
@@ -7035,7 +7035,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  215
 
-Calling a DEFINE FUNCTION in a Master File
+Calling a DEFINE FUNCTION in a Master File
 
 Calling a DEFINE FUNCTION in a Master File
 
@@ -7093,7 +7093,7 @@ DEFINE WHOLENAME/A40 = DF.DMFUNCS.DMPROPER(LASTNAME, FIRSTNAME);
 
 216
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 The following request uses the DEFINE field WHOLENAME:
 
@@ -7151,7 +7151,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  217
 
-Using Date System Amper Variables in Master File DEFINEs
+Using Date System Amper Variables in Master File DEFINEs
 
 &TOD
 
@@ -7206,7 +7206,7 @@ DEFINE TDATE/A12   ='&DATE';, $
 
 218
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 The following request displays the value of TDATE:
 
@@ -7252,7 +7252,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  219
 
-Parameterizing Master and Access File Values Using Variables
+Parameterizing Master and Access File Values Using Variables
 
 Reference: Messages for Date System Amper Variables in Master File DEFINEs
 
@@ -7305,7 +7305,7 @@ OCCURS, REMARKS, DESCRIPTION, TITLE, HELPMESSAGE.
 
 220
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 In the DBA section of a Master File, the following attributes can be parameterized: USER,
 VALUE. For information about using these variables in a Master File profile to create dynamic
@@ -7363,7 +7363,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  221
 
-Parameterizing Master and Access File Values Using Variables
+Parameterizing Master and Access File Values Using Variables
 
 In the Access File, replace the value for the TABLENAME attribute with the variable name:
 
@@ -7419,7 +7419,7 @@ VARIABLE NAME=tsuf,USAGE=YYM,$
 
 222
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 In the Access File, concatenate the variables to create the TABLENAME attribute. Note that the
 separator for between each part is a period, but to concatenate a variable name and retain the
@@ -7469,7 +7469,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  223
 
-Converting Alphanumeric Dates to WebFOCUS Dates
+Converting Alphanumeric Dates to WebFOCUS Dates
 
 Specifying Variables in a Date Pattern
 
@@ -7533,7 +7533,7 @@ Specifies a three-character month name in lower case.
 
 224
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 [Mon]
 
@@ -7599,7 +7599,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  225
 
-Converting Alphanumeric Dates to WebFOCUS Dates
+Converting Alphanumeric Dates to WebFOCUS Dates
 
 [day]
 
@@ -7658,7 +7658,7 @@ DATEPATTERN = '[Mon] [DD], [YY]'
 
 226
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 If the date in the data source is of the form APR-06, the DATEPATTERN attribute is:
 
@@ -7717,7 +7717,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  227
 
-Converting Alphanumeric Dates to WebFOCUS Dates
+Converting Alphanumeric Dates to WebFOCUS Dates
 
 In the DATE1 Master File, the DATE1 field has alphanumeric USAGE and ACTUAL formats, each
 A18:
@@ -7770,7 +7770,7 @@ June 4, '04
 
 228
 
-4. Describing an Individual Field
+4. Describing an Individual Field
 
 In order to sort the data correctly, you can add a DATEPATTERN attribute to the Master File
 that enables WebFOCUS to convert the date to a WebFOCUS date field. You must also edit the
@@ -7803,7 +7803,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  229
 
-Converting Alphanumeric Dates to WebFOCUS Dates
+Converting Alphanumeric Dates to WebFOCUS Dates
 
 Now, issuing the same request produces the following output. Note that DATE1 has been
 converted to a WebFOCUS date in MtrDYY format (as specified in the USAGE format):

--- a/specifications/describing_data/describing_data_05_chapter5.md
+++ b/specifications/describing_data/describing_data_05_chapter5.md
@@ -49,7 +49,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  231
 
-Sequential Data Source Formats
+Sequential Data Source Formats
 
 Sequential Data Source Formats
 
@@ -101,7 +101,7 @@ The name of the author.
 
 232
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 The title of the book.
 
@@ -151,7 +151,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  233
 
-Sequential Data Source Formats
+Sequential Data Source Formats
 
 You must describe the entire record. The values for field name and alias can be omitted for
 fields that do not need to be accessed. This is significant when using existing data sources,
@@ -203,7 +203,7 @@ Describing a Token-Delimited Data Source on page 282.
 
 234
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 You can use the SET HNODATA command to specify how to propagate missing data to these
 data sources when you create them using the HOLD command. For more information, see the
@@ -253,7 +253,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  235
 
-Sequential Data Source Formats
+Sequential Data Source Formats
 
 Reference: Accessing SUFFIX=TAB Data Sources
 
@@ -301,7 +301,7 @@ the record.
 
 236
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 You can use the system editor to change values, add new records, and delete records. Since
 the number of data fields on a line varies depending on the presence or absence of fields and
@@ -352,7 +352,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  237
 
-Standard Master File Attributes for a Sequential Data Source
+Standard Master File Attributes for a Sequential Data Source
 
 Standard Master File Attributes for a Sequential Data Source
 
@@ -402,7 +402,7 @@ segment. The PARENT name may be one to eight characters.
 
 238
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 SEGTYPE. The SEGTYPE attribute should be S0 for VSAM data sources. (For a general
 description of the SEGTYPE attribute, see Describing a Group of Fields on page 65.)
@@ -455,7 +455,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  239
 
-Standard Master File Attributes for a VSAM or ISAM Data Source
+Standard Master File Attributes for a VSAM or ISAM Data Source
 
 Fields of type D have a value of 8.
 
@@ -509,7 +509,7 @@ FILE = LIBRARY5, SUFFIX = VSAM,$
 
 240
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 Example:
 
@@ -567,7 +567,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  241
 
-Standard Master File Attributes for a VSAM or ISAM Data Source
+Standard Master File Attributes for a VSAM or ISAM Data Source
 
 To avoid the need to calculate these lengths, you can use the GROUP ELEMENTS option, which
 describes a group as a set of elements without USAGE and ACTUAL formats.
@@ -620,7 +620,7 @@ Are ACTUAL formats for each field.
 
 242
 
-Reference: Usage Notes for Group Elements
+Reference: Usage Notes for Group Elements
 
 5. Describing a Sequential, VSAM, or ISAM Data Source
 
@@ -729,7 +729,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  243
 
-Describing a Multiply Occurring Field in a Free-Format Data Source
+Describing a Multiply Occurring Field in a Free-Format Data Source
 
 Note that the display characteristics of the group have not changed. The mixed format group
 GRP1 will still display as all alphanumeric.
@@ -764,7 +764,7 @@ descendant of the first descendant segment, as shown in the following diagram:
 
 244
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 Describe this data source as follows:
 
@@ -821,7 +821,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  245
 
-Describing a Multiply Occurring Field in a Fixed-Format, VSAM, or ISAM Data Source
+Describing a Multiply Occurring Field in a Fixed-Format, VSAM, or ISAM Data Source
 
 Using the OCCURS Attribute
 
@@ -870,7 +870,7 @@ restriction is necessary to ensure that data in the record is interpreted unambi
 
 246
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 Example:
 
@@ -937,7 +937,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  247
 
-Describing a Multiply Occurring Field in a Fixed-Format, VSAM, or ISAM Data Source
+Describing a Multiply Occurring Field in a Fixed-Format, VSAM, or ISAM Data Source
 
 In this example, fields B1 and B2 and fields C1 and C2 repeat within the record. The number
 of times that fields B1 and B2 occur has nothing to do with the number of times fields C1 and
@@ -976,7 +976,7 @@ C1
 
 248
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 In this example, field C1 only occurs after fields B1 and B2 occur once. It occurs varying
 numbers of times, recorded by a counter field, B2. There is not a set of occurrences of C1
@@ -1071,7 +1071,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-Describing a Multiply Occurring Field in a Fixed-Format, VSAM, or ISAM Data Source
+Describing a Multiply Occurring Field in a Fixed-Format, VSAM, or ISAM Data Source
 
 It produces the following data structure:
 
@@ -1094,7 +1094,7 @@ FILENAME = EXAMPLE3, SUFFIX = FIX,$
 
 250
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 Note:
 
@@ -1137,7 +1137,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  251
 
-Describing a Multiply Occurring Field in a Fixed-Format, VSAM, or ISAM Data Source
+Describing a Multiply Occurring Field in a Fixed-Format, VSAM, or ISAM Data Source
 
 Syntax:
 
@@ -1198,7 +1198,7 @@ FILENAME = EXAMPLE3, SUFFIX = FIX,$
 
 252
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 This produces the following structure:
 
@@ -1224,7 +1224,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  253
 
-Redefining a Field in a Non-FOCUS Data Source
+Redefining a Field in a Non-FOCUS Data Source
 
 Syntax:
 
@@ -1274,7 +1274,7 @@ The redefined fields can have any user-defined name.
 
 254
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 Syntax:
 
@@ -1327,7 +1327,7 @@ Describing Data With TIBCO WebFOCUS® Language
  255
 
 
-Extra-Large Record Length Support
+Extra-Large Record Length Support
 
 Reference: Special Considerations for Redefining a Field
 
@@ -1373,7 +1373,7 @@ appears in hexadecimal notation.
 
 256
 
-Describing Multiple Record Types
+Describing Multiple Record Types
 
 5. Describing a Sequential, VSAM, or ISAM Data Source
 
@@ -1424,7 +1424,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  257
 
-Describing Multiple Record Types
+Describing Multiple Record Types
 
 SEGTYPE Attributes With RECTYPE Fields
 
@@ -1472,7 +1472,7 @@ ACCEPT list, this can be any value.
 
 258
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 format
 
@@ -1527,7 +1527,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  259
 
-Describing Multiple Record Types
+Describing Multiple Record Types
 
 FIELDNAME = RECTYPE, ALIAS = ACCTREC, USAGE = P3,ACTUAL = P2,
  ACCEPT = 100 TO 200, $
@@ -1557,7 +1557,7 @@ save space.
 
 260
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 The synopsis is assigned to its own subordinate segment with an attribute of
 OCCURS=VARIABLE in the Master File. Although there are segments in the diagram to the right
@@ -1610,7 +1610,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  261
 
-Describing Multiple Record Types
+Describing Multiple Record Types
 
 In the example in Describing Positionally Related Records on page 260, if the first record in the
 data source is not a PUBINFO record, the record is considered to be a child without a parent.
@@ -1665,7 +1665,7 @@ instance of that segment.
 
 262
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 In the sample data source, the repetition of the publisher number as PUBNO1 and PUBNO2 in
 the descendant segments interrelates the three types of records.
@@ -1686,7 +1686,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  263
 
-Describing Multiple Record Types
+Describing Multiple Record Types
 
 Describing Unrelated Records
 
@@ -1720,7 +1720,7 @@ A structure such as the following can also describe this data source:
 
 264
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 The Master File for the structure in this example is:
 
@@ -1783,7 +1783,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  265
 
-Describing Multiple Record Types
+Describing Multiple Record Types
 
 Magazine
 
@@ -1815,7 +1815,7 @@ Both types of file structure can be represented by the following:
 
 266
 
-Example:
+Example:
 
 Describing a Key and a Record Type for a VSAM Data Source With Unrelated Records
 
@@ -1866,7 +1866,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  267
 
-Describing Multiple Record Types
+Describing Multiple Record Types
 
 Syntax:
 
@@ -1916,7 +1916,7 @@ ACCEPT = 100 TO 200, $
 
 268
 
-Example:
+Example:
 
 Using a Generalized Record Type
 
@@ -1968,7 +1968,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  269
 
-Describing Multiple Record Types
+Describing Multiple Record Types
 
 FILENAME=DOC2, SUFFIX=VSAM,$
 SEGNAME=ROOT, SEGTYPE=SO,$
@@ -2003,7 +2003,7 @@ request as a display field, as a sort field, or in selection tests using either 
 
 270
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 Example:
 
@@ -2068,7 +2068,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-Combining Multiply Occurring Fields and Multiple Record Types
+Combining Multiply Occurring Fields and Multiple Record Types
 
 Describing a Multiply Occurring Field and Multiple Record Types
 
@@ -2105,7 +2105,7 @@ FILENAME = EXAMPLE1, SUFFIX = FIX,$
 
 272
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 It produces the following data structure:
 
@@ -2133,7 +2133,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  273
 
-Combining Multiply Occurring Fields and Multiple Record Types
+Combining Multiply Occurring Fields and Multiple Record Types
 
 Although fields C1 and D1 appear in separate segments, they are actually part of the
 repeating pattern that makes up the OCCURS=VARIABLE segment. Since they occur
@@ -2167,7 +2167,7 @@ on RECTYPEs.
 
 274
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 Example:
 
@@ -2215,7 +2215,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  275
 
-Combining Multiply Occurring Fields and Multiple Record Types
+Combining Multiply Occurring Fields and Multiple Record Types
 
 The following diagram illustrates this relationship:
 
@@ -2232,7 +2232,7 @@ name.
 
 276
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 Syntax:
 
@@ -2294,7 +2294,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  277
 
-Establishing VSAM Data and Index Buffers
+Establishing VSAM Data and Index Buffers
 
 list
 
@@ -2351,7 +2351,7 @@ VSAM data sources online.
 
 278
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 The AMP subparameters BUFND and BUFNI enable z/OS batch users to enhance the I/O
 efficiency of TABLE, TABLEF, MODIFY, and JOIN against VSAM data sources by holding
@@ -2405,7 +2405,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  279
 
-Using a VSAM Alternate Index
+Using a VSAM Alternate Index
 
 The primary benefit of these indexes is improved efficiency. You can use it as an alternate,
 more efficient, retrieval sequence or take advantage of its potential indirectly, with screening
@@ -2447,7 +2447,7 @@ and Macros for details.)
 
 280
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 Example:
 
@@ -2511,7 +2511,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-Describing a Token-Delimited Data Source
+Describing a Token-Delimited Data Source
 
 This information, along with the TSO DDNAME command, may be used to ensure the proper
 allocation of your alternate index.
@@ -2558,7 +2558,7 @@ printable and non-printable characters, the delimiter is defined as a group:
 
 282
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 GROUP=DELIMITER,      ALIAS=          , USAGE=ufmtg, ACTUAL=afmtg ,$
  FIELDNAME=DELIMITER, ALIAS=delimiter1, USAGE=ufmt1, ACTUAL=afmt1 ,$
@@ -2629,7 +2629,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  283
 
-Describing a Token-Delimited Data Source
+Describing a Token-Delimited Data Source
 
 Numeric values may be used to represent any character, but are predominantly used for
 non-printable characters such as Tab. The numeric values may differ between EBCDIC and
@@ -2677,7 +2677,7 @@ GROUP=DELIMITER,  ALIAS=   ,USAGE=A9, ACTUAL=A3  ,$
 
 284
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 Example:
 
@@ -2735,7 +2735,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  285
 
-Describing a Token-Delimited Data Source
+Describing a Token-Delimited Data Source
 
 where:
 
@@ -2786,7 +2786,7 @@ the synonym and reading the data.
 
 286
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 PRESERVESPACE={YES|NO}
 
@@ -2836,7 +2836,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  287
 
-Describing a Token-Delimited Data Source
+Describing a Token-Delimited Data Source
 
 The PIPE1 Master File is:
 
@@ -2891,7 +2891,7 @@ SEGNAME=PIPE1, DELIMITER=|, ENCLOSURE=", HEADER=YES, $
 
 288
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 Example:
 
@@ -2929,7 +2929,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  289
 
-Describing a Token-Delimited Data Source
+Describing a Token-Delimited Data Source
 
 In the DFIX1 file, the alphanumeric fields contain all of the blank spaces that existed in the
 original file:
@@ -2976,7 +2976,7 @@ West       ,Gifts      ,Thermos         ,571368,45648
 
 290
 
-5. Describing a Sequential, VSAM, or ISAM Data Source
+5. Describing a Sequential, VSAM, or ISAM Data Source
 
 Creating the same file with PRESERVESPACE NO removes the trailing blank spaces:
 
@@ -3038,7 +3038,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  291
 
-Describing a Token-Delimited Data Source
+Describing a Token-Delimited Data Source
 
 24: hexadecimal value for dollar sign ($).
 

--- a/specifications/describing_data/describing_data_06_chapter6.md
+++ b/specifications/describing_data/describing_data_06_chapter6.md
@@ -43,7 +43,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  293
 
-Types of FOCUS Data Sources
+Types of FOCUS Data Sources
 
 Types of FOCUS Data Sources
 
@@ -109,7 +109,7 @@ required, except for MDI options.
 
 294
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 You can convert to an XFOCUS data source from a FOCUS data source by changing the SUFFIX
 in the Master File and applying the REBUILD utility.
@@ -151,7 +151,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  295
 
-Types of FOCUS Data Sources
+Types of FOCUS Data Sources
 
 Procedure: How to Create an XFOCUS Data Source
 
@@ -204,7 +204,7 @@ SUFFIX FOC and XFOCUS in a single COMBINE.
 
 296
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 Designing a FOCUS Data Source
 
@@ -240,7 +240,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  297
 
-Designing a FOCUS Data Source
+Designing a FOCUS Data Source
 
 Join Considerations
 
@@ -290,7 +290,7 @@ unsorted data sources (FIXFORM).
 
 298
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 Use segments with a SEGTYPE of SH1 when adding and maintaining data in date
 sequence. In this case, a SEGTYPE of SH1 logically positions the most recent dates at the
@@ -341,7 +341,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  299
 
-Describing a Single Segment
+Describing a Single Segment
 
 Three additional segment attributes that describe joins between FOCUS segments, CRFILE,
 CRKEY, and CRSEGNAME, are described in Defining a Join in a Master File on page 349.
@@ -388,7 +388,7 @@ instances.
 
 300
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 (blank)
 
@@ -441,7 +441,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  301
 
-Describing a Single Segment
+Describing a Single Segment
 
 KL
 
@@ -491,7 +491,7 @@ highest value and continuing to the lowest.
 
 302
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 Segments whose key is a date field often use a high-to-low sort order, since it ensures that
 the segment instances with the most recent dates are the first ones encountered in a
@@ -598,7 +598,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  303
 
-Describing a Single Segment
+Describing a Single Segment
 
 Describing Segment Relationships
 
@@ -646,7 +646,7 @@ data sources allows you to use different disk drives.
 
 304
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 Divided data sources require more careful file maintenance. Be especially careful about
 procedures that are done separately to separate data sources, such as backups. For example,
@@ -692,7 +692,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  305
 
-Describing a Single Segment
+Describing a Single Segment
 
 This description groups the five segments into two physical files, as shown in the following
 diagram:
@@ -719,7 +719,7 @@ fields can be stored in one file.
 
 306
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 In the following example, the text fields DESCRIPTION and TOPICS are stored in the LOCATION
 file CRSEDESC. The text field PREREQUISITE is stored in another file, PREREQS.
@@ -771,7 +771,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  307
 
-Describing a Single Segment
+Describing a Single Segment
 
 Number of Segments
 
@@ -821,7 +821,7 @@ message.
 
 308
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 If DATASET is used in a Master File whose data source is managed by the FOCUS Database
 Server, the DATASET attribute is ignored on the server side because the FOCUS Database
@@ -876,7 +876,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  309
 
-Describing a Single Segment
+Describing a Single Segment
 
 or
 
@@ -932,7 +932,7 @@ FILE = ...
 
 310
 
-Timestamping a FOCUS Segment: AUTODATE
+Timestamping a FOCUS Segment: AUTODATE
 
 6. Describing a FOCUS Data Source
 
@@ -985,7 +985,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  311
 
-Describing a Single Segment
+Describing a Single Segment
 
 Example:
 
@@ -1042,7 +1042,7 @@ DATECHK                       DIFF_DAYS
 
 312
 
-Reference: Usage Notes for AUTODATE
+Reference: Usage Notes for AUTODATE
 
 PRINT * and PRINT.SEG.fld print the AUTODATE field.
 
@@ -1089,7 +1089,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  313
 
-GROUP Attribute
+GROUP Attribute
 
 Syntax:
 
@@ -1148,7 +1148,7 @@ Are the USAGE formats of the component fields in the group.
 
 314
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 FIELDTYPE=I
 
@@ -1201,7 +1201,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  315
 
-GROUP Attribute
+GROUP Attribute
 
 Although MODIFY enables you to update group components even if they are key fields, this
 is not recommended. Instead, use SCAN or FSCAN to update key fields.
@@ -1255,7 +1255,7 @@ STEVENS        ALFRED      071382660   80/06/02
 
 316
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 Example:
 
@@ -1313,7 +1313,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  317
 
-GROUP Attribute
+GROUP Attribute
 
 To avoid the need to calculate these lengths, you can use the GROUP ELEMENTS option, which
 describes a group as a set of elements without USAGE and ACTUAL formats.
@@ -1366,7 +1366,7 @@ Are ACTUAL formats for each field.
 
 318
 
-Reference: Usage Notes for Group Elements
+Reference: Usage Notes for Group Elements
 
 6. Describing a FOCUS Data Source
 
@@ -1475,7 +1475,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  319
 
-ACCEPT Attribute
+ACCEPT Attribute
 
 ACCEPT Attribute
 
@@ -1525,7 +1525,7 @@ acceptable values.
 
 320
 
-INDEX Attribute
+INDEX Attribute
 
 6. Describing a FOCUS Data Source
 
@@ -1570,7 +1570,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  321
 
-INDEX Attribute
+INDEX Attribute
 
 Joins and the INDEX Attribute
 
@@ -1585,7 +1585,7 @@ data source.
 
 322
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 The value for the field named JOBCODE in the EMPLOYEE data source is matched to the field
 named JOBCODE in the JOBFILE data source by using the index for the JOBCODE field in the
@@ -1617,7 +1617,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  323
 
-Describing a Partitioned FOCUS Data Source
+Describing a Partitioned FOCUS Data Source
 
 You can index the field after the data source has already been created and populated with
 records, by using the REBUILD facility with the INDEX option.
@@ -1666,7 +1666,7 @@ in size over time, and can be repartitioned based on the requirements of the app
 
 324
 
-Intelligent Partitioning
+Intelligent Partitioning
 
 6. Describing a FOCUS Data Source
 
@@ -1714,7 +1714,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  325
 
-Describing a Partitioned FOCUS Data Source
+Describing a Partitioned FOCUS Data Source
 
 Syntax:
 
@@ -1764,7 +1764,7 @@ FILENAME=VIDEOTR2,  SUFFIX=FOC,
 
 326
 
-Reference: Using a Partitioned Data Source
+Reference: Using a Partitioned Data Source
 
 The following illustrates how to use an intelligently partitioned data source. The Access File for
 the VIDEOTR2 data source describes three partitions based on DATE:
@@ -1795,7 +1795,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  327
 
-Describing a Partitioned FOCUS Data Source
+Describing a Partitioned FOCUS Data Source
 
 Reference: Usage Notes for Partitioned FOCUS Data Sources
 
@@ -1841,7 +1841,7 @@ attribute in the Master File, the request is processed with the Master File alon
 
 328
 
-Reference: Access File Attributes for a FOCUS Access File
+Reference: Access File Attributes for a FOCUS Access File
 
 6. Describing a FOCUS Data Source
 
@@ -1889,7 +1889,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  329
 
-Describing a Partitioned FOCUS Data Source
+Describing a Partitioned FOCUS Data Source
 
 DATA=file_specification,
    [WHERE= expression; ,]$
@@ -1944,7 +1944,7 @@ Is the name of the MDI.
 
 330
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 segname
 
@@ -1979,7 +1979,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  331
 
-Describing a Partitioned FOCUS Data Source
+Describing a Partitioned FOCUS Data Source
 
 Example:
 
@@ -2044,7 +2044,7 @@ MASTER=VIDEOTR2 ,$
 
 
 
-The following shows the Access File, named VIDEOTR2, on Windows:
+The following shows the Access File, named VIDEOTR2, on Windows:
 
 6. Describing a FOCUS Data Source
 
@@ -2101,7 +2101,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-Multi-Dimensional Index (MDI)
+Multi-Dimensional Index (MDI)
 
 An MDI can be partitioned into multiple MDI files. However, even if the data source on which
 the MDI is built is partitioned, each MDI partition spans all data source partitions.
@@ -2159,7 +2159,7 @@ Are the fields to use as dimensions. At least two dimensions are required for an
 334
 
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 mdifile1, ..., mdifilen
 
@@ -2213,7 +2213,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  335
 
-Multi-Dimensional Index (MDI)
+Multi-Dimensional Index (MDI)
 
 Example:
 
@@ -2268,7 +2268,7 @@ Fields used as the basis for vertical partitioning, such as date or region.
 
 336
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 Derived dimensions (DEFINE fields) that define a new category based on an existing
 category. For example, if your data source contains the field STATE but you need region for
@@ -2305,7 +2305,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  337
 
-Multi-Dimensional Index (MDI)
+Multi-Dimensional Index (MDI)
 
 The total size of all dimensions in an MDI cannot exceed 256 bytes. However, if you
 include the MAXVALUES attribute in the Access File declaration for a dimension,
@@ -2351,7 +2351,7 @@ must then rebuild the MDI.
 
 338
 
-Example:
+Example:
 
 Creating a Multi-Dimensional Index
 
@@ -2404,7 +2404,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  339
 
-Multi-Dimensional Index (MDI)
+Multi-Dimensional Index (MDI)
 
 Syntax:
 
@@ -2455,7 +2455,7 @@ platforms and to enable it on forward byte platforms.
 
 340
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 In its analysis, AUTOINDEX considers the following factors:
 
@@ -2509,7 +2509,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  341
 
-Multi-Dimensional Index (MDI)
+Multi-Dimensional Index (MDI)
 
 Joining to a Multi-Dimensional Index
 
@@ -2552,7 +2552,7 @@ total retrieval time.
 
 342
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 Syntax:
 
@@ -2599,7 +2599,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  343
 
-Multi-Dimensional Index (MDI)
+Multi-Dimensional Index (MDI)
 
 Syntax:
 
@@ -2658,7 +2658,7 @@ The ALL attribute is required.
 
 344
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 Encoding Values in a Multi-Dimensional Index
 
@@ -2716,7 +2716,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  345
 
-Multi-Dimensional Index (MDI)
+Multi-Dimensional Index (MDI)
 
 request
 
@@ -2772,7 +2772,7 @@ END
 
 346
 
-6. Describing a FOCUS Data Source
+6. Describing a FOCUS Data Source
 
 Partitioning a Multi-Dimensional Index
 
@@ -2831,7 +2831,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  347
 
-Multi-Dimensional Index (MDI)
+Multi-Dimensional Index (MDI)
 
 Displaying a Warning Message
 

--- a/specifications/describing_data/describing_data_07_chapter7.md
+++ b/specifications/describing_data/describing_data_07_chapter7.md
@@ -45,7 +45,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  349
 
-Static Joins Defined in the Master File: SEGTYPE = KU and KM
+Static Joins Defined in the Master File: SEGTYPE = KU and KM
 
 Statically within a Master File. This method is helpful if you want to access the joined
 structure frequently. The link (pointer) information needed to implement the join is
@@ -89,7 +89,7 @@ JOBCODE field contains a code that specifies the employee job.
 
 350
 
-7. Defining a Join in a Master File
+7. Defining a Join in a Master File
 
 The complete description of the job and other related information is stored in a separate data
 source named JOBFILE. You can retrieve the job description from JOBFILE by locating the
@@ -113,7 +113,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  351
 
-Static Joins Defined in the Master File: SEGTYPE = KU and KM
+Static Joins Defined in the Master File: SEGTYPE = KU and KM
 
 The EMPLOYEE data source is viewed as follows:
 
@@ -153,7 +153,7 @@ Both fields must have the same format type and length.
 
 352
 
-7. Defining a Join in a Master File
+7. Defining a Join in a Master File
 
 The cross-referenced field must be indexed (FIELDTYPE=I or INDEX=I).
 
@@ -205,7 +205,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  353
 
-Static Joins Defined in the Master File: SEGTYPE = KU and KM
+Static Joins Defined in the Master File: SEGTYPE = KU and KM
 
 Using a Unique Join for Decoding
 
@@ -243,7 +243,7 @@ SEGTYPE = KM
 
 354
 
-Example:
+Example:
 
 Specifying a Static Multiple Join
 
@@ -278,7 +278,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  355
 
-Using Cross-Referenced Descendant Segments: SEGTYPE = KL and KLU
+Using Cross-Referenced Descendant Segments: SEGTYPE = KL and KLU
 
 Within a report request, both cross-referenced data sources, JOBFILE and EDUCFILE, are
 treated as though they are part of the EMPLOYEE data source. The data structure resembles
@@ -304,7 +304,7 @@ CRFILE = db_name, [CRSEGNAME = crsegname,]
 
 356
 
-7. Defining a Join in a Master File
+7. Defining a Join in a Master File
 
 where:
 
@@ -358,7 +358,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  357
 
-Using Cross-Referenced Descendant Segments: SEGTYPE = KL and KLU
+Using Cross-Referenced Descendant Segments: SEGTYPE = KL and KLU
 
 Example:
 
@@ -376,7 +376,7 @@ static (KM) and dynamic (DKM) joins.
 
 358
 
-When the JOBSEG segment is retrieved from JOBFILE, it also retrieves all of the children for
+When the JOBSEG segment is retrieved from JOBFILE, it also retrieves all of the children for
 JOBSEG that were declared with KL or KLU SEGTYPEs in the EMPLOYEE Master File:
 
 7. Defining a Join in a Master File
@@ -385,7 +385,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  359
 
-Using Cross-Referenced Descendant Segments: SEGTYPE = KL and KLU
+Using Cross-Referenced Descendant Segments: SEGTYPE = KL and KLU
 
 Example:
 
@@ -406,7 +406,7 @@ descriptions in COURSEG by declaring it as a linked segment.
 
 360
 
-From this perspective, COURSEG is a child of ATTNDSEG, as shown in the following diagram.
+From this perspective, COURSEG is a child of ATTNDSEG, as shown in the following diagram.
 
 7. Defining a Join in a Master File
 
@@ -436,7 +436,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  361
 
-Dynamic Joins Defined in the Master File: SEGTYPE = DKU and DKM
+Dynamic Joins Defined in the Master File: SEGTYPE = DKU and DKM
 
 Hierarchy of Linked Segments
 
@@ -469,7 +469,7 @@ report request.
 
 362
 
-7. Defining a Join in a Master File
+7. Defining a Join in a Master File
 
 This makes static joins much faster than dynamic ones, but harder to change. You can
 redefine or remove a static join only using the REBUILD facility. You can redefine or remove a
@@ -525,7 +525,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  363
 
-Conditional Joins in the Master File
+Conditional Joins in the Master File
 
 Conditional Joins in the Master File
 
@@ -582,7 +582,7 @@ traditional cross-references in the Master File.
 
 364
 
-7. Defining a Join in a Master File
+7. Defining a Join in a Master File
 
 Note: If you specify a unique join when the relationship between the host and cross-
 referenced files is one-to-many, the results will be unpredictable.
@@ -633,7 +633,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  365
 
-Conditional Joins in the Master File
+Conditional Joins in the Master File
 
 The following request uses the joined Master File.
 
@@ -659,7 +659,7 @@ the characters 019, as specified in the join condition:
 366
 
 
-Comparing Static and Dynamic Joins
+Comparing Static and Dynamic Joins
 
 7. Defining a Join in a Master File
 
@@ -726,7 +726,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  367
 
-Joining to One Cross-Referenced Segment From Several Host Segments
+Joining to One Cross-Referenced Segment From Several Host Segments
 
 Join Type
 
@@ -796,7 +796,7 @@ handle these data structures using Master File defined joins.
 
 368
 
-7. Defining a Join in a Master File
+7. Defining a Join in a Master File
 
 Joining From Several Segments in One Host Data Source
 
@@ -815,7 +815,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  369
 
-Joining to One Cross-Referenced Segment From Several Host Segments
+Joining to One Cross-Referenced Segment From Several Host Segments
 
 You cannot retrieve this information with a standard Master File defined join because there are
 two cross-reference keys in the host data source (PRODMGR and DIVMGR) and in your reports
@@ -865,7 +865,7 @@ to separately in reports. The actual field names in PERSFILE are supplied as ali
 
 370
 
-7. Defining a Join in a Master File
+7. Defining a Join in a Master File
 
 Note that the NAME field cannot be renamed since it is the common join field. It must be
 included in the declaration along with the fields being renamed, as it is described in the cross-
@@ -904,7 +904,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  371
 
-Joining to One Cross-Referenced Segment From Several Host Segments
+Joining to One Cross-Referenced Segment From Several Host Segments
 
 Consider an application that keeps track of customer orders for parts, warehouse inventory of
 parts, and general part information. If this were described as a single data source, it would be
@@ -920,7 +920,7 @@ segment. In the ORDERS data source, ORDER is the host segment.
 
 372
 
-7. Defining a Join in a Master File
+7. Defining a Join in a Master File
 
 In addition, there is a one-to-many join from the STOCK segment in the INVENTRY data source
 to the ORDER segment in the ORDERS data source, and a reciprocal one-to-many join from the
@@ -940,7 +940,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  373
 
-Creating a Single-Root Cluster Master File
+Creating a Single-Root Cluster Master File
 
 A description for this case, shown for two levels of subparts, is:
 
@@ -964,7 +964,7 @@ SEGSUF=DFIX (Delimited Flat File).
 
 374
 
-Syntax:
+Syntax:
 
 How to Read a Field Containing Delimited Values as Individual Rows
 
@@ -1025,7 +1025,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  375
 
-Creating a Single-Root Cluster Master File
+Creating a Single-Root Cluster Master File
 
 delimiter
 
@@ -1085,7 +1085,7 @@ United States  -97.0000000,38.0000000
 
 376
 
-7. Defining a Join in a Master File
+7. Defining a Join in a Master File
 
 Following is the original Master File, COMMA1.
 
@@ -1143,7 +1143,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  377
 
-Creating a Multiple-Root Cluster Master File
+Creating a Multiple-Root Cluster Master File
 
 Creating a Multiple-Root Cluster Master File
 
@@ -1168,7 +1168,7 @@ WebFOCUS Language manual.
 
 378
 
-7. Defining a Join in a Master File
+7. Defining a Join in a Master File
 
 Syntax:
 
@@ -1230,7 +1230,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  379
 
-Creating a Multiple-Root Cluster Master File
+Creating a Multiple-Root Cluster Master File
 
 CRFILE=[dapp/]dfilename
 
@@ -1286,7 +1286,7 @@ SEGMENT=WF_RETAIL_CUSTOMER, CRFILE=wfretail/dimensions/wf_retail_customer,
 
 380
 
-7. Defining a Join in a Master File
+7. Defining a Join in a Master File
 
 The following is an example of a non-shared dimension segment definition from the
 WF_RETAIL_LITE Master File, where the synonym is defined in in the wfretail application.
@@ -1303,6 +1303,6 @@ Describing Data With TIBCO WebFOCUS® Language
 
  381
 
-Creating a Multiple-Root Cluster Master File
+Creating a Multiple-Root Cluster Master File
 
 382

--- a/specifications/describing_data/describing_data_08_chapter8.md
+++ b/specifications/describing_data/describing_data_08_chapter8.md
@@ -46,7 +46,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  383
 
-Grouping Business Logic In a Business View
+Grouping Business Logic In a Business View
 
 Business Views are most useful as views of relational and FOCUS data sources.
 
@@ -98,7 +98,7 @@ field name in the original Master File.
 
 384
 
-8. Creating a Business View of a Master File
+8. Creating a Business View of a Master File
 
 real_segment_name
 
@@ -164,7 +164,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  385
 
-Grouping Business Logic In a Business View
+Grouping Business Logic In a Business View
 
 Language Name
 
@@ -298,7 +298,7 @@ NOR
 
 POL
 
-Language Name
+Language Name
 
 Portuguese - Brazilian
 
@@ -381,7 +381,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  387
 
-Grouping Business Logic In a Business View
+Grouping Business Logic In a Business View
 
 You can issue an SQL SELECT command against a Business View. However, a Direct SQL
 Passthru request is not supported against a Business View.
@@ -416,7 +416,7 @@ which is a cross-referenced segment.
 
 388
 
-8. Creating a Business View of a Master File
+8. Creating a Business View of a Master File
 
 Note that a field named JOBCODE exists in folders 2 and 3. The BELONGS_TO_SEGMENT
 attribute distinguishes between the JOBCODE field from the PAYINFO segment and the
@@ -466,7 +466,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  389
 
-Grouping Business Logic In a Business View
+Grouping Business Logic In a Business View
 
 FOLDER=FOLDER1, $
  FIELDNAME=EMPID, ALIAS=EMP_ID,
@@ -523,7 +523,7 @@ END
 
 390
 
-8. Creating a Business View of a Master File
+8. Creating a Business View of a Master File
 
 The output is:
 
@@ -577,7 +577,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  391
 
-Business View DV Roles
+Business View DV Roles
 
 Business View DV Roles
 
@@ -627,7 +627,7 @@ fields within the folder structure will be accessible for reporting.
 
 392
 
-8. Creating a Business View of a Master File
+8. Creating a Business View of a Master File
 
 You can assign a DV role to a folder or field by right-clicking the folder or field and selecting a
 DV role.
@@ -676,7 +676,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  393
 
-Business View DV Roles
+Business View DV Roles
 
 For a folder or field assigned the DV role Measure, the following attribute is added to the
 folder or field declaration in the synonym.

--- a/specifications/describing_data/describing_data_09_chapter9.md
+++ b/specifications/describing_data/describing_data_09_chapter9.md
@@ -50,7 +50,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  395
 
-CHECK Command Display
+CHECK Command Display
 
 RETRIEVE
 
@@ -107,7 +107,7 @@ Is the number of segments in the Master File, including cross-referenced segment
 
 396
 
-9. Checking and Changing a Master File: CHECK
+9. Checking and Changing a Master File: CHECK
 
 REAL
 
@@ -162,7 +162,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  397
 
-CHECK Command Display
+CHECK Command Display
 
 Determining Common Errors
 
@@ -198,7 +198,7 @@ AA IN SEGMENT SEGB        (VS SEGA)
 
 398
 
-9. Checking and Changing a Master File: CHECK
+9. Checking and Changing a Master File: CHECK
 
 PICTURE Option
 
@@ -269,7 +269,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-PICTURE Option
+PICTURE Option
 
 where:
 
@@ -308,7 +308,7 @@ Parent segments are shown above children segments connected by straight lines.
 
 400
 
-9. Checking and Changing a Master File: CHECK
+9. Checking and Changing a Master File: CHECK
 
 Example:
 
@@ -368,7 +368,7 @@ Describing Data With TIBCO WebFOCUS® Language
  401
 
 
-HOLD Option
+HOLD Option
 
 File Attributes:
 
@@ -422,7 +422,7 @@ source, the segment types, and the attributes of the fields: field names, aliase
 
 402
 
-9. Checking and Changing a Master File: CHECK
+9. Checking and Changing a Master File: CHECK
 
 CHECK FILE EMPLOYEE HOLD
 TABLE FILE HOLD
@@ -480,7 +480,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-HOLD Option
+HOLD Option
 
 Specifying an Alternate File Name With the HOLD Option
 

--- a/specifications/describing_data/describing_data_10_chapter10.md
+++ b/specifications/describing_data/describing_data_10_chapter10.md
@@ -50,7 +50,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  405
 
-Implementing Data Source Security
+Implementing Data Source Security
 
 You can ensure that only records that pass a validation test are retrieved using the
 RESTRICT attribute discussed in Limiting Data Source Access: The RESTRICT Attribute on
@@ -98,7 +98,7 @@ security placed on it have access to that data source.
 
 406
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 The ACCESS attribute defines the type of access a given user has. The four types of access
 available are:
@@ -157,7 +157,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  407
 
-Implementing Data Source Security
+Implementing Data Source Security
 
 Reference: Special Considerations for Data Source Security
 
@@ -206,7 +206,7 @@ DBA=JONES76,$
 
 408
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 Procedure: How to Change a DBA Password
 
@@ -264,7 +264,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  409
 
-Implementing Data Source Security
+Implementing Data Source Security
 
 Syntax:
 
@@ -318,7 +318,7 @@ be changed within the session.
 
 410
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 Syntax:
 
@@ -377,7 +377,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  411
 
-Implementing Data Source Security
+Implementing Data Source Security
 
 Controlling Case Sensitivity of Passwords
 
@@ -432,7 +432,7 @@ SET USER = User2
 
 412
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 Establishing User Identity
 
@@ -493,7 +493,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  413
 
-Specifying an Access Type: The ACCESS Attribute
+Specifying an Access Type: The ACCESS Attribute
 
 The password is MARY in file FIVE and FRANK in all other files:
 
@@ -541,7 +541,7 @@ data source.
 
 414
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 You can assign the ACCESS attribute one of four values. These are:
 
@@ -644,7 +644,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-Specifying an Access Type: The ACCESS Attribute
+Specifying an Access Type: The ACCESS Attribute
 
 Command
 
@@ -723,7 +723,7 @@ command. Users with access of W or U may not.
 
 
 
-Reference: RESTRICT Attribute Keywords
+Reference: RESTRICT Attribute Keywords
 
 10. Providing Data Source Security: DBA
 
@@ -784,7 +784,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  417
 
-Limiting Data Source Access: The RESTRICT Attribute
+Limiting Data Source Access: The RESTRICT Attribute
 
 The optional RESTRICT attribute further restricts a user access to certain fields, values, or
 segments.
@@ -837,7 +837,7 @@ VALIDATE.
 
 418
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 name
 
@@ -890,7 +890,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  419
 
-Limiting Data Source Access: The RESTRICT Attribute
+Limiting Data Source Access: The RESTRICT Attribute
 
 The following request sets the password to USER1 and sums dollar sales and units by
 REGION, CATEGORY, and PRODUCT:
@@ -949,7 +949,7 @@ FIELD specifies that the user cannot access the fields named with the NAME param
 
 420
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 SEGMENT specifies that the user cannot access the segments named with the NAME
 parameter.
@@ -1001,7 +1001,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  421
 
-Limiting Data Source Access: The RESTRICT Attribute
+Limiting Data Source Access: The RESTRICT Attribute
 
 Example:
 
@@ -1048,7 +1048,7 @@ Note: RESTRICT=VALUE is not supported in Maintain Data.
 
 422
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 Syntax:
 
@@ -1102,7 +1102,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  423
 
-Controlling the Source of Access Restrictions in a Multi-file Structure
+Controlling the Source of Access Restrictions in a Multi-file Structure
 
 You can apply the test conditions to the parent segments of the data segments on which the
 tests are applicable. Consider the following example:
@@ -1148,7 +1148,7 @@ File on page 428.
 
 424
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 The SET DBASOURCE command can only be issued one time in a session or connection. Any
 attempt to issue the command additional times will be ignored. If the value is set in a profile,
@@ -1203,7 +1203,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  425
 
-Controlling the Source of Access Restrictions in a Multi-file Structure
+Controlling the Source of Access Restrictions in a Multi-file Structure
 
 If the SET DBASOURCE command is issued more than once in a session, the following
 message displays and the value is not changed:
@@ -1262,7 +1262,7 @@ BYPASSING TO END OF COMMAND
 
 426
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 Now, issue the following SET PASS command:
 
@@ -1315,7 +1315,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  427
 
-Adding DBA Restrictions to the Join Condition
+Adding DBA Restrictions to the Join Condition
 
 Adding DBA Restrictions to the Join Condition
 
@@ -1358,7 +1358,7 @@ attribute.
 
 428
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 Note:
 
@@ -1411,7 +1411,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  429
 
-Placing Security Information in a Central Master File
+Placing Security Information in a Central Master File
 
 filename
 
@@ -1466,7 +1466,7 @@ FILENAME=THREE,$
 
 430
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 Example:
 
@@ -1521,7 +1521,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  431
 
-Placing Security Information in a Central Master File
+Placing Security Information in a Central Master File
 
 Add the following security attributes to the bottom of the COURSE Master File. These attributes
 makes the EMPDATA Master File the central file that contains the security attributes to use for
@@ -1567,7 +1567,7 @@ filename
 
 432
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 File Naming Requirements for DBAFILE
 
@@ -1624,7 +1624,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-Summary of Security Attributes
+Summary of Security Attributes
 
 In the new system, the DBA sections of all data sources in a JOIN or COMBINE are examined.
 If DBAFILE is included in a Master File, then its passwords and restrictions are read. To make
@@ -1688,7 +1688,7 @@ source.
 
 434
 
-Attribute
+Attribute
 
 Alias
 
@@ -1774,7 +1774,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  435
 
-Hiding Restriction Rules: The ENCRYPT Command
+Hiding Restriction Rules: The ENCRYPT Command
 
 Hiding Restriction Rules: The ENCRYPT Command
 
@@ -1828,7 +1828,7 @@ request for encryption is made in the Master File by setting the attribute ENCRY
 
 436
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 Example:
 
@@ -1854,7 +1854,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  437
 
-FOCEXEC Security
+FOCEXEC Security
 
 Note: If you change the DBA password, you must issue the RESTRICT command, as described
 in How to Change a DBA Password on page 409.
@@ -1905,7 +1905,7 @@ ENCRYPT FILE SALERPT FOCEXEC
 
 438
 
-10. Providing Data Source Security: DBA
+10. Providing Data Source Security: DBA
 
 You use the following procedure to decrypt the FOCEXEC named SALERPT:
 
@@ -1916,6 +1916,6 @@ Describing Data With TIBCO WebFOCUS® Language
 
  439
 
-FOCEXEC Security
+FOCEXEC Security
 
 440

--- a/specifications/describing_data/describing_data_11_chapter11.md
+++ b/specifications/describing_data/describing_data_11_chapter11.md
@@ -43,7 +43,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  441
 
-Creating a New Data Source: The CREATE Command
+Creating a New Data Source: The CREATE Command
 
 Creating a New Data Source: The CREATE Command
 
@@ -93,7 +93,7 @@ data source.
 
 442
 
-11. Creating and Rebuilding a Data Source
+11. Creating and Rebuilding a Data Source
 
 Note the following when issuing CREATE on z/OS:
 
@@ -148,7 +148,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  443
 
-Rebuilding a Data Source: The REBUILD Command
+Rebuilding a Data Source: The REBUILD Command
 
 The following message appears:
 
@@ -201,7 +201,7 @@ prerequisites regarding file allocation, security authorization, and backup.
 
 444
 
-Reference: Before You Use REBUILD: Prerequisites
+Reference: Before You Use REBUILD: Prerequisites
 
 Before you use the REBUILD facility, there are several prerequisites that you must consider:
 
@@ -254,7 +254,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  445
 
-Rebuilding a Data Source: The REBUILD Command
+Rebuilding a Data Source: The REBUILD Command
 
 Controlling the Frequency of REBUILD Messages
 
@@ -304,7 +304,7 @@ CHECK COMPLETED...
 
 446
 
-Optimizing File Size: The REBUILD Subcommand
+Optimizing File Size: The REBUILD Subcommand
 
 11. Creating and Rebuilding a Data Source
 
@@ -362,7 +362,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  447
 
-Optimizing File Size: The REBUILD Subcommand
+Optimizing File Size: The REBUILD Subcommand
 
 2. Select the REBUILD subcommand by entering:
 
@@ -422,7 +422,7 @@ The following procedure:
 
 448
 
-11. Creating and Rebuilding a Data Source
+11. Creating and Rebuilding a Data Source
 
 4. Indicates that no record selection tests are required.
 
@@ -472,7 +472,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  449
 
-Changing Data Source Structure: The REORG Subcommand
+Changing Data Source Structure: The REORG Subcommand
 
 Procedure: How to Use the REORG Subcommand
 
@@ -537,7 +537,7 @@ and the name and statistics for the temporary file used to hold the data.
 
 450
 
-8. After the DUMP phase is complete, you are ready to begin the second phase of REBUILD
+8. After the DUMP phase is complete, you are ready to begin the second phase of REBUILD
 
 11. Creating and Rebuilding a Data Source
 
@@ -593,7 +593,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  451
 
-Changing Data Source Structure: The REORG Subcommand
+Changing Data Source Structure: The REORG Subcommand
 
 Example:
 
@@ -641,7 +641,7 @@ The data source will be loaded and the appropriate statistics will be generated.
 
 452
 
-11. Creating and Rebuilding a Data Source
+11. Creating and Rebuilding a Data Source
 
 Indexing Fields: The INDEX Subcommand
 
@@ -675,7 +675,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  453
 
-Indexing Fields: The INDEX Subcommand
+Indexing Fields: The INDEX Subcommand
 
 Procedure: How to Use the INDEX Subcommand
 
@@ -738,7 +738,7 @@ The field will be indexed and the appropriate statistics will be generated.
 
 454
 
-Creating an External Index: The EXTERNAL INDEX Subcommand
+Creating an External Index: The EXTERNAL INDEX Subcommand
 
 11. Creating and Rebuilding a Data Source
 
@@ -781,7 +781,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  455
 
-Creating an External Index: The EXTERNAL INDEX Subcommand
+Creating an External Index: The EXTERNAL INDEX Subcommand
 
 Procedure: How to Use the EXTERNAL INDEX Subcommand
 
@@ -842,7 +842,7 @@ EMPLOYEE
 
 456
 
-11. Creating and Rebuilding a Data Source
+11. Creating and Rebuilding a Data Source
 
 7. Specify the name of the field to index:
 
@@ -890,7 +890,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  457
 
-Creating an External Index: The EXTERNAL INDEX Subcommand
+Creating an External Index: The EXTERNAL INDEX Subcommand
 
 Verification of the component files is now done for both the date and time stamp of file
 creation. Files with the same date and time stamp that are copied display the following
@@ -936,7 +936,7 @@ add index records. If it is, REBUILD EXTERNAL INDEX generates the following mess
 
 458
 
-Positioning Indexed Fields
+Positioning Indexed Fields
 
 11. Creating and Rebuilding a Data Source
 
@@ -992,7 +992,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  459
 
-Checking Data Source Integrity: The CHECK Subcommand
+Checking Data Source Integrity: The CHECK Subcommand
 
 REPLACE
 
@@ -1047,7 +1047,7 @@ offending segment or instance.
 
 460
 
-11. Creating and Rebuilding a Data Source
+11. Creating and Rebuilding a Data Source
 
 Although CHECK is able to report on a good deal of data that would otherwise be lost, it is
 important to remember that frequently backing up your FOCUS data sources is the best
@@ -1102,7 +1102,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  461
 
-Checking Data Source Integrity: The CHECK Subcommand
+Checking Data Source Integrity: The CHECK Subcommand
 
 DELETE indicates that the data has been deleted and should not have been retrieved.
 
@@ -1160,7 +1160,7 @@ SET ALL = ON
 
 462
 
-11. Creating and Rebuilding a Data Source
+11. Creating and Rebuilding a Data Source
 
 3. Enter:
 
@@ -1225,7 +1225,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-Changing the Data Source Creation Date and Time: The TIMESTAMP Subcommand
+Changing the Data Source Creation Date and Time: The TIMESTAMP Subcommand
 
 Note that the BANK_NAME count in the TABLEF report is different than the number of
 FUNDTRAN instances reported by the ? FILE query. This is because FUNDTRAN is a unique
@@ -1273,7 +1273,7 @@ searched for using the EDAPATH variable.
 
 464
 
-11. Creating and Rebuilding a Data Source
+11. Creating and Rebuilding a Data Source
 
 4. Enter one of the following options for the source of the date and time:
 
@@ -1323,7 +1323,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  465
 
-Converting Legacy Dates: The DATE NEW Subcommand
+Converting Legacy Dates: The DATE NEW Subcommand
 
 The storage size of integer dates (I6YMD, I6MDY, for example) is 4 bytes, so no pad field is
 added.
@@ -1373,7 +1373,7 @@ keys in the data source.
 
 466
 
-11. Creating and Rebuilding a Data Source
+11. Creating and Rebuilding a Data Source
 
 Adequate workspace must be available for the temporary REBUILD file. As a rule of thumb,
 have space 10 to 20% larger than the size of the existing file available.
@@ -1431,7 +1431,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  467
 
-Converting Legacy Dates: The DATE NEW Subcommand
+Converting Legacy Dates: The DATE NEW Subcommand
 
 The dates will be converted and the appropriate statistics will be generated, including the
 number of segments changed.
@@ -1480,7 +1480,7 @@ the previous field format to any field coded without an explicit USAGE= statemen
 
 468
 
-11. Creating and Rebuilding a Data Source
+11. Creating and Rebuilding a Data Source
 
 Using the New Master File Created by DATE NEW
 
@@ -1541,7 +1541,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  469
 
-Creating a Multi-Dimensional Index: The MDINDEX Subcommand
+Creating a Multi-Dimensional Index: The MDINDEX Subcommand
 
 Action Taken on a Date Field During REBUILD/DATE NEW
 

--- a/specifications/describing_data/describing_data_12_appendix_a.md
+++ b/specifications/describing_data/describing_data_12_appendix_a.md
@@ -67,7 +67,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-EMPLOYEE Data Source
+EMPLOYEE Data Source
 
 PAYINFO
 
@@ -115,7 +115,7 @@ Lists the dates that employees attended in-house courses.
 
 
 
-COURSEG (from EDUCFILE)
+COURSEG (from EDUCFILE)
 
 Lists the courses that the employees attended.
 
@@ -167,7 +167,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  473
 
-JOBFILE Data Source
+JOBFILE Data Source
 
 EMPLOYEE Structure Diagram
 
@@ -185,7 +185,7 @@ Describes what each position is. The field JOBCODE in this segment is indexed.
 
 
 
-A. Master Files and Diagrams
+A. Master Files and Diagrams
 
 SKILLSEG
 
@@ -243,7 +243,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-EDUCFILE Data Source
+EDUCFILE Data Source
 
 EDUCFILE Data Source
 
@@ -273,7 +273,7 @@ FILENAME=EDUCFILE, SUFFIX=FOC
 
 
 
-EDUCFILE Structure Diagram
+EDUCFILE Structure Diagram
 
 SECTION 01
               STRUCTURE OF FOCUS    FILE EDUCFILE ON 05/15/03 AT 14.45.44
@@ -331,7 +331,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-SALES Data Source
+SALES Data Source
 
 SALES Master File
 
@@ -353,7 +353,7 @@ FILENAME=KSALES,   SUFFIX=FOC
 
 478
 
-SALES Structure Diagram
+SALES Structure Diagram
 
 SECTION 01
              STRUCTURE OF FOCUS    FILE SALES ON 05/15/03 AT 14.50.28
@@ -413,7 +413,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
 
 
-CAR Data Source
+CAR Data Source
 
 COMP
 
@@ -449,7 +449,7 @@ The aliases in the CAR Master File are specified without the ALIAS keyword.
 
 
 
-CAR Master File
+CAR Master File
 
 A. Master Files and Diagrams
 
@@ -486,7 +486,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  481
 
-LEDGER Data Source
+LEDGER Data Source
 
 CAR Structure Diagram
 
@@ -498,7 +498,7 @@ and the commas act as placeholders.
 
 482
 
-A. Master Files and Diagrams
+A. Master Files and Diagrams
 
 LEDGER Master File
 
@@ -543,7 +543,7 @@ Describing Data With TIBCO WebFOCUS® Language
  483
 
 
-REGION Data Source
+REGION Data Source
 
 FINANCE Structure Diagram
 
@@ -597,7 +597,7 @@ SECTION 01
 
 
 
-A. Master Files and Diagrams
+A. Master Files and Diagrams
 
 EMPDATA Data Source
 
@@ -649,7 +649,7 @@ Describing Data With TIBCO WebFOCUS® Language
  485
 
 
-COURSE Data Source
+COURSE Data Source
 
 TRAINING Master File
 
@@ -700,7 +700,7 @@ FILENAME=COURSE,   SUFFIX=FOC
 486
 
 
-COURSE Structure Diagram
+COURSE Structure Diagram
 
 SECTION 01
              STRUCTURE OF FOCUS    FILE COURSE   ON 05/15/03 AT 12.26.05
@@ -756,7 +756,7 @@ Describing Data With TIBCO WebFOCUS® Language
  487
 
 
-LOCATOR Data Source
+LOCATOR Data Source
 
 JOBLIST Master File
 
@@ -803,7 +803,7 @@ SEGNAME=LOCATOR,   SEGTYPE=S1,
 
 488
 
-A. Master Files and Diagrams
+A. Master Files and Diagrams
 
 LOCATOR Structure Diagram
 
@@ -861,7 +861,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  489
 
-SALHIST Data Source
+SALHIST Data Source
 
 SALHIST Data Source
 
@@ -899,7 +899,7 @@ are used in examples that illustrate the use of the Maintain Data facility.
 
 490
 
-VIDEOTRK Master File
+VIDEOTRK Master File
 
 A. Master Files and Diagrams
 
@@ -931,7 +931,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  491
 
-VIDEOTRK, MOVIES, and ITEMS Data Sources
+VIDEOTRK, MOVIES, and ITEMS Data Sources
 
 VIDEOTRK Structure Diagram
 
@@ -978,7 +978,7 @@ SECTION 01
 492
 
 
-A. Master Files and Diagrams
+A. Master Files and Diagrams
 
 MOVIES Master File
 
@@ -1025,7 +1025,7 @@ Describing Data With TIBCO WebFOCUS® Language
  493
 
 
-VIDEOTR2 Data Source
+VIDEOTR2 Data Source
 
 ITEMS Structure Diagram
 
@@ -1077,7 +1077,7 @@ FILENAME=VIDEOTR2, SUFFIX=FOC
 494
 
 
-VIDEOTR2 Structure Diagram
+VIDEOTR2 Structure Diagram
 
 SECTION 01
      STRUCTURE OF FOCUS    FILE VIDEOTR2 ON 05/15/03 AT 16.45.48
@@ -1138,7 +1138,7 @@ Describing Data With TIBCO WebFOCUS® Language
  495
 
 
-Gotham Grinds Data Sources
+Gotham Grinds Data Sources
 
 GGPRODS contains product information for Gotham Grinds. It consists of one segment,
 PRODS01.
@@ -1180,7 +1180,7 @@ FILENAME=GGDEMOG, SUFFIX=FOC
 
 496
 
-GGDEMOG Structure Diagram
+GGDEMOG Structure Diagram
 
 SECTION 01
      STRUCTURE OF FOCUS    FILE GGDEMOG  ON 05/15/03 AT 12.26.05
@@ -1220,7 +1220,7 @@ Describing Data With TIBCO WebFOCUS® Language
  497
 
 
-Gotham Grinds Data Sources
+Gotham Grinds Data Sources
 
 GGORDER Structure Diagram
 
@@ -1272,7 +1272,7 @@ FILENAME=GGPRODS, SUFFIX=FOC
 498
 
 
-GGPRODS Structure Diagram
+GGPRODS Structure Diagram
 
 SECTION 01
      STRUCTURE OF FOCUS    FILE GGPRODS  ON 05/15/03 AT 12.26.05
@@ -1326,7 +1326,7 @@ Describing Data With TIBCO WebFOCUS® Language
  499
 
 
-Gotham Grinds Data Sources
+Gotham Grinds Data Sources
 
 GGSALES Structure Diagram
 
@@ -1383,7 +1383,7 @@ SECTION 01
 
 
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 A. Master Files and Diagrams
 
@@ -1432,7 +1432,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  501
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 CENTCOMP Master File
 
@@ -1483,7 +1483,7 @@ SECTION 01
 502
 
 
-CENTFIN Master File
+CENTFIN Master File
 
 A. Master Files and Diagrams
 
@@ -1532,7 +1532,7 @@ Describing Data With TIBCO WebFOCUS® Language
  503
 
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 CENTHR Master File
 
@@ -1582,7 +1582,7 @@ FILE=CENTHR, SUFFIX=FOC
 
 504
 
-A. Master Files and Diagrams
+A. Master Files and Diagrams
 
   DEFINE BQUARTER/Q=START_DATE;
    TITLE='Beginning,Quarter',
@@ -1636,7 +1636,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  505
 
-Century Corp Data Sources
+Century Corp Data Sources
 
   DEFINE SALARY/D12.2=IF BMONTH LT 4 THEN PAYLEVEL * 12321
    ELSE IF BMONTH GE 4 AND BMONTH LT 8 THEN PAYLEVEL * 13827
@@ -1666,7 +1666,7 @@ SECTION 01
 506
 
 
-CENTINV Master File
+CENTINV Master File
 
 A. Master Files and Diagrams
 
@@ -1722,7 +1722,7 @@ Describing Data With TIBCO WebFOCUS® Language
  507
 
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 CENTORD Master File
 
@@ -1770,7 +1770,7 @@ FILE=CENTORD, SUFFIX=FOC
 
 508
 
-CENTORD Structure Diagram
+CENTORD Structure Diagram
 
 SECTION 01
       STRUCTURE OF FOCUS    FILE CENTORD  ON 05/15/03 AT 10.17.52
@@ -1819,7 +1819,7 @@ Describing Data With TIBCO WebFOCUS® Language
  509
 
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 CENTQA Master File
 
@@ -1871,7 +1871,7 @@ FILE=CENTQA, SUFFIX=FOC, FDFC=19, FYRT=00
 
 510
 
-CENTQA Structure Diagram
+CENTQA Structure Diagram
 
 SECTION 01
        STRUCTURE OF FOCUS    FILE CENTQA   ON 05/15/03 AT 10.46.43
@@ -1928,7 +1928,7 @@ Describing Data With TIBCO WebFOCUS® Language
  511
 
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 CENTGL Structure Diagram
 
@@ -1978,7 +1978,7 @@ SECTION 01
 
 
 
-CENTSTMT Master File
+CENTSTMT Master File
 
 A. Master Files and Diagrams
 
@@ -2013,7 +2013,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  513
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 CENTSTMT Structure Diagram
 
@@ -2068,7 +2068,7 @@ FIELDNAME=SYS_ACCOUNT,          ALIAS=ALINE,   FORMAT=A6,
 514
 
 
-CENTGLL Structure Diagram
+CENTGLL Structure Diagram
 
 SECTION 01
        STRUCTURE OF FOCUS    FILE CENTGLL ON 05/15/03 AT 14.45.44
@@ -2091,6 +2091,6 @@ Describing Data With TIBCO WebFOCUS® Language
  515
 
 
-Century Corp Data Sources
+Century Corp Data Sources
 
 516

--- a/specifications/describing_data/describing_data_13_appendix_b.md
+++ b/specifications/describing_data/describing_data_13_appendix_b.md
@@ -41,6 +41,6 @@ Describing Data With TIBCO WebFOCUS® Language
 
  517
 
-Displaying Messages
+Displaying Messages
 
 518

--- a/specifications/describing_data/describing_data_14_appendix_c.md
+++ b/specifications/describing_data/describing_data_14_appendix_c.md
@@ -50,7 +50,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  519
 
-Data Storage and Display
+Data Storage and Display
 
 -123.8
 
@@ -204,7 +204,7 @@ An integer value entered with no decimal places is stored as entered.
 
 520
 
-C. Rounding in WebFOCUS
+C. Rounding in WebFOCUS
 
 When a value with decimal places is entered into an integer field using a transaction, that
 value is rounded, and the result is stored. If the fractional portion of the value is less than 0.5,
@@ -252,7 +252,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  521
 
-Data Storage and Display
+Data Storage and Display
 
 When the number of decimal places input is greater than the number of decimal places stored
 in the format, M and X field values are stored as they are input, up to the limit of precision.
@@ -298,7 +298,7 @@ When the final digit is 5, these numbers may round down instead of up.
 
 522
 
-C. Rounding in WebFOCUS
+C. Rounding in WebFOCUS
 
 The following example shows an input value with two decimal places, which is stored as a
 packed field with two decimal places, a packed field with one decimal place, a D field with one
@@ -356,7 +356,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  523
 
-Rounding in Calculations and Conversions
+Rounding in Calculations and Conversions
 
 The following report results:
 
@@ -412,7 +412,7 @@ rounding algorithm described previously is applied.
 524
 
 
-Example:
+Example:
 
 Redefining Field Formats
 
@@ -468,7 +468,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  525
 
-Rounding in Calculations and Conversions
+Rounding in Calculations and Conversions
 
 The request prints the values and a total for all six database fields, and for the five DEFINE
 fields.
@@ -496,7 +496,7 @@ The following image shows the resulting output on Windows:
 
 526
 
-C. Rounding in WebFOCUS
+C. Rounding in WebFOCUS
 
 In this example, the PACKED2 sum is an accurate sum of the displayed values, which are the
 same as the stored values. The PACKED4 values and total are the same as the PACKED2
@@ -535,7 +535,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  527
 
-Rounding in Calculations and Conversions
+Rounding in Calculations and Conversions
 
 The output shows that the double precision floating-point number is not exactly the same as
 the input values in most cases. It has extra digits for those values that do not have an exact
@@ -594,7 +594,7 @@ TOTAL
 
 
 
-C. Rounding in WebFOCUS
+C. Rounding in WebFOCUS
 
 The DEFP3 field is the result of a DEFINE. The values are treated like data source field values.
 The printed total, 1420.765, is the sum of the printed DEFP3 values, just as the PACKED2
@@ -607,11 +607,11 @@ Describing Data With TIBCO WebFOCUS® Language
 
  529
 
-Rounding in Calculations and Conversions
+Rounding in Calculations and Conversions
 
 530
 
-Legal and Third-Party Notices
+Legal and Third-Party Notices
 
 SOME TIBCO SOFTWARE EMBEDS OR BUNDLES OTHER TIBCO SOFTWARE. USE OF SUCH
 EMBEDDED OR BUNDLED TIBCO SOFTWARE IS SOLELY TO ENABLE THE FUNCTIONALITY (OR
@@ -659,7 +659,7 @@ DESCRIBED IN THIS DOCUMENT AT ANY TIME.
 
  531
 
-THE CONTENTS OF THIS DOCUMENT MAY BE MODIFIED AND/OR QUALIFIED, DIRECTLY OR
+THE CONTENTS OF THIS DOCUMENT MAY BE MODIFIED AND/OR QUALIFIED, DIRECTLY OR
 INDIRECTLY, BY OTHER DOCUMENTATION WHICH ACCOMPANIES THIS SOFTWARE, INCLUDING
 BUT NOT LIMITED TO ANY RELEASE NOTES AND "READ ME" FILES.
 
@@ -670,7 +670,7 @@ Copyright © 2021. TIBCO Software Inc. All Rights Reserved.
 
 532
 
-Index
+Index
 
 ? FILE command 462
 
@@ -782,7 +782,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  533
 
-Index
+Index
 
 blank lines between declarations 27, 28
 
@@ -904,7 +904,7 @@ rounding 528
 
 COMPUTEs in Master File 204
 
-Index
+Index
 
 concatenated data sources 458
 
@@ -1028,7 +1028,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  535
 
-Index
+Index
 
 data sources 17, 31, 471
 
@@ -1152,7 +1152,7 @@ database rotation 96, 98
 
 536
 
-Index
+Index
 
 database structure 73
 
@@ -1278,7 +1278,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  537
 
-Index
+Index
 
 DBATABLE procedure 422
 
@@ -1402,7 +1402,7 @@ packed-decimal 120
 
 538
 
-display formats for fields 113, 114, 170, 173,
+display formats for fields 113, 114, 170, 173,
 
 dynamic keyed multiple (DKM) segments 362,
 
@@ -1524,7 +1524,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  539
 
-Index
+Index
 
 extract files 401
 
@@ -1646,7 +1646,7 @@ filler fields 69, 232
 
 filter in a Master File 208
 
-Index
+Index
 
 filters 434
 
@@ -1770,7 +1770,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  541
 
-Index
+Index
 
 G
 
@@ -1888,7 +1888,7 @@ integer data type 115
 
 rounding of values 135
 
-integer fields 520
+integer fields 520
 
 rounding 519, 520
 
@@ -2008,7 +2008,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  543
 
-Index
+Index
 
 keyed unique (KU) segments 350, 352, 353
 
@@ -2128,7 +2128,7 @@ declarations 27
 
 544
 
-Master Files 18, 19, 26, 178, 181, 405, 416,
+Master Files 18, 19, 26, 178, 181, 405, 416,
 
 MDI (Multi-Dimensional Index) 333, 346
 
@@ -2254,7 +2254,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  545
 
-Index
+Index
 
 Multi-Dimensional Index (MDI) 333, 346, 470
 
@@ -2374,7 +2374,7 @@ null values 176–178
 
 546
 
-Index
+Index
 
 numbers 519
 
@@ -2496,7 +2496,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  547
 
-Index
+Index
 
 pointer chains 460, 462
 
@@ -2616,7 +2616,7 @@ relating segments 71, 80, 95
 
 many-to-many relationships 86, 88
 
-Index
+Index
 
 relating segments 71, 80, 95
 
@@ -2740,7 +2740,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  549
 
-Index
+Index
 
 sample data sources 471
 
@@ -2862,7 +2862,7 @@ free-format 236, 237
 
 generalized record types 267–269
 
-Index
+Index
 
 sequential data sources 33, 231, 232, 235, 236,
 
@@ -2988,7 +2988,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  551
 
-Index
+Index
 
 SUFFIX DFIX 282, 285
 
@@ -3104,7 +3104,7 @@ VALUE option to RESTRICT attribute 417, 422,
 
 423
 
-values 135, 422
+values 135, 422
 
 VSAM data sources 33, 231
 
@@ -3222,7 +3222,7 @@ Describing Data With TIBCO WebFOCUS® Language
 
  553
 
-Index
+Index
 
 YRTHRESH attribute 31, 103
 


### PR DESCRIPTION
This PR addresses roadmap tasks 0.55 and 0.56. It introduces a dedicated roadmap for cleaning up the WebFOCUS documentation and performs the first step: removing form feed characters that were artifacts of PDF conversion. Additionally, it refines the Java port roadmap by breaking down large report command tasks into smaller, more feasible sub-tasks to facilitate incremental development.

Fixes #502

---
*PR created automatically by Jules for task [17494953009319324790](https://jules.google.com/task/17494953009319324790) started by @chatelao*