### PR TITLE
Implement COMPUTE command in Java ASG Builder

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -79,7 +79,9 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
     - [ ] 3.1.4.4 Formatting:
       - [x] 3.1.4.4.1 HEADING and FOOTING.
       - [ ] 3.1.4.4.2 ON ... SUBHEAD/SUBFOOT.
-    - [ ] 3.1.4.5 Calculations (COMPUTE, RECAP).
+    - [ ] 3.1.4.5 Calculations:
+      - [x] 3.1.4.5.1 COMPUTE command.
+      - [ ] 3.1.4.5.2 RECAP command and assignments.
     - [ ] 3.1.4.6 Summarization (SUBTOTAL, SUMMARIZE).
   - [ ] 3.1.5 Advanced Features:
     - [ ] 3.1.5.1 Compound Layout.

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -596,4 +596,16 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
                 .collect(Collectors.joining(" "));
         return new Footing(text, centered);
     }
+
+    @Override
+    public Object visitCompute_command(WebFocusReportParser.Compute_commandContext ctx) {
+        String name = ctx.qualified_name().getText();
+        String format = ctx.format_name() != null ? ctx.format_name().getText() : null;
+        Expression expression = (Expression) visit(ctx.dm_expression());
+        String alias = null;
+        if (ctx.as_phrase() != null) {
+            alias = (String) visit(ctx.as_phrase());
+        }
+        return new ComputeCommand(name, expression, format, alias);
+    }
 }

--- a/src/main/java/com/transpiler/asg/ComputeCommand.java
+++ b/src/main/java/com/transpiler/asg/ComputeCommand.java
@@ -5,7 +5,11 @@ package com.transpiler.asg;
  */
 public record ComputeCommand(
     String name,
-    String expression,
-    String format
+    Expression expression,
+    String format,
+    String alias
 ) implements Command {
+    public ComputeCommand(String name, Expression expression, String format) {
+        this(name, expression, format, null);
+    }
 }

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -553,6 +553,17 @@ public class WebFocusReportASGBuilderTest {
     }
 
     @Test
+    public void testComputeCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+        WebFocusReportParser parser = createParser("COMPUTE BONUS/D12.2 = SALARY * 0.1 AS 'Annual Bonus';");
+        ComputeCommand compute = (ComputeCommand) builder.visit(parser.compute_command());
+        assertEquals("BONUS", compute.name());
+        assertEquals("D12.2", compute.format());
+        assertTrue(compute.expression() instanceof BinaryOperation);
+        assertEquals("Annual Bonus", compute.alias());
+    }
+
+    @Test
     public void testWhenCommand() {
         WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
         WebFocusReportParser parser = createParser("WHEN COUNTRY EQ 'USA'");

--- a/src/test/java/com/transpiler/asg/ASGParityTest.java
+++ b/src/test/java/com/transpiler/asg/ASGParityTest.java
@@ -167,9 +167,9 @@ class ASGParityTest {
         assertEquals("TABLE", onTable.target());
         assertEquals("COLUMN-TOTAL", onTable.actions().get(0));
 
-        ComputeCommand compute = new ComputeCommand("BONUS", "SALARY * 0.1", "D12.2");
+        ComputeCommand compute = new ComputeCommand("BONUS", new BinaryOperation(new Identifier("SALARY"), "*", new Literal(0.1)), "D12.2");
         assertEquals("BONUS", compute.name());
-        assertEquals("SALARY * 0.1", compute.expression());
+        assertTrue(compute.expression() instanceof BinaryOperation);
         assertEquals("D12.2", compute.format());
     }
 


### PR DESCRIPTION
This change implements the COMPUTE command in the Java WebFocusReportASGBuilder. It also refactors the ComputeCommand ASG node to use a structured Expression and includes an alias field for functional parity with the Python implementation. Unit tests were added and updated to verify the changes.

Fixes #509

---
*PR created automatically by Jules for task [10588023916624530381](https://jules.google.com/task/10588023916624530381) started by @chatelao*