### PR TITLE
Implement RECAP command in Java ASG and Builder

### DIFF
--- a/JAVA_PORT_ROADMAP.md
+++ b/JAVA_PORT_ROADMAP.md
@@ -82,7 +82,7 @@ This document outlines the strategic porting of the WebFOCUS to PostgreSQL Trans
       - [x] 3.1.4.4.3 ON TABLE SUBHEAD/SUBFOOT.
     - [ ] 3.1.4.5 Calculations:
       - [x] 3.1.4.5.1 COMPUTE command.
-      - [ ] 3.1.4.5.2 RECAP command and assignments.
+      - [x] 3.1.4.5.2 RECAP command and assignments.
     - [ ] 3.1.4.6 Summarization (SUBTOTAL, SUMMARIZE).
   - [ ] 3.1.5 Advanced Features:
     - [ ] 3.1.5.1 Compound Layout.

--- a/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
+++ b/src/main/java/com/transpiler/WebFocusReportASGBuilder.java
@@ -706,4 +706,56 @@ public class WebFocusReportASGBuilder extends WebFocusReportBaseVisitor<Object> 
         }
         return new ComputeCommand(name, expression, format, alias);
     }
+
+    @Override
+    public Object visitRecap_command(WebFocusReportParser.Recap_commandContext ctx) {
+        List<RecapAssignment> assignments = ctx.recap_assignment().stream()
+                .map(a -> (RecapAssignment) visit(a))
+                .toList();
+        return new RecapCommand(assignments);
+    }
+
+    @Override
+    public Object visitRecap_assignment(WebFocusReportParser.Recap_assignmentContext ctx) {
+        String name = ctx.qualified_name().getText();
+
+        boolean hasColRef = ctx.getChild(1).getText().equals("(");
+        Expression columnRef = hasColRef ? (Expression) visit(ctx.dm_expression(0)) : null;
+
+        int exprIdx = hasColRef ? 1 : 0;
+        Expression expression = (Expression) visit(ctx.dm_expression(exprIdx));
+
+        String format = ctx.format_name() != null ? ctx.format_name().getText() : null;
+
+        String alias = null;
+        Integer indent = null;
+        boolean noprint = false;
+
+        for (var opt : ctx.recap_option()) {
+            Object res = visit(opt);
+            if (res instanceof String) {
+                alias = (String) res;
+            } else if (res instanceof Integer) {
+                indent = (Integer) res;
+            } else if (res instanceof Boolean && (Boolean) res) {
+                noprint = true;
+            }
+        }
+
+        return new RecapAssignment(name, expression, columnRef, format, alias, indent, noprint);
+    }
+
+    @Override
+    public Object visitRecap_option(WebFocusReportParser.Recap_optionContext ctx) {
+        if (ctx.as_phrase() != null) {
+            return visit(ctx.as_phrase());
+        }
+        if (ctx.INDENT() != null) {
+            return Integer.parseInt(ctx.NUMBER().getText());
+        }
+        if (ctx.NOPRINT() != null) {
+            return true;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/transpiler/asg/RecapAssignment.java
+++ b/src/main/java/com/transpiler/asg/RecapAssignment.java
@@ -1,0 +1,15 @@
+package com.transpiler.asg;
+
+/**
+ * Represents a single assignment within a RECAP command.
+ */
+public record RecapAssignment(
+    String name,
+    Expression expression,
+    Expression columnRef,
+    String format,
+    String alias,
+    Integer indent,
+    boolean noprint
+) implements ASGNode {
+}

--- a/src/main/java/com/transpiler/asg/RecapCommand.java
+++ b/src/main/java/com/transpiler/asg/RecapCommand.java
@@ -1,0 +1,14 @@
+package com.transpiler.asg;
+
+import java.util.List;
+
+/**
+ * Represents a RECAP command.
+ */
+public record RecapCommand(
+    List<RecapAssignment> assignments
+) implements Command {
+    public RecapCommand(List<RecapAssignment> assignments) {
+        this.assignments = assignments != null ? List.copyOf(assignments) : List.of();
+    }
+}

--- a/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
+++ b/src/test/java/com/transpiler/WebFocusReportASGBuilderTest.java
@@ -564,6 +564,29 @@ public class WebFocusReportASGBuilderTest {
     }
 
     @Test
+    public void testRecapCommand() {
+        WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
+        WebFocusReportParser parser = createParser("RECAP TOTAL_SALARY(1)/D12.2 = SALARY + 1000 AS 'Total Salary' INDENT 4 NOPRINT;");
+        RecapCommand recap = (RecapCommand) builder.visit(parser.recap_command());
+        assertEquals(1, recap.assignments().size());
+
+        RecapAssignment assignment = recap.assignments().get(0);
+        assertEquals("TOTAL_SALARY", assignment.name());
+        assertEquals("D12.2", assignment.format());
+        assertEquals("Total Salary", assignment.alias());
+        assertEquals(4, assignment.indent());
+        assertTrue(assignment.noprint());
+
+        assertNotNull(assignment.columnRef());
+        assertTrue(assignment.columnRef() instanceof Literal);
+        assertEquals(1, ((Literal) assignment.columnRef()).value());
+
+        assertTrue(assignment.expression() instanceof BinaryOperation);
+        BinaryOperation expr = (BinaryOperation) assignment.expression();
+        assertEquals("+", expr.operator());
+    }
+
+    @Test
     public void testWhenCommand() {
         WebFocusReportASGBuilder builder = new WebFocusReportASGBuilder();
         WebFocusReportParser parser = createParser("WHEN COUNTRY EQ 'USA'");


### PR DESCRIPTION
This PR implements the `RECAP` command in the Java port of the WebFOCUS to PostgreSQL transpiler. 

Key changes:
- **ASG Nodes**: Created `RecapAssignment` and `RecapCommand` in `com.transpiler.asg`. These nodes capture the structure of `RECAP` assignments, including optional column references, formats, aliases, indentation, and NOPRINT flags.
- **Visitor Implementation**: Added visitor methods to `WebFocusReportASGBuilder` to transform `RECAP` parse tree nodes into ASG nodes.
- **Testing**: Added a `testRecapCommand` to the existing test suite to verify correct parsing and node construction for complex `RECAP` commands.
- **Roadmap**: Marked item 3.1.4.5.2 as complete in `JAVA_PORT_ROADMAP.md`.

Fixes #513

---
*PR created automatically by Jules for task [13286073827492712635](https://jules.google.com/task/13286073827492712635) started by @chatelao*