### PR TITLE
Java Port: Implement ON Formatting and Report Options

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -78,7 +78,8 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
       - [x] 3.1.4.3.3 WHEN clause (Dialogue Manager filtering).
     - [ ] 3.1.4.4 Formatting:
       - [x] 3.1.4.4.1 HEADING and FOOTING.
-      - [ ] 3.1.4.4.2 ON ... SUBHEAD/SUBFOOT.
+      - [x] 3.1.4.4.2 ON ... SUBHEAD/SUBFOOT.
+      - [x] 3.1.4.4.3 ON TABLE SUBHEAD/SUBFOOT.
     - [ ] 3.1.4.5 Calculations:
       - [x] 3.1.4.5.1 COMPUTE command.
       - [ ] 3.1.4.5.2 RECAP command and assignments.

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -120,6 +120,104 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
     }
 
     @Override
+    public Object visitOn_command(WebFocusReportParser.On_commandContext ctx) {
+        String target;
+        List<Command> actions = new ArrayList<>();
+        if (ctx.TABLE() != null) {
+            target = "TABLE";
+            Object result = visit(ctx.on_table_options());
+            if (result instanceof List<?>) {
+                actions.addAll((List<Command>) result);
+            } else if (result instanceof Command) {
+                actions.add((Command) result);
+            }
+        } else {
+            target = ctx.qualified_name().getText();
+            Object result = visit(ctx.on_field_options());
+            if (result instanceof List<?>) {
+                actions.addAll((List<Command>) result);
+            } else if (result instanceof Command) {
+                actions.add((Command) result);
+            }
+        }
+        return new OnCommand(target, actions);
+    }
+
+    @Override
+    public Object visitOn_table_options(WebFocusReportParser.On_table_optionsContext ctx) {
+        if (ctx.SUBHEAD() != null || ctx.SUBFOOT() != null) {
+            boolean centered = ctx.CENTER() != null;
+            String text = ctx.STRING().stream()
+                    .map(s -> s.getText().substring(1, s.getText().length() - 1))
+                    .collect(Collectors.joining(" "));
+            return ctx.SUBHEAD() != null ? new Subhead(text, centered) : new Subfoot(text, centered);
+        }
+        if (ctx.COLUMN_TOTAL_KW() != null) {
+            return new SetCommand("COLUMN-TOTAL", "ON");
+        }
+        if (ctx.ROW_TOTAL_KW() != null) {
+            return new SetCommand("ROW-TOTAL", "ON");
+        }
+        if (ctx.ACROSS_TOTAL() != null) {
+            return new SetCommand("ACROSS-TOTAL", "ON");
+        }
+        if (ctx.output_command() != null) {
+            return visit(ctx.output_command());
+        }
+        if (ctx.summarize_command() != null) {
+            return visit(ctx.summarize_command());
+        }
+        // TODO: recap_command, merge_command
+        if (ctx.set_command() != null) {
+            return visit(ctx.set_command());
+        }
+        // TODO: STYLE blocks
+        return null;
+    }
+
+    @Override
+    public Object visitOn_field_options(WebFocusReportParser.On_field_optionsContext ctx) {
+        if (ctx.SUBHEAD() != null || ctx.SUBFOOT() != null) {
+            boolean centered = ctx.CENTER() != null;
+            String text = ctx.STRING().stream()
+                    .map(s -> s.getText().substring(1, s.getText().length() - 1))
+                    .collect(Collectors.joining(" "));
+            return ctx.SUBHEAD() != null ? new Subhead(text, centered) : new Subfoot(text, centered);
+        }
+        if (ctx.summarize_command() != null) {
+            return visit(ctx.summarize_command());
+        }
+        // TODO: recap_command
+        if (ctx.PAGE_BREAK() != null) {
+            return new PageBreak();
+        }
+        return null;
+    }
+
+    @Override
+    public Object visitOutput_command(WebFocusReportParser.Output_commandContext ctx) {
+        String outputType = ctx.getChild(0).getText().toUpperCase();
+        String filename = ctx.qualified_name() != null ? ctx.qualified_name().getText() : null;
+        String format = null;
+        if (ctx.FORMAT() != null) {
+            if (ctx.NAME() != null) format = ctx.NAME().getText();
+            else if (ctx.verb() != null) format = ctx.verb().getText().toUpperCase();
+        }
+        String openClose = null;
+        if (ctx.OPEN() != null) openClose = "OPEN";
+        else if (ctx.CLOSE() != null) openClose = "CLOSE";
+
+        return new OutputCommand(outputType, filename, format, openClose);
+    }
+
+    @Override
+    public Object visitSet_command(WebFocusReportParser.Set_commandContext ctx) {
+        String parameter = ctx.getChild(1).getText().toUpperCase();
+        String value = ctx.getChild(2).getText().toUpperCase();
+        return new SetCommand(parameter, value);
+    }
+
+    @Override
     public Object visitRequest(WebFocusReportParser.RequestContext ctx) {
         String filename = (String) visit(ctx.table_file());
         List<Command> components = new ArrayList<>();

--- a/src/main/java/com/transpiler/asg/OnCommand.java
+++ b/src/main/java/com/transpiler/asg/OnCommand.java
@@ -7,9 +7,9 @@ import java.util.List;
  */
 public record OnCommand(
     String target,
-    List<String> actions
+    List<Command> actions
 ) implements Command {
-    public OnCommand(String target, List<String> actions) {
+    public OnCommand(String target, List<Command> actions) {
         this.target = target;
         this.actions = actions != null ? List.copyOf(actions) : List.of();
     }

--- a/src/main/java/com/transpiler/asg/PageBreak.java
+++ b/src/main/java/com/transpiler/asg/PageBreak.java
@@ -1,0 +1,7 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a PAGE-BREAK command.
+ */
+public record PageBreak() implements Command {
+}

--- a/src/main/java/com/transpiler/asg/Subfoot.java
+++ b/src/main/java/com/transpiler/asg/Subfoot.java
@@ -1,0 +1,10 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a SUBFOOT command.
+ */
+public record Subfoot(
+    String text,
+    boolean centered
+) implements Command {
+}

--- a/src/main/java/com/transpiler/asg/Subhead.java
+++ b/src/main/java/com/transpiler/asg/Subhead.java
@@ -1,0 +1,10 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a SUBHEAD command.
+ */
+public record Subhead(
+    String text,
+    boolean centered
+) implements Command {
+}

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -575,6 +575,54 @@ public class WebFocusReportASGBuilderTest {
         assertEquals("USA", ((Literal) op.right()).value());
     }
 
+    @Test
+    public void testOnTableCommands() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // ON TABLE SUBHEAD
+        WebFocusReportParser parser = createParser("ON TABLE SUBHEAD \"Report Header\"");
+        OnCommand onTable = (OnCommand) builder.visit(parser.on_command());
+        assertEquals("TABLE", onTable.target());
+        assertEquals(1, onTable.actions().size());
+        assertTrue(onTable.actions().get(0) instanceof Subhead);
+        Subhead subhead = (Subhead) onTable.actions().get(0);
+        assertEquals("Report Header", subhead.text());
+
+        // ON TABLE COLUMN-TOTAL
+        parser = createParser("ON TABLE COLUMN-TOTAL");
+        onTable = (OnCommand) builder.visit(parser.on_command());
+        assertTrue(onTable.actions().get(0) instanceof SetCommand);
+        SetCommand setCmd = (SetCommand) onTable.actions().get(0);
+        assertEquals("COLUMN-TOTAL", setCmd.parameter());
+
+        // ON TABLE HOLD
+        parser = createParser("ON TABLE HOLD AS MYFILE FORMAT FOCUS");
+        onTable = (OnCommand) builder.visit(parser.on_command());
+        assertTrue(onTable.actions().get(0) instanceof OutputCommand);
+        OutputCommand output = (OutputCommand) onTable.actions().get(0);
+        assertEquals("HOLD", output.outputType());
+        assertEquals("MYFILE", output.filename());
+        assertEquals("FOCUS", output.format());
+    }
+
+    @Test
+    public void testOnFieldCommands() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+
+        // ON COUNTRY SUBFOOT
+        WebFocusReportParser parser = createParser("ON COUNTRY SUBFOOT \"End of Country\"");
+        OnCommand onField = (OnCommand) builder.visit(parser.on_command());
+        assertEquals("COUNTRY", onField.target());
+        assertTrue(onField.actions().get(0) instanceof Subfoot);
+        Subfoot subfoot = (Subfoot) onField.actions().get(0);
+        assertEquals("End of Country", subfoot.text());
+
+        // ON COUNTRY PAGE-BREAK
+        parser = createParser("ON COUNTRY PAGE-BREAK");
+        onField = (OnCommand) builder.visit(parser.on_command());
+        assertTrue(onField.actions().get(0) instanceof PageBreak);
+    }
+
     private WebFocusReportParser createParser(String input) {
         WebFocusReportLexer lexer = new WebFocusReportLexer(CharStreams.fromString(input));
         return new WebFocusReportParser(new CommonTokenStream(lexer));

--- a/src/test/java/com/transpiler/asg/ASGParityTest.java
+++ b/src/test/java/com/transpiler/asg/ASGParityTest.java
@@ -163,9 +163,9 @@ class ASGParityTest {
         assertEquals("End of Report", footing.text());
         assertFalse(footing.centered());
 
-        OnCommand onTable = new OnCommand("TABLE", List.of("COLUMN-TOTAL"));
+        OnCommand onTable = new OnCommand("TABLE", List.of(new SetCommand("COLUMN-TOTAL", "ON")));
         assertEquals("TABLE", onTable.target());
-        assertEquals("COLUMN-TOTAL", onTable.actions().get(0));
+        assertEquals("COLUMN-TOTAL", ((SetCommand)onTable.actions().get(0)).parameter());
 
         ComputeCommand compute = new ComputeCommand("BONUS", new BinaryOperation(new Identifier("SALARY"), "*", new Literal(0.1)), "D12.2");
         assertEquals("BONUS", compute.name());


### PR DESCRIPTION
This PR implements formatting commands for the Java port of the WebFOCUS to PostgreSQL transpiler. Specifically, it adds support for `ON TABLE` and `ON field` commands including `SUBHEAD`, `SUBFOOT`, `PAGE-BREAK`, and various total/output options. This was achieved by introducing new ASG nodes (`Subhead`, `Subfoot`, `PageBreak`), refactoring the `OnCommand` node for better type safety, and implementing the corresponding visitor methods in `WebFocusReportASGBuilder`. Functional parity and correctness were verified through updated and new unit tests, with the full Java test suite passing.

Fixes #511

---
*PR created automatically by Jules for task [14108076825632187338](https://jules.google.com/task/14108076825632187338) started by @chatelao*