### PR TITLE
Granularize spec roadmap and implement H1 headers

### DIFF
--- a/scripts/format_titles.py
+++ b/scripts/format_titles.py
@@ -1,0 +1,66 @@
+import os
+import sys
+
+def format_title(filepath):
+    if not os.path.isfile(filepath):
+        return False
+
+    with open(filepath, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    if not lines:
+        return False
+
+    # Find the first non-empty line
+    first_non_empty_idx = -1
+    for i, line in enumerate(lines):
+        if line.strip():
+            first_non_empty_idx = i
+            break
+
+    if first_non_empty_idx == -1:
+        return False
+
+    first_line = lines[first_non_empty_idx]
+
+    # If it's already an H1 header, skip
+    if first_line.startswith('# '):
+        return False
+
+    # Prepend #
+    lines[first_non_empty_idx] = f"# {first_line}"
+
+    # Ensure there's a blank line after the title
+    if first_non_empty_idx + 1 < len(lines):
+        if lines[first_non_empty_idx + 1].strip():
+            lines.insert(first_non_empty_idx + 1, '\n')
+    else:
+        lines.append('\n')
+
+    with open(filepath, 'w', encoding='utf-8') as f:
+        f.writelines(lines)
+
+    return True
+
+def main():
+    spec_root = 'specifications'
+    spec_dirs = ['creating_reports', 'describing_data']
+    files_processed = 0
+    files_updated = 0
+
+    for sd in spec_dirs:
+        full_sd = os.path.join(spec_root, sd)
+        if os.path.isdir(full_sd):
+            for filename in sorted(os.listdir(full_sd)):
+                if filename.endswith('.md'):
+                    filepath = os.path.join(full_sd, filename)
+                    files_processed += 1
+                    if format_title(filepath):
+                        files_updated += 1
+                        print(f"Updated: {filepath}")
+
+    print(f"Total files processed: {files_processed}")
+    print(f"Total files updated: {files_updated}")
+
+if __name__ == "__main__":
+    main()

--- a/specifications/ROADMAP.md
+++ b/specifications/ROADMAP.md
@@ -32,6 +32,8 @@ Based on initial analysis, the following issues are prevalent:
 
 ### Phase 2: Structural Reform (Establishing Hierarchy)
 *   - [ ] **Task 2.1**: Convert "Chapter X" and major section titles into `#` and `##` headers.
+    *   - [x] **Task 2.1.1**: Convert the first line of each chapter/appendix file into an H1 header.
+    *   - [ ] **Task 2.1.2**: Convert major section titles into H2 headers.
 *   - [ ] **Task 2.2**: Reconstruct the Table of Contents (TOC) using standard Markdown list syntax with working anchors.
 *   - [ ] **Task 2.3**: Fix multi-line paragraph wrapping that was broken by PDF line breaks.
 

--- a/specifications/creating_reports/creating_reports_00_front_matter.md
+++ b/specifications/creating_reports/creating_reports_00_front_matter.md
@@ -1,4 +1,5 @@
-Creating Reports With
+# Creating Reports With
+
 TIBCO® WebFOCUS Language
 
 Release 8207

--- a/specifications/creating_reports/creating_reports_01_chapter1.md
+++ b/specifications/creating_reports/creating_reports_01_chapter1.md
@@ -1,4 +1,4 @@
-Creating Reports Overview
+# Creating Reports Overview
 
 WebFOCUS is a complete information control system with comprehensive features for
 retrieving and analyzing data that enables you to create reports quickly and easily. It

--- a/specifications/creating_reports/creating_reports_02_chapter2.md
+++ b/specifications/creating_reports/creating_reports_02_chapter2.md
@@ -1,4 +1,4 @@
-Displaying Report Data
+# Displaying Report Data
 
 Reporting, at the simplest level, retrieves field values from a data source and displays
 those values. There are three ways to do this:

--- a/specifications/creating_reports/creating_reports_03_chapter3.md
+++ b/specifications/creating_reports/creating_reports_03_chapter3.md
@@ -1,4 +1,4 @@
-Sorting Tabular Reports
+# Sorting Tabular Reports
 
 Sorting enables you to group or organize report information vertically and horizontally, in
 rows and columns, and specify a desired sequence of data items in the report.

--- a/specifications/creating_reports/creating_reports_04_chapter4.md
+++ b/specifications/creating_reports/creating_reports_04_chapter4.md
@@ -1,4 +1,4 @@
-Selecting Records for Your Report
+# Selecting Records for Your Report
 
 When generating a report and selecting fields, you may not want to include every
 instance of a field. By including selection criteria, you can display only those field values

--- a/specifications/creating_reports/creating_reports_05_chapter5.md
+++ b/specifications/creating_reports/creating_reports_05_chapter5.md
@@ -1,4 +1,4 @@
-Creating Temporary Fields
+# Creating Temporary Fields
 
 When you create a report, you are not restricted to the fields that exist in your data
 source. If you can generate the information you want from the existing data, you can

--- a/specifications/creating_reports/creating_reports_06_chapter6.md
+++ b/specifications/creating_reports/creating_reports_06_chapter6.md
@@ -1,4 +1,4 @@
-Including Totals and Subtotals
+# Including Totals and Subtotals
 
 To help interpret detailed information in a report, you can summarize the information
 using row and column totals, grand totals, and subtotals. You can use these summary

--- a/specifications/creating_reports/creating_reports_07_chapter7.md
+++ b/specifications/creating_reports/creating_reports_07_chapter7.md
@@ -1,4 +1,4 @@
-Using Expressions
+# Using Expressions
 
 An expression combines field names, constants, and operators in a calculation that
 returns a single value. You can use an expression in a variety of commands to assign a

--- a/specifications/creating_reports/creating_reports_08_chapter8.md
+++ b/specifications/creating_reports/creating_reports_08_chapter8.md
@@ -1,4 +1,4 @@
-Chapter8
+# Chapter8
 
 Saving and Reusing Your Report Output
 

--- a/specifications/creating_reports/creating_reports_09_chapter9.md
+++ b/specifications/creating_reports/creating_reports_09_chapter9.md
@@ -1,4 +1,4 @@
-Choosing a Display Format
+# Choosing a Display Format
 
 You can choose from several different display formats when you display a report on the
 screen. Some display formats are best suited for particular kinds of uses. For example,

--- a/specifications/creating_reports/creating_reports_10_chapter10.md
+++ b/specifications/creating_reports/creating_reports_10_chapter10.md
@@ -1,4 +1,4 @@
-Linking a Report to Other Resources
+# Linking a Report to Other Resources
 
 You can use StyleSheet declarations to define links from any report component. You can
 use links to:

--- a/specifications/creating_reports/creating_reports_11_chapter11.md
+++ b/specifications/creating_reports/creating_reports_11_chapter11.md
@@ -1,4 +1,4 @@
-Navigating Within an HTML Report
+# Navigating Within an HTML Report
 
 You can include the following navigation features within a report to control the report
 display:

--- a/specifications/creating_reports/creating_reports_12_chapter12.md
+++ b/specifications/creating_reports/creating_reports_12_chapter12.md
@@ -1,4 +1,4 @@
-Bursting Reports Into Multiple HTML Files
+# Bursting Reports Into Multiple HTML Files
 
 Bursting separates a single report into multiple HTML files based on the value of the first
 sort field in your report.

--- a/specifications/creating_reports/creating_reports_13_chapter13.md
+++ b/specifications/creating_reports/creating_reports_13_chapter13.md
@@ -1,4 +1,5 @@
-Handling Records With Missing Field
+# Handling Records With Missing Field
+
 Values
 
 Missing data is defined as data that is missing from a report because it is not relevant or

--- a/specifications/creating_reports/creating_reports_14_chapter14.md
+++ b/specifications/creating_reports/creating_reports_14_chapter14.md
@@ -1,4 +1,4 @@
-Joining Data Sources
+# Joining Data Sources
 
 You can join two or more related data sources to create a larger integrated data structure
 from which you can report in a single request. The joined structure is virtual. It is a way of

--- a/specifications/creating_reports/creating_reports_15_chapter15.md
+++ b/specifications/creating_reports/creating_reports_15_chapter15.md
@@ -1,4 +1,4 @@
-Merging Data Sources
+# Merging Data Sources
 
 You can gather data for your reports by merging the contents of data structures with the
 MATCH command, or concatenating data sources with the MORE phrase, and reporting

--- a/specifications/creating_reports/creating_reports_16_chapter16.md
+++ b/specifications/creating_reports/creating_reports_16_chapter16.md
@@ -1,4 +1,4 @@
-Formatting Reports: An Overview
+# Formatting Reports: An Overview
 
 To create an effective report, you need to account for:
 

--- a/specifications/creating_reports/creating_reports_17_chapter17.md
+++ b/specifications/creating_reports/creating_reports_17_chapter17.md
@@ -1,4 +1,4 @@
-Chapter17 Creating and Managing a WebFOCUS
+# Chapter17 Creating and Managing a WebFOCUS
 
 StyleSheet
 

--- a/specifications/creating_reports/creating_reports_18_chapter18.md
+++ b/specifications/creating_reports/creating_reports_18_chapter18.md
@@ -1,4 +1,4 @@
-Controlling Report Formatting
+# Controlling Report Formatting
 
 When you format a report, you can control how the formatting is applied. You can:
 

--- a/specifications/creating_reports/creating_reports_19_chapter19.md
+++ b/specifications/creating_reports/creating_reports_19_chapter19.md
@@ -1,4 +1,4 @@
-Chapter19 Identifying a Report Component in a
+# Chapter19 Identifying a Report Component in a
 
 WebFOCUS StyleSheet
 

--- a/specifications/creating_reports/creating_reports_20_chapter20.md
+++ b/specifications/creating_reports/creating_reports_20_chapter20.md
@@ -1,4 +1,4 @@
-Using an External Cascading Style Sheet
+# Using an External Cascading Style Sheet
 
 Cascading style sheets (CSS) provide a standard way of formatting HTML documents. To
 format WebFOCUS HTML report output using an external CSS, simply link the CSS to the

--- a/specifications/creating_reports/creating_reports_21_chapter21.md
+++ b/specifications/creating_reports/creating_reports_21_chapter21.md
@@ -1,4 +1,4 @@
-Laying Out the Report Page
+# Laying Out the Report Page
 
 You can customize page layout using StyleSheet attributes. The page layout attributes
 available to you, like all other attributes, depend on the display format. For instance,

--- a/specifications/creating_reports/creating_reports_22_chapter22.md
+++ b/specifications/creating_reports/creating_reports_22_chapter22.md
@@ -1,4 +1,5 @@
-Using Headings, Footings, Titles, and
+# Using Headings, Footings, Titles, and
+
 Labels
 
 After you have selected the data for a report, you can make it more meaningful by adding

--- a/specifications/creating_reports/creating_reports_23_chapter23.md
+++ b/specifications/creating_reports/creating_reports_23_chapter23.md
@@ -1,4 +1,4 @@
-Formatting Report Data
+# Formatting Report Data
 
 This chapter covers information about formatting and positioning text in a report. You can
 select the size, color, font, and style for the text of your report, in addition to being able

--- a/specifications/creating_reports/creating_reports_24_chapter24.md
+++ b/specifications/creating_reports/creating_reports_24_chapter24.md
@@ -1,4 +1,4 @@
-Creating a Graph
+# Creating a Graph
 
 Graphs often convey meaning more clearly than data listed in tabular format. Using the
 GRAPH command, you can easily transform almost any type of data into an effective

--- a/specifications/creating_reports/creating_reports_25_chapter25.md
+++ b/specifications/creating_reports/creating_reports_25_chapter25.md
@@ -1,4 +1,4 @@
-Chapter25 Creating Financial Reports With Financial
+# Chapter25 Creating Financial Reports With Financial
 
 Modeling Language (FML)
 

--- a/specifications/creating_reports/creating_reports_26_chapter26.md
+++ b/specifications/creating_reports/creating_reports_26_chapter26.md
@@ -1,4 +1,4 @@
-Creating a Free-Form Report
+# Creating a Free-Form Report
 
 You can present data in an unrestricted or free-form format using a layout of your own
 design.

--- a/specifications/creating_reports/creating_reports_27_chapter27.md
+++ b/specifications/creating_reports/creating_reports_27_chapter27.md
@@ -1,4 +1,4 @@
-Using SQL to Create Reports
+# Using SQL to Create Reports
 
 SQL users can issue report requests that combine SQL statements with TABLE
 formatting phrases to take advantage of a wide range of report preparation options.

--- a/specifications/creating_reports/creating_reports_28_chapter28.md
+++ b/specifications/creating_reports/creating_reports_28_chapter28.md
@@ -1,4 +1,4 @@
-Improving Report Processing
+# Improving Report Processing
 
 The following high-performance methods optimize data retrieval and report processing:
 

--- a/specifications/creating_reports/creating_reports_29_appendix_a.md
+++ b/specifications/creating_reports/creating_reports_29_appendix_a.md
@@ -1,4 +1,4 @@
-Appendix A
+# Appendix A
 
 Master Files and Diagrams
 

--- a/specifications/creating_reports/creating_reports_30_appendix_b.md
+++ b/specifications/creating_reports/creating_reports_30_appendix_b.md
@@ -1,4 +1,4 @@
-Appendix B
+# Appendix B
 
 Error Messages
 

--- a/specifications/creating_reports/creating_reports_31_appendix_c.md
+++ b/specifications/creating_reports/creating_reports_31_appendix_c.md
@@ -1,4 +1,4 @@
-Appendix C
+# Appendix C
 
 Table Syntax Summary and Limits
 

--- a/specifications/creating_reports/creating_reports_32_appendix_d.md
+++ b/specifications/creating_reports/creating_reports_32_appendix_d.md
@@ -1,4 +1,4 @@
-Appendix D
+# Appendix D
 
 Referring to Fields in a Report Request
 

--- a/specifications/describing_data/describing_data_00_front_matter.md
+++ b/specifications/describing_data/describing_data_00_front_matter.md
@@ -1,4 +1,4 @@
-TIBCO WebFOCUS®
+# TIBCO WebFOCUS®
 
 Describing Data With TIBCO WebFOCUS®
 Language

--- a/specifications/describing_data/describing_data_01_chapter1.md
+++ b/specifications/describing_data/describing_data_01_chapter1.md
@@ -1,4 +1,4 @@
-Understanding a Data Source Description
+# Understanding a Data Source Description
 
 Information Builders products provide a flexible data description language, which you can
 use with many types of data sources, including:

--- a/specifications/describing_data/describing_data_02_chapter2.md
+++ b/specifications/describing_data/describing_data_02_chapter2.md
@@ -1,4 +1,4 @@
-Identifying a Data Source
+# Identifying a Data Source
 
 In order to interpret data, your application needs to know the name you are using to
 identify the data source and what type of data source it is. For example, is it a DB2 data

--- a/specifications/describing_data/describing_data_03_chapter3.md
+++ b/specifications/describing_data/describing_data_03_chapter3.md
@@ -1,4 +1,4 @@
-Describing a Group of Fields
+# Describing a Group of Fields
 
 Certain fields in a data source may have a one-to-one correspondence. The different
 groups formed can be related to one another. For some types of data sources you can

--- a/specifications/describing_data/describing_data_04_chapter4.md
+++ b/specifications/describing_data/describing_data_04_chapter4.md
@@ -1,4 +1,4 @@
-Describing an Individual Field
+# Describing an Individual Field
 
 A field is the smallest meaningful element of data in a data source, but it can exhibit a
 number of complex characteristics. Master File attributes are used to describe these

--- a/specifications/describing_data/describing_data_05_chapter5.md
+++ b/specifications/describing_data/describing_data_05_chapter5.md
@@ -1,4 +1,5 @@
-Describing a Sequential, VSAM, or ISAM
+# Describing a Sequential, VSAM, or ISAM
+
 Data Source
 
 You can describe and report from sequential, VSAM, and ISAM data sources.

--- a/specifications/describing_data/describing_data_06_chapter6.md
+++ b/specifications/describing_data/describing_data_06_chapter6.md
@@ -1,4 +1,4 @@
-Describing a FOCUS Data Source
+# Describing a FOCUS Data Source
 
 The following covers data description topics unique to FOCUS data sources:
 

--- a/specifications/describing_data/describing_data_07_chapter7.md
+++ b/specifications/describing_data/describing_data_07_chapter7.md
@@ -1,4 +1,4 @@
-Defining a Join in a Master File
+# Defining a Join in a Master File
 
 Describe a new relationship between any two segments that have at least one field in
 common by joining them. The underlying data structures remain physically separate, but

--- a/specifications/describing_data/describing_data_08_chapter8.md
+++ b/specifications/describing_data/describing_data_08_chapter8.md
@@ -1,4 +1,4 @@
-Creating a Business View of a Master File
+# Creating a Business View of a Master File
 
 A Business View (BV) of a Master File groups related items together to reflect an
 application business logic rather than the physical position of items in the data source.

--- a/specifications/describing_data/describing_data_09_chapter9.md
+++ b/specifications/describing_data/describing_data_09_chapter9.md
@@ -1,4 +1,5 @@
-Checking and Changing a Master File:
+# Checking and Changing a Master File:
+
 CHECK
 
 Use the CHECK command to validate your Master Files. You must always do this after

--- a/specifications/describing_data/describing_data_10_chapter10.md
+++ b/specifications/describing_data/describing_data_10_chapter10.md
@@ -1,4 +1,4 @@
-Providing Data Source Security: DBA
+# Providing Data Source Security: DBA
 
 As Database Administrator, you can use DBA security features to provide security for any
 FOCUS data source. You can use these security features to limit the number of records

--- a/specifications/describing_data/describing_data_11_chapter11.md
+++ b/specifications/describing_data/describing_data_11_chapter11.md
@@ -1,4 +1,4 @@
-Creating and Rebuilding a Data Source
+# Creating and Rebuilding a Data Source
 
 You can create a new data source, or re-initialize an existing data source, using the
 CREATE command.

--- a/specifications/describing_data/describing_data_12_appendix_a.md
+++ b/specifications/describing_data/describing_data_12_appendix_a.md
@@ -1,4 +1,4 @@
-Appendix A
+# Appendix A
 
 Master Files and Diagrams
 

--- a/specifications/describing_data/describing_data_13_appendix_b.md
+++ b/specifications/describing_data/describing_data_13_appendix_b.md
@@ -1,4 +1,4 @@
-Appendix B
+# Appendix B
 
 Error Messages
 

--- a/specifications/describing_data/describing_data_14_appendix_c.md
+++ b/specifications/describing_data/describing_data_14_appendix_c.md
@@ -1,4 +1,4 @@
-Appendix C
+# Appendix C
 
 Rounding in WebFOCUS
 


### PR DESCRIPTION
This change addresses a task from the `specifications/ROADMAP.md` by breaking down the broad "Structural Reform" phase into more manageable steps and implementing the first of these steps. 

Specifically, Task 2.1 in `specifications/ROADMAP.md` was granularized into Task 2.1.1 (Convert first line to H1 header) and Task 2.1.2 (Convert major section titles to H2 headers). 

I then implemented Task 2.1.1 using a new Python script, `scripts/format_titles.py`, which identifies the first non-empty line of each markdown file in the specifications subdirectories and prepends it with `# ` to create a proper Markdown H1 header. This script was run against all 48 files in `specifications/creating_reports/` and `specifications/describing_data/`.

All changes were verified and full regression testing was performed using `mvn test` and `pytest`.

Fixes #517

---
*PR created automatically by Jules for task [1841321872253830368](https://jules.google.com/task/1841321872253830368) started by @chatelao*